### PR TITLE
Report status while configuring network

### DIFF
--- a/pkg/console/spinner.go
+++ b/pkg/console/spinner.go
@@ -12,6 +12,7 @@ type Spinner struct {
 	panel  string
 	prefix string
 	ticker *time.Ticker
+	focus  bool
 
 	stop    chan TaskResult
 	stopped chan bool
@@ -35,6 +36,17 @@ func NewSpinner(g *gocui.Gui, panel string, prefix string) *Spinner {
 		prefix:  prefix,
 		stop:    make(chan TaskResult),
 		stopped: make(chan bool),
+	}
+}
+
+func NewFocusSpinner(g *gocui.Gui, panel string, prefix string) *Spinner {
+	return &Spinner{
+		g:       g,
+		panel:   panel,
+		prefix:  prefix,
+		stop:    make(chan TaskResult),
+		stopped: make(chan bool),
+		focus:   true,
 	}
 }
 
@@ -78,8 +90,15 @@ func (s *Spinner) writePanel(message string, clear bool, fgColor gocui.Attribute
 			ch <- struct{}{}
 		}()
 		v, err := g.View(s.panel)
+		if err == gocui.ErrUnknownView {
+			return nil
+		}
 		if err != nil {
 			return err
+		}
+
+		if s.focus {
+			g.SetCurrentView(s.panel)
 		}
 		if clear {
 			v.Clear()


### PR DESCRIPTION
**Related issue**
https://github.com/harvester/harvester/issues/1212

* Add functionality to the spinner for trapping the cursor focus so
  users can't adjust settings while we're configuring the system:
  `NewFocusSpinner`.

* Set up the focus spinner while we're requesting IP through DHCP and
  setting up networking.

* For other types of message, call `updateValidatorMessage` to prevent
  trapping focus.

* Fix spinner behavior: When it can't find the view, don't do anything.

* Update `validateDHCPAddresses`: Calls `getIPThroughDHCP` to validate
  DHCP. No need to call `setupNetwork` at this time because it will be
  called when we go to next page.

**Note**
I didn't change the way how IP is shown after it's received from DHCP.