### PR TITLE
Specify rancher version in rancherd config

### DIFF
--- a/package/harvester-os/files/usr/share/rancher/rancherd/config.yaml.d/50-defaults.yaml
+++ b/package/harvester-os/files/usr/share/rancher/rancherd/config.yaml.d/50-defaults.yaml
@@ -1,9 +1,6 @@
 rancherValues:
   rancherImagePullPolicy: IfNotPresent
-  rancherImage: rancher/rancher
-  rancherImageTag: v2.6.1-rc5
   noDefaultAdmin: false
   features: multi-cluster-management=false,multi-cluster-management-agent=false
   useBundledSystemChart: true
   bootstrapPassword: admin
-rancherInstallerImage: rancher/system-agent-installer-rancher:v2.6.1-rc5

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -111,6 +111,7 @@ type HarvesterConfig struct {
 	OS             `json:"os,omitempty"`
 	Install        `json:"install,omitempty"`
 	RuntimeVersion string `json:"runtimeVersion,omitempty"`
+	RancherVersion string `json:"rancherVersion,omitempty"`
 }
 
 func NewHarvesterConfig() *HarvesterConfig {

--- a/pkg/config/cos.go
+++ b/pkg/config/cos.go
@@ -31,6 +31,9 @@ var (
 	// RKE2Version is replaced by ldflags
 	RKE2Version = ""
 
+	// RancherVersion replaced by ldflags
+	RancherVersion = ""
+
 	originalNetworkConfigs        = make(map[string][]byte)
 	saveOriginalNetworkConfigOnce sync.Once
 )
@@ -144,6 +147,9 @@ func ConvertToCOS(config *HarvesterConfig) (*yipSchema.YipConfig, error) {
 func initRancherdStage(config *HarvesterConfig, stage *yipSchema.Stage) error {
 	if config.RuntimeVersion == "" {
 		config.RuntimeVersion = RKE2Version
+	}
+	if config.RancherVersion == "" {
+		config.RancherVersion = RancherVersion
 	}
 
 	rancherdConfig, err := render("rancherd-config.yaml", config)

--- a/pkg/config/templates/rancherd-config.yaml
+++ b/pkg/config/templates/rancherd-config.yaml
@@ -6,5 +6,6 @@ role: cluster-init
 {{- end }}
 token: '{{ .Token }}'
 kubernetesVersion: {{ .RuntimeVersion }}
+rancherVersion: {{ .RancherVersion }}
 labels:
  - harvesterhci.io/managed=true

--- a/scripts/build
+++ b/scripts/build
@@ -16,6 +16,7 @@ fi
 
 source ${SCRIPTS_DIR}/version-harvester $harvester_path
 source ${SCRIPTS_DIR}/version-rke2
+source ${SCRIPTS_DIR}/version-rancher
 source ${SCRIPTS_DIR}/version
 
 echo "Harvester version: ${HARVESTER_VERSION}"
@@ -24,6 +25,7 @@ echo "Installer version: ${VERSION}"
 mkdir -p bin
 
 LINKFLAGS="-X github.com/harvester/harvester-installer/pkg/config.RKE2Version=$RKE2_VERSION
+           -X github.com/harvester/harvester-installer/pkg/config.RancherVersion=$RANCHER_VERSION
            -X github.com/harvester/harvester-installer/pkg/version.Version=$VERSION
            -X github.com/harvester/harvester-installer/pkg/version.HarvesterVersion=$HARVESTER_VERSION
            $LINKFLAGS"

--- a/scripts/version-rancher
+++ b/scripts/version-rancher
@@ -1,0 +1,1 @@
+RANCHER_VERSION="v2.6.1-rc5"


### PR DESCRIPTION
This is required in rancherd `v0.0.1-alpha9`, otherwise rancherd
will pull latest version from default channel.

**NOTE**
This requires at least [one PR's merged in os2 repo](https://github.com/harvester/os2/pulls) (rancherd version will be bumped).