### PR TITLE
Bump luet-makeiso version

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -29,7 +29,7 @@ RUN mkdir /usr/tmp && \
 
 # makeiso
 RUN wget --quiet https://github.com/mudler/luet/releases/download/0.17.0/luet-0.17.0-linux-amd64 -O /usr/bin/luet && chmod +x /usr/bin/luet
-RUN wget --quiet https://github.com/mudler/luet-makeiso/releases/download/0.3.3/luet-makeiso-0.3.3-linux-amd64 -O /usr/bin/luet-makeiso && chmod +x /usr/bin/luet-makeiso
+RUN wget --quiet https://github.com/mudler/luet-makeiso/releases/download/0.3.8/luet-makeiso-0.3.8-linux-amd64 -O /usr/bin/luet-makeiso && chmod +x /usr/bin/luet-makeiso
 
 ENV GO111MODULE off
 ENV DAPPER_ENV REPO TAG DRONE_TAG CROSS

--- a/package/harvester-os/iso.yaml
+++ b/package/harvester-os/iso.yaml
@@ -18,3 +18,5 @@ luet:
       urls:
         - quay.io/costoolkit/releases-green
       type: docker
+squashfs_options:
+  compression: xz


### PR DESCRIPTION
The new version allows specifying compression.
It might be useful to developers by changing the compressor to `zstd` to speed up the building process.

```diff
diff --git a/package/harvester-os/iso.yaml b/package/harvester-os/iso.yaml
index 694f8bf..7fe320e 100644
--- a/package/harvester-os/iso.yaml
+++ b/package/harvester-os/iso.yaml
@@ -19,4 +19,4 @@ luet:
         - quay.io/costoolkit/releases-green
       type: docker
 squashfs_options:
-  compression: xz
+  compression: zstd
```

