### PR TITLE
Use default route device as the interface of canal

### DIFF
--- a/pkg/config/templates/rke2-canal-config.yaml
+++ b/pkg/config/templates/rke2-canal-config.yaml
@@ -3,7 +3,3 @@ kind: HelmChartConfig
 metadata:
   name: rke2-canal
   namespace: kube-system
-spec:
-  valuesContent: |-
-    flannel:
-      iface: "{{ .MgmtInterface }}"


### PR DESCRIPTION
It's a temporary solution before the bond solution completes.

issue: https://github.com/harvester/harvester/issues/1207