### PR TITLE
Create booting interface configuration files in PXE boot installation

### DIFF
--- a/package/harvester-os/files/system/oem/90_network.yaml
+++ b/package/harvester-os/files/system/oem/90_network.yaml
@@ -1,7 +1,27 @@
-name: "Bring up interface"
+name: "Network configuration"
 stages:
+  rootfs:
+    - name: Create DHCP config for boot interfaces
+      if: cat /proc/cmdline | grep -q "harvester.install.automatic=true"
+      commands:
+      - |
+        if [ ! -e /tmp/net.ifaces ]; then
+          echo "net.ifaces is not found. Skip configuring boot interface."
+          exit 0
+        fi
+        
+        for iface in $(</tmp/net.ifaces); do
+          echo "Create DHCP config for $iface"
+        
+          cat > /sysroot/etc/sysconfig/network/ifcfg-$iface <<'EOF'
+        BOOTPROTO='dhcp'
+        STARTMODE='onboot'
+        EOF
+        
+        done
   initramfs:
-    - commands:
+    - name: Bring up interfaces
+      commands:
       - |
         for i in /sys/class/net/{eth*,en*,ib*}; do
           [ -e $i ] || continue


### PR DESCRIPTION
Create booting interface configuration files in PXE boot installation

The configuration files are needed to let wicked correctly apply DNS
settings.

For booting parameter `ip=dhcp`, the script creates DHCP configuration files for the booting interface(s).
If a machine has multiple network interfaces and more than one of them receive DHCP IPs, the booting interfaces are undetermined. Sometimes it's the first interface that receives a DHCP IP, sometimes all interfaces are listed.

For booting parameter `ip=ens5:dhcp ip=ens6:dhcp`, the script creates DHCP configuration files for interface `ens5` and `ens6`

**Why do we need this?**
A PXE-booted Live OS can be divided into 3 stages, each has its own network configuration.
- PXE firmware: The firmware sends DHCP requests to get an IP to download iPXE config, kernel, and initrd back. The kernel is booted.
- Initramfs: If the iPXE config downloaded from the previous stage contains kernel parameter `ip=dhcp`, a Dracut module will try to send DHCP requests again. If it gets IP, it will download squashfs and pivot to it. At this stage, gateway information and DNS server offered by DHCP server are correctly configured.
- Switch to real rootfs (the squashfs image): wicked is in charge of the network. But because the rootfs is changed, it no longer contains the correct DNS server information in the previous stage. We need to tell wicked to make DHCP requests again and it will correctly set the DNS servers. That's why we need to generate wicked configs.

**Related issue**
https://github.com/harvester/harvester/issues/1214