### PR TITLE
Show harvester version on console dashboard

### DIFF
--- a/pkg/console/dashboard_panels.go
+++ b/pkg/console/dashboard_panels.go
@@ -98,7 +98,7 @@ func logoPanel(g *gocui.Gui) error {
 		}
 		v.Frame = false
 		fmt.Fprintf(v, logo)
-		versionStr := "version: " + version.Version
+		versionStr := "version: " + version.HarvesterVersion
 		logoLength := 74
 		nSpace := logoLength - len(versionStr)
 		fmt.Fprintf(v, "\n%*s", nSpace, "")

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,5 +1,6 @@
 package version
 
 var (
-	Version = "dev"
+	Version          = "dev"
+	HarvesterVersion = "dev" // Will be replaced by ldflags
 )

--- a/scripts/build
+++ b/scripts/build
@@ -5,13 +5,28 @@ TOP_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
 SCRIPTS_DIR="${TOP_DIR}/scripts"
 PACKAGE_HARVESTER_OS_DIR="${TOP_DIR}/package/harvester-os"
 
-source ${SCRIPTS_DIR}/version-rke2
-
 cd ${TOP_DIR}
+
+# Pull harvester source and determine harvester version
+harvester_path=../harvester
+if [ ! -d ${harvester_path} ];then
+    echo "No existed harvester source. Pulling..."
+    git clone --branch master --single-branch --depth 1 https://github.com/harvester/harvester.git ../harvester
+fi
+
+source ${SCRIPTS_DIR}/version-harvester $harvester_path
+source ${SCRIPTS_DIR}/version-rke2
+source ${SCRIPTS_DIR}/version
+
+echo "Harvester version: ${HARVESTER_VERSION}"
+echo "Installer version: ${VERSION}"
 
 mkdir -p bin
 
-LINKFLAGS="-X github.com/harvester/harvester-installer/pkg/config.RKE2Version=$RKE2_VERSION $LINKFLAGS"
+LINKFLAGS="-X github.com/harvester/harvester-installer/pkg/config.RKE2Version=$RKE2_VERSION
+           -X github.com/harvester/harvester-installer/pkg/version.Version=$VERSION
+           -X github.com/harvester/harvester-installer/pkg/version.HarvesterVersion=$HARVESTER_VERSION
+           $LINKFLAGS"
 
 if [ "$(uname)" = "Linux" ]; then
     OTHER_LINKFLAGS="-extldflags -static -s"

--- a/scripts/build-bundle
+++ b/scripts/build-bundle
@@ -67,6 +67,7 @@ get_url()
 # Prepare Harvester chart
 harvester_path=../harvester
 if [ ! -d ${harvester_path} ];then
+    echo "No existed harvester source. Pulling into /tmp/harvester"
     git clone --branch master --single-branch --depth 1 https://github.com/harvester/harvester.git /tmp/harvester
     harvester_path=/tmp/harvester
 fi

--- a/scripts/version
+++ b/scripts/version
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+unset DIRTY
 if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
     DIRTY="-dirty"
 fi

--- a/scripts/version-harvester
+++ b/scripts/version-harvester
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+HARVESTER_VERSION=$(cd $1; source ./scripts/version &> /dev/null; echo $VERSION)


### PR DESCRIPTION
* Add a new version variable `HarvesterVersion` to store version of harvester. Console dashboard shows this version, instead of the installer version.

* Add a new script `version-harvester` to determine and set up `HARVESTER_VERSION` variable for later use.

* Update script `version`: Unset variable `DIRTY` in case it was set somewhere else.

* Update script `build`:
  - Pull harvester source from github if not exists. This will happen if we're calling `make` from harvester-installer, but not from calling `make build-iso` from harvester.

  - Source "version-harvester" script to get the version of harvester.

  - Update both harvester and harvester-installer version variables using ldflags, `HarvesterVersion` and `Version` respectively.

Tested by calling `make` from harvester-installer and `make build-iso` from harvester.