### PR TITLE
Allow installation on raid-disks

### DIFF
--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -182,7 +182,7 @@ func addDiskPanel(c *Console) error {
 }
 
 func getDiskOptions() ([]widgets.Option, error) {
-	output, err := exec.Command("/bin/sh", "-c", `lsblk -r -o NAME,SIZE,TYPE | grep -w disk|cut -d ' ' -f 1,2`).CombinedOutput()
+	output, err := exec.Command("/bin/sh", "-c", `lsblk -r -o NAME,SIZE,TYPE | grep -E "\b(disk|raid[0-9]+)$" | cut -d ' ' -f 1,2 | sort -u`).CombinedOutput()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Allow installation on raid-disks such as mdraid / Intel RST

Before:
![Screenshot from 2021-10-04 14-33-19](https://user-images.githubusercontent.com/759887/135858268-8a7e76e6-aa27-4652-be71-42f533f3530f.png)
After:
![Screenshot from 2021-10-04 15-06-59](https://user-images.githubusercontent.com/759887/135858266-d550ba9e-eaeb-4f18-9b32-a9b33e79fc32.png)