### PR TITLE
Retry if fetching remote config fails

### DIFF
--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -1209,9 +1209,10 @@ func addInstallPanel(c *Console) error {
 		go func() {
 			logrus.Info("Local config: ", c.config)
 			if c.config.Install.ConfigURL != "" {
-				remoteConfig, err := getRemoteConfig(c.config.Install.ConfigURL)
+				printToPanel(c.Gui, fmt.Sprintf("Fetching %s...", c.config.Install.ConfigURL), installPanel)
+				remoteConfig, err := retryRemoteConfig(c.config.Install.ConfigURL, c.Gui)
 				if err != nil {
-					logrus.Error(err.Error())
+					logrus.Error(err)
 					printToPanel(c.Gui, err.Error(), installPanel)
 					return
 				}


### PR DESCRIPTION
It's possible that the system's network stack is not ready before the installer is started. Add a retry loop to workaround this situation.

The retry interval is 10 seconds and the retries count is 30 times (5 minutes timeout).

**Related issue**:
https://github.com/harvester/harvester/issues/907

**Screenshot**
![Screen Shot 2021-06-08 at 4 01 54 PM](https://user-images.githubusercontent.com/1691518/121160822-00843c00-c87f-11eb-9a73-79f018ddba6c.png)
