### PR TITLE
Bump rke2 to v1.21.5+rke2r1

### DIFF
--- a/package/harvester-os/files/usr/share/rancher/rancherd/config.yaml.d/50-defaults.yaml
+++ b/package/harvester-os/files/usr/share/rancher/rancherd/config.yaml.d/50-defaults.yaml
@@ -1,7 +1,7 @@
 rancherValues:
   rancherImagePullPolicy: IfNotPresent
   rancherImage: rancher/rancher
-  rancherImageTag: v2.6.0
+  rancherImageTag: v2.6.1-rc5
   noDefaultAdmin: false
   features: multi-cluster-management=false,multi-cluster-management-agent=false
   useBundledSystemChart: true

--- a/package/harvester-os/files/usr/share/rancher/rancherd/config.yaml.d/50-defaults.yaml
+++ b/package/harvester-os/files/usr/share/rancher/rancherd/config.yaml.d/50-defaults.yaml
@@ -6,4 +6,4 @@ rancherValues:
   features: multi-cluster-management=false,multi-cluster-management-agent=false
   useBundledSystemChart: true
   bootstrapPassword: admin
-rancherInstallerImage: ibuildthecloud/system-agent-installer-rancher:dev
+rancherInstallerImage: rancher/system-agent-installer-rancher:v2.6.1-rc5

--- a/scripts/images/rancher-images.txt
+++ b/scripts/images/rancher-images.txt
@@ -1,11 +1,12 @@
-docker.io/rancher/fleet-agent:v0.3.6
-docker.io/rancher/fleet:v0.3.6
+docker.io/rancher/fleet-agent:v0.3.7-rc3
+docker.io/rancher/fleet:v0.3.7-rc3
 docker.io/rancher/gitjob:v0.1.21
 docker.io/rancher/kubectl:v1.20.2
-docker.io/rancher/rancher:v2.6.0
-docker.io/rancher/rancher-webhook:v0.2.0
+docker.io/rancher/rancher:v2.6.1-rc5
+docker.io/rancher/rancher-webhook:v0.2.1
 docker.io/rancher/shell:v0.1.10
-docker.io/rancher/system-agent:v0.1.0-suc
+docker.io/rancher/shell:v0.1.8
+docker.io/rancher/system-agent:v0.1.1-rc1-suc
 docker.io/rancher/system-upgrade-controller:v0.7.5
 docker.io/rancher/mirrored-directxman12-k8s-prometheus-adapter:v0.8.4
 docker.io/rancher/mirrored-prometheus-node-exporter:v1.1.2
@@ -17,5 +18,4 @@ docker.io/rancher/mirrored-library-busybox:1.31.1
 docker.io/rancher/mirrored-grafana-grafana:7.5.8
 docker.io/rancher/mirrored-library-nginx:1.21.1-alpine
 docker.io/rancher/mirrored-kube-state-metrics-kube-state-metrics:v2.0.0
-docker.io/rancher/shell:v0.1.8
 docker.io/rancher/mirrored-jettech-kube-webhook-certgen:v1.5.2

--- a/scripts/images/rancherd-bootstrap-images.txt
+++ b/scripts/images/rancherd-bootstrap-images.txt
@@ -1,2 +1,2 @@
-docker.io/ibuildthecloud/system-agent-installer-rancher:dev
+docker.io/rancher/system-agent-installer-rancher:v2.6.1-rc5
 docker.io/rancher/system-agent-installer-rke2:$RKE2_VERSION

--- a/scripts/version-rke2
+++ b/scripts/version-rke2
@@ -1,1 +1,1 @@
-RKE2_VERSION="v1.21.4-rc1+rke2r4"
+RKE2_VERSION="v1.21.5+rke2r1"


### PR DESCRIPTION
- Bump RKE2 to `v1.21.5+rke2r1` https://github.com/harvester/harvester/issues/991
- Bump Rancher to `v2.6-1-rc5` https://github.com/harvester/harvester/issues/1243