### PR TITLE
Do not add commit hash and working tree status to artifacts

### DIFF
--- a/package/harvester-os/files/usr/share/rancher/rancherd/config.yaml.d/50-defaults.yaml
+++ b/package/harvester-os/files/usr/share/rancher/rancherd/config.yaml.d/50-defaults.yaml
@@ -7,3 +7,19 @@ rancherValues:
   useBundledSystemChart: true
   bootstrapPassword: admin
 rancherInstallerImage: ibuildthecloud/system-agent-installer-rancher:dev
+bootstrapResources:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: rancher-expose
+    namespace: cattle-system
+  spec:
+    type: NodePort
+    selector:
+      app: rancher
+    ports:
+      - name: https-internal
+        nodePort: 30443
+        port: 443
+        protocol: TCP
+        targetPort: 444

--- a/package/harvester-os/templates/91-harvester-bootstrap-chart.yaml
+++ b/package/harvester-os/templates/91-harvester-bootstrap-chart.yaml
@@ -1,42 +1,4 @@
 bootstrapResources:
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    name: harvester-cluster-repo
-    namespace: cattle-system
-  spec:
-    selector:
-      matchLabels:
-        app: harvester-cluster-repo
-    replicas: 1
-    template:
-      metadata:
-        labels:
-          app: harvester-cluster-repo
-      spec:
-        containers:
-        - name: httpd
-          image: $CLUSTER_REPO_IMAGE
-          ports:
-          - containerPort: 80
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: harvester-cluster-repo
-    namespace: cattle-system
-  spec:
-    selector:
-      app: harvester-cluster-repo
-    ports:
-      - protocol: TCP
-        port: 80
-        targetPort: 80
-- apiVersion: catalog.cattle.io/v1
-  kind: ClusterRepo
-  metadata:
-    name: harvester-charts
-  spec:
-    url: http://harvester-cluster-repo.cattle-system/charts
 - apiVersion: management.cattle.io/v3
   kind: ManagedChart
   metadata:
@@ -78,18 +40,3 @@ bootstrapResources:
           tag: master-head
           imagePullPolicy: "IfNotPresent"
     version: $HARVESTER_CHART_VERSION
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: rancher-expose
-    namespace: cattle-system
-  spec:
-    type: NodePort
-    selector:
-      app: rancher
-    ports:
-      - name: https-internal
-        nodePort: 30443
-        port: 443
-        protocol: TCP
-        targetPort: 444

--- a/package/harvester-os/templates/91-harvester-bootstrap-repo.yaml
+++ b/package/harvester-os/templates/91-harvester-bootstrap-repo.yaml
@@ -1,0 +1,39 @@
+bootstrapResources:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: harvester-cluster-repo
+    namespace: cattle-system
+  spec:
+    selector:
+      matchLabels:
+        app: harvester-cluster-repo
+    replicas: 1
+    template:
+      metadata:
+        labels:
+          app: harvester-cluster-repo
+      spec:
+        containers:
+        - name: httpd
+          image: $CLUSTER_REPO_IMAGE
+          ports:
+          - containerPort: 80
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: harvester-cluster-repo
+    namespace: cattle-system
+  spec:
+    selector:
+      app: harvester-cluster-repo
+    ports:
+      - protocol: TCP
+        port: 80
+        targetPort: 80
+- apiVersion: catalog.cattle.io/v1
+  kind: ClusterRepo
+  metadata:
+    name: harvester-charts
+  spec:
+    url: http://harvester-cluster-repo.cattle-system/charts

--- a/scripts/build-bundle
+++ b/scripts/build-bundle
@@ -75,7 +75,9 @@ helm repo index ${CHARTS_DIR}
 
 # Update chart version in Rancherd bootstrap resources
 harvester_chart_version=$(yq e .version ${harvester_chart_path}/Chart.yaml --exit-status)
