### PR TITLE
k3os: always copy k3os for upgrade

### DIFF
--- a/k3os/pkg/system/component.go
+++ b/k3os/pkg/system/component.go
@@ -5,6 +5,8 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strconv"
+	"time"
 
 	"github.com/docker/docker/pkg/mount"
 	"github.com/otiai10/copy"
@@ -51,7 +53,7 @@ func CopyComponent(src, dst string, remount bool, key string) (bool, error) {
 		return false, err
 	}
 	dstInfo, _ := StatComponentVersion(dst, key, VersionCurrent)
-	if dstInfo != nil && dstInfo.Name() == srcInfo.Name() {
+	if dstInfo != nil && dstInfo.Name() == srcInfo.Name() && key != "k3os" {
 		logrus.Infof("skipping %q because destination version matches source: %s", key, dstInfo.Name())
 		return false, nil
 	}
@@ -88,7 +90,7 @@ func CopyComponent(src, dst string, remount bool, key string) (bool, error) {
 	// if the destination already exists, attempt to move it out of the way
 	if dstInfo, err := os.Stat(dstPath); err == nil {
 		if dstInfo.IsDir() {
-			dstExist := dstPath + `.old`
+			dstExist := dstPath + `.old-` + strconv.FormatInt(time.Now().Unix(), 10)
 			if err = os.Rename(dstPath, dstExist); err != nil {
 				return false, err
 			}


### PR DESCRIPTION
https://github.com/harvester/harvester/issues/383

Problem:
After an upgrade completes, the terminal console still shows the previous version. k3os does not upgrade itself if the version does not change. 

Solution:
Since we compile the console into the k3os binary we need to upgrade it anyway. Also, rename the previous directory to a unique name so that it does not conflict after multiple upgrades.