### PR TITLE
Fix webhook pods fail to start in air gapped environment

### DIFF
--- a/manifests/harvester.yaml
+++ b/manifests/harvester.yaml
@@ -23,3 +23,4 @@ spec:
     service.harvester.type: "NodePort"
     service.harvester.httpsNodePort: 30443
     rancherEmbedded: "true"
+    webhook.image.imagePullPolicy: "IfNotPresent"


### PR DESCRIPTION
The pull policy need to be "IfNotPresent" to use the pre-loaded images.



Related issue: https://github.com/harvester/harvester/issues/962