### PR TITLE
Force GPT if storage size greater than MBR limit

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -72,6 +72,7 @@ type Install struct {
 	NoFormat  bool   `json:"noFormat,omitempty"`
 	Debug     bool   `json:"debug,omitempty"`
 	TTY       string `json:"tty,omitempty"`
+	ForceGPT  bool   `json:"forceGpt,omitempty"`
 
 	Webhooks []Webhook `json:"webhooks,omitempty"`
 }

--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -1241,6 +1241,16 @@ func addInstallPanel(c *Console) error {
 				c.config.TTY = getFirstConsoleTTY()
 			}
 
+			requireGPT, err := isForceGPTRequired(c.config.Install.Device)
+			if err != nil {
+				logrus.Errorf("failed to determine forcing GPT is required: %s. Not forcing GPT.", err)
+				requireGPT = false
+			}
+			c.config.Install.ForceGPT = requireGPT
+			if c.config.Install.ForceGPT {
+				logrus.Infof("forcing GPT partition scheme")
+			}
+
 			// case insensitive for network method and vip mode
 			for key, network := range c.config.Networks {
 				network.Method = strings.ToLower(network.Method)


### PR DESCRIPTION
**Need to wait until https://github.com/harvester/os2/pull/16 is merged.**

Use `cos-installer`'s option `--force-gpt` to use GPT partition scheme if storage size is greater than MBR limit (2TiB).

## Test steps
1. Create a VM with a virtual disk size greater than 2 TiB (It should be fine to create such a huge disk on a host with storage size smaller than that)
2. Make sure you have BIOS firmware, not UEFI
3. Boot up the installer and select the virtual disk
4. Installation should succeed

It would also be great to test this on a bare-metal system with storage greater than the limit.

### Notes
If the storage size on a BIOS system is below the limit, we won't force GPT. MBR will be used instead.

Related: https://github.com/harvester/harvester/issues/1299