### PR TITLE
Fix netconfig fail to update name servers in target OS

### DIFF
--- a/package/harvester-os/files/usr/sbin/harv-install
+++ b/package/harvester-os/files/usr/sbin/harv-install
@@ -105,6 +105,9 @@ preload_rke2_images()
     echo "Loading images. This may take a few minutes..."
     chroot . /bin/bash <<"EOF"
       set -e
+      # update the nameserver
+      netconfig update
+
       inst_tmp=$(mktemp -d -p /usr/local)
       trap "rm -rf $inst_tmp" exit
 
@@ -170,8 +173,6 @@ preload_rancherd_images()
 
 do_preload()
 {
-    touch $TARGET/etc/resolv.conf && mount -o bind,ro /etc/resolv.conf $TARGET/etc/resolv.conf
-
     # Bind mount persistent folder to preload images
     BIND_MOUNTS=("var/lib/rancher")
 
@@ -189,8 +190,6 @@ do_preload()
     for i in ${BIND_MOUNTS[@]}; do
         umount $TARGET/$i
     done
-
-    umount $TARGET/etc/resolv.conf
 }
 
 update_grub_settings()


### PR DESCRIPTION
The previous way to set name servers in the image preloading phase
removes the symbolic link:

```
 /etc/resolv.conf -> /var/run/netconfig/resolv.conf
```

This makes netconfig fail to update name servers from DHCP protocol.
Using netconfig to keep the link.

**Depends on**: https://github.com/harvester/os2/pull/8
**Related**: harvester/harvester#1137
