### PR TITLE
Accept image repository with more than 3 subpaths

### DIFF
--- a/scripts/build-bundle
+++ b/scripts/build-bundle
@@ -160,7 +160,7 @@ curl ${longhorn_image_url}>>${image_list_file}
 
 # format image list
 awk -F ':' '{if($2==""){print $1":latest"}else{print $0}}' "${image_list_file}" | \
-awk -F '/' '{if(NF==3){print $0} else if(NF==2){print "docker.io/"$0}else if(NF=1){print "docker.io/library/"$0}}' >"${image_list_file}.tmp"
+awk -F '/' '{if(NF>=3){print $0} else if(NF==2){print "docker.io/"$0}else if(NF=1){print "docker.io/library/"$0}}' >"${image_list_file}.tmp"
 
 # clean image list
 sort -u "${image_list_file}.tmp" | \


### PR DESCRIPTION
Related: https://github.com/harvester/harvester/pull/1336#discussion_r720286413

Need to accept image repository with more than three subpaths, e.g. `registry.suse.com/suse/sles/15.3/virt-operator`