### PR TITLE
Autoscroll install panel

### DIFF
--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -1251,6 +1251,7 @@ func addInstallPanel(c *Console) error {
 	installV.Title = " Installing Harvester "
 	installV.SetLocation(maxX/8, maxY/8, maxX/8*7, maxY/8*7)
 	installV.Wrap = true
+	installV.Autoscroll = true
 	c.AddElement(installPanel, installV)
 	installV.Frame = true
 	return nil

--- a/pkg/console/util.go
+++ b/pkg/console/util.go
@@ -351,13 +351,6 @@ func printToPanel(g *gocui.Gui, message string, panelName string) {
 			return err
 		}
 		fmt.Fprintln(v, message)
-
-		lines := len(v.BufferLines())
-		_, sy := v.Size()
-		if lines > sy {
-			ox, oy := v.Origin()
-			v.SetOrigin(ox, oy+1)
-		}
 		return nil
 	})
 

--- a/pkg/widgets/panel.go
+++ b/pkg/widgets/panel.go
@@ -11,18 +11,19 @@ const (
 )
 
 type Panel struct {
-	g       *gocui.Gui
-	Name    string
-	Title   string
-	Frame   bool
-	Wrap    bool
-	Focus   bool
-	FgColor gocui.Attribute
-	Content string
-	X0      int
-	X1      int
-	Y0      int
-	Y1      int
+	g          *gocui.Gui
+	Name       string
+	Title      string
+	Frame      bool
+	Wrap       bool
+	Focus      bool
+	FgColor    gocui.Attribute
+	Content    string
+	X0         int
+	X1         int
+	Y0         int
+	Y1         int
+	Autoscroll bool
 
 	// Hook functions
 	PreShow   func() error
@@ -86,6 +87,7 @@ func (p *Panel) Show() error {
 		v.Frame = p.Frame
 		v.Wrap = p.Wrap
 		v.FgColor = p.FgColor
+		v.Autoscroll = p.Autoscroll
 		if _, err := fmt.Fprint(v, p.Content); err != nil {
 			return err
 		}


### PR DESCRIPTION
We need to adjust Y-axis movement because lone-lines are wrapped in the install panel (new feature in https://github.com/harvester/harvester-installer/pull/88.).
The `Autoscroll` flag of a View seems to work well, I remove the manually movement and turn the flag on.

### Screenshots (the outputs are mocked messages)
**Before**
![before](https://user-images.githubusercontent.com/1691518/126116099-4d84bc28-7272-429a-a5e6-d17b8341e692.gif)
**After**

![after](https://user-images.githubusercontent.com/1691518/126116114-9377cb67-e236-4153-8a05-2d71ad2d0a85.gif)


### Test plans
- Install harvester and make sure no messages are dropped in the install (last) panel.

Developer can apply this [patch](https://gist.github.com/bk201/40d8655f0a5f08bc95ae0f585ee23d43) to artificially generate some output without really running the installation.










