### PR TITLE
Update server port to rancher

### DIFF
--- a/manifests/harvester.yaml
+++ b/manifests/harvester.yaml
@@ -19,7 +19,5 @@ spec:
     containers.apiserver.image.imagePullPolicy: "IfNotPresent"
     containers.apiserver.hciMode: "true"
     harvester-network-controller.image.pullPolicy: "IfNotPresent"
-    service.harvester.type: "NodePort"
-    service.harvester.httpsNodePort: 30443
     rancherEmbedded: "true"
     webhook.image.imagePullPolicy: "IfNotPresent"

--- a/manifests/rancher.yaml
+++ b/manifests/rancher.yaml
@@ -34,7 +34,7 @@ spec:
     app: rancher
   ports:
     - name: https-internal
-      nodePort: 30444
+      nodePort: 30443
       port: 443
       protocol: TCP
       targetPort: 444

--- a/manifests/rancher.yaml
+++ b/manifests/rancher.yaml
@@ -14,15 +14,12 @@ spec:
   set:
     ingress.enabled: "false"
     ingress.tls.source: "rancher"
-    privateCA: "true"
     antiAffinity: "required"
-    rancherImageTag: master-861fb9208fd59c7f0c5266f087ccf050c1577ead-head
+    bootstrapPassword: "admin"
   valuesContent: |-
     extraEnv:
-    - name: CATTLE_BOOTSTRAP_PASSWORD
-      value: admin
     - name: CATTLE_FEATURES
-      value: continuous-delivery=false,embedded-cluster-api=false,fleet=false,monitoringv1=false,multi-cluster-management=false,multi-cluster-management-agent=false,provisioningv2=false,rke2=false
+      value: multi-cluster-management=false,multi-cluster-management-agent=false,
 ---
 apiVersion: v1
 kind: Service

--- a/scripts/build
+++ b/scripts/build
@@ -7,7 +7,7 @@ cd $(dirname $0)/..
 
 echo "Start building ISO"
 
-K3S_VERSION=v1.20.4+k3s1
+K3S_VERSION=v1.21.3+k3s1
 K3S_IMAGE_URL=https://raw.githubusercontent.com/rancher/k3s/${K3S_VERSION}/scripts/airgap/image-list.txt
 
 RANCHER_VERSION=2.5.7

--- a/scripts/build
+++ b/scripts/build
@@ -10,7 +10,7 @@ echo "Start building ISO"
 K3S_VERSION=v1.21.3+k3s1
 K3S_IMAGE_URL=https://raw.githubusercontent.com/rancher/k3s/${K3S_VERSION}/scripts/airgap/image-list.txt
 
-RANCHER_VERSION=2.5.7
+RANCHER_VERSION=2.6.0-rc3
 RANCHER_IMAGE_URL=https://github.com/rancher/rancher/releases/download/v{$RANCHER_VERSION}/rancher-images.txt
 CERT_MANAGER_VERSION=v1.2.0
 

--- a/scripts/images/rancher-images.txt
+++ b/scripts/images/rancher-images.txt
@@ -1,5 +1,5 @@
-rancher/fleet-agent:
-rancher/fleet:
+#rancher/fleet-agent:
+#rancher/fleet:
 rancher/gitjob:
 rancher/library-busybox:
 rancher/pause:
@@ -7,3 +7,4 @@ rancher/rancher-operator:
 rancher/rancher-webhook:
 rancher/rancher:
 rancher/shell:
+rancher/klipper-helm:


### PR DESCRIPTION
- Use default 30443 port for the Rancher server https://github.com/harvester/harvester/issues/755
- Bump k3s to v1.21.3 to with runC v1.0.0 support of https://github.com/harvester/harvester/pull/990
