### PR TITLE
Label nodes which supports virtualization

### DIFF
--- a/pkg/config/cos.go
+++ b/pkg/config/cos.go
@@ -196,6 +196,12 @@ func initRancherdStage(config *HarvesterConfig, stage *yipSchema.Stage) error {
 	if err != nil {
 		return err
 	}
+	if _, err := os.Stat("/dev/kvm"); err == nil {
+		if err != nil {
+			return err
+		}
+		rke2AgentConfig += " - harvesterhci.io/kubevirt=true"
+	}
 	stage.Files = append(stage.Files,
 		yipSchema.File{
 			Path:        "/etc/rancher/rke2/config.yaml.d/90-harvester-agent.yaml",


### PR DESCRIPTION
Extend logic which was added on #93 in way that there will additional `harvesterhci.io/kubevirt=true` label on those nodes which can run KubeVirt and host virtual machines.

First step to support VM mode requested on https://github.com/harvester/harvester/issues/1290