-sed -i "s/\$HARVESTER_CHART_VERSION/${harvester_chart_version}/" ${PACKAGE_HARVESTER_OS_DIR}/files/usr/share/rancher/rancherd/config.yaml.d/91-harvester-bootstrap.yaml
+sed "s/\$HARVESTER_CHART_VERSION/${harvester_chart_version}/" \
+  ${PACKAGE_HARVESTER_OS_DIR}/templates/91-harvester-bootstrap-chart.yaml > \
+  ${PACKAGE_HARVESTER_OS_DIR}/files/usr/share/rancher/rancherd/config.yaml.d/91-harvester-bootstrap-chart.yaml
 
 if [ -n "$HARVESTER_INSTALLER_OFFLINE_BUILD" -a -e /bundle ]; then
  cp -rf /bundle/* ${BUNDLE_DIR}/

--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -22,15 +22,20 @@ docker build --pull \
 KERNEL=$(docker run --rm ${HARVESTER_OS_IMAGE} readlink /boot/vmlinuz)
 INITRD=$(docker run --rm ${HARVESTER_OS_IMAGE} readlink /boot/initrd)
 docker create --cidfile=os-img-container ${HARVESTER_OS_IMAGE}
-docker cp $(<os-img-container):/boot/${KERNEL} ${ARTIFACTS_DIR}/harvester-${VERSION}-vmlinuz-${ARCH}
-docker cp $(<os-img-container):/boot/${INITRD} ${ARTIFACTS_DIR}/harvester-${VERSION}-initrd-${ARCH}
-chmod +r ${ARTIFACTS_DIR}/harvester-${VERSION}-initrd-${ARCH}
+docker cp $(<os-img-container):/boot/${KERNEL} ${ARTIFACTS_DIR}/harvester-vmlinuz-${ARCH}
+docker cp $(<os-img-container):/boot/${INITRD} ${ARTIFACTS_DIR}/harvester-initrd-${ARCH}
+chmod +r ${ARTIFACTS_DIR}/harvester-initrd-${ARCH}
 docker rm $(<os-img-container) && rm -f os-img-container
 
 # build ISO
-ISO_PREFIX=harvester-${VERSION}-${ARCH}
+ISO_PREFIX=harvester-${ARCH}
 [ -d iso ] && yq e ".overlay.isoimage = \"$(pwd)/iso\"" iso.yaml -i
 luet-makeiso iso.yaml --image "${HARVESTER_OS_IMAGE}" --output ${ARTIFACTS_DIR}/${ISO_PREFIX}
 
+# remove leading directory components of the ISO name
+CHECKSUM_FILE=${ARTIFACTS_DIR}/${ISO_PREFIX}.iso.sha256
+CHECKSUM=$(cat $CHECKSUM_FILE | awk '{print $1}')
+echo "$CHECKSUM ${ISO_PREFIX}.iso" > $CHECKSUM_FILE
+
 # Extract the squashfs image for PXE boot
-xorriso -osirrox on -indev ${ARTIFACTS_DIR}/${ISO_PREFIX}.iso -extract /rootfs.squashfs ${ARTIFACTS_DIR}/harvester-${VERSION}-rootfs-${ARCH}.squashfs
+xorriso -osirrox on -indev ${ARTIFACTS_DIR}/${ISO_PREFIX}.iso -extract /rootfs.squashfs ${ARTIFACTS_DIR}/harvester-rootfs-${ARCH}.squashfs

--- a/scripts/package-harvester-repo
+++ b/scripts/package-harvester-repo
@@ -23,4 +23,6 @@ docker image save -o ${IMAGES_DIR}/harvester-repo-images.tar $(<${IMAGES_DIR}/ha
 zstd --rm ${IMAGES_DIR}/harvester-repo-images.tar -o ${IMAGES_DIR}/harvester-repo-images.tar.zst
 
 # Update image name in Rancherd bootstrap resources
-sed -i "s,\$CLUSTER_REPO_IMAGE,${CLUSTER_REPO_IMAGE}," ${PACKAGE_HARVESTER_OS_DIR}/files/usr/share/rancher/rancherd/config.yaml.d/91-harvester-bootstrap.yaml
+sed "s,\$CLUSTER_REPO_IMAGE,${CLUSTER_REPO_IMAGE}," \
+  ${PACKAGE_HARVESTER_OS_DIR}/templates/91-harvester-bootstrap-repo.yaml > \
+  ${PACKAGE_HARVESTER_OS_DIR}/files/usr/share/rancher/rancherd/config.yaml.d/91-harvester-bootstrap-repo.yaml


### PR DESCRIPTION
The generated artifacts now looks like:

```
harvester-amd64.iso
harvester-amd64.iso.sha256
harvester-initrd-amd64
harvester-rootfs-amd64.squashfs
harvester-vmlinuz-amd64
```

rather than:

```
harvester-cc76525-dirty-amd64.iso.sha256
harvester-cc76525-dirty-vmlinuz-amd64
harvester-cc76525-dirty-initrd-amd64
harvester-cc76525-dirty-rootfs-amd64.squashfs
harvester-cc76525-dirty-amd64.iso
```