### PR TITLE
Add a new network method none to bypass network configuration

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -7,6 +7,7 @@ const (
 
 	NetworkMethodDHCP   = "dhcp"
 	NetworkMethodStatic = "static"
+	NetworkMethodNone   = "none"
 
 	MgmtInterfaceName = "harvester-mgmt"
 

--- a/pkg/console/validator.go
+++ b/pkg/console/validator.go
@@ -18,6 +18,7 @@ var (
 	ErrMsgTokenNotSpecified             = "token not specified"
 
 	ErrMsgMgmtInterfaceNotSpecified    = "no management interface specified"
+	ErrMsgMgmtInterfaceInvalidMethod   = "management network must configure with either static or DHCP method"
 	ErrMsgInterfaceNotSpecified        = "no interface specified"
 	ErrMsgInterfaceNotSpecifiedForMgmt = "no interface specified for management network"
 	ErrMsgInterfaceNotFound            = "interface not found"
@@ -133,8 +134,14 @@ func checkNetworks(networks map[string]config.Network) error {
 
 	if mgmtNetwork, ok := networks[config.MgmtInterfaceName]; !ok {
 		return errors.New(ErrMsgMgmtInterfaceNotSpecified)
-	} else if len(mgmtNetwork.Interfaces) == 0 {
-		return errors.New(ErrMsgInterfaceNotSpecifiedForMgmt)
+	} else {
+		if len(mgmtNetwork.Interfaces) == 0 {
+			return errors.New(ErrMsgInterfaceNotSpecifiedForMgmt)
+		}
+		method := mgmtNetwork.Method
+		if method != config.NetworkMethodDHCP && method != config.NetworkMethodStatic {
+			return errors.New(ErrMsgMgmtInterfaceInvalidMethod)
+		}
 	}
 
 	for _, network := range networks {
@@ -144,7 +151,7 @@ func checkNetworks(networks map[string]config.Network) error {
 			}
 		}
 		switch network.Method {
-		case config.NetworkMethodDHCP, "":
+		case config.NetworkMethodDHCP, config.NetworkMethodNone, "":
 			return nil
 		case config.NetworkMethodStatic:
 			if err := checkStaticRequiredString("ip", network.IP); err != nil {
@@ -189,7 +196,7 @@ func checkVip(vip, vipHwAddr, vipMode string) error {
 		if err := checkHwAddr(vipHwAddr); err != nil {
 			return err
 		}
-	case config.NetworkMethodStatic:
+	case config.NetworkMethodStatic, config.NetworkMethodNone:
 		return nil
 	default:
 		return prettyError(ErrMsgNetworkMethodUnknown, vipMode)


### PR DESCRIPTION
Related: https://github.com/harvester/harvester/issues/1325

## Solution

- Add a new network method `none` to bypass configuring any DHCP or static network

## Test plan

### Installer console

- [ ] Run installer and it should act as before. Won't show the `none` network method.

### Install via pxe boot

- [ ] Set `install.networks.harvester-mgmt.method` to `none`. Should throw an error.
- [ ] Set `install.networks.harvester-mgmt.method` to `static` or `dhcp`. Should work as before.
- [ ] Set `install.networks.harvester-mgmt.method` to `static` or `dhcp`. And configure another network with `method: none` Should succeed to install and won't generate any ifroute-* files and only ifcfg- with `BOOTPROTO=none` for the extra network.


