### PR TITLE
fix(install_panels.go): use IsDNS1123Subdomain to validate hostname

### DIFF
--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -741,8 +741,10 @@ func addNetworkPanel(c *Console) error {
 		if hostName == "" {
 			return "must specify hostname", nil
 		}
-		if errs := validation.IsQualifiedName(hostName); len(errs) > 0 {
-			return fmt.Sprintf("%s is not a valid hostname", hostName), nil
+		// ref: https://github.com/kubernetes/kubernetes/blob/b15f788d29df34337fedc4d75efe5580c191cbf3/pkg/apis/core/validation/validation.go#L242-L245
+		if errs := validation.IsDNS1123Subdomain(hostName); len(errs) > 0 {
+			// TODO: show regexp for validation to users
+			return "Invalid hostname. A lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.'.", nil
 		}
 		c.config.Hostname = hostName
 		return "", nil

--- a/pkg/console/validator.go
+++ b/pkg/console/validator.go
@@ -199,6 +199,13 @@ func checkVip(vip, vipHwAddr, vipMode string) error {
 }
 
 func (v ConfigValidator) Validate(cfg *config.HarvesterConfig) error {
+	// check hostname
+	// ref: https://github.com/kubernetes/kubernetes/blob/b15f788d29df34337fedc4d75efe5580c191cbf3/pkg/apis/core/validation/validation.go#L242-L245
+	if errs := validation.IsDNS1123Subdomain(cfg.OS.Hostname); len(errs) > 0 {
+		// TODO: show regexp for validation to users
+		return errors.Errorf("Invalid hostname. A lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.'.")
+	}
+
 	if err := checkDevice(cfg.Install.Device); err != nil {
 		return err
 	}


### PR DESCRIPTION
Follow Kubernetes node name validation method.

Issue: https://github.com/harvester/harvester/issues/1277