### PR TITLE
Enable crash kernel for target OS

### DIFF
--- a/package/harvester-os/files/etc/cos/bootargs.cfg
+++ b/package/harvester-os/files/etc/cos/bootargs.cfg
@@ -2,9 +2,9 @@ set console_params="console=tty1"
 set kernel=/boot/vmlinuz
 set crash_kernel_params="crashkernel=219M,high crashkernel=72M,low"
 if [ -n "$recoverylabel" ]; then
-    set kernelcmd="$console_params root=live:LABEL=$recoverylabel rd.live.dir=/ rd.live.squashimg=$img panic=0 net.ifnames=1 $crash_kernel_params"
+    set kernelcmd="$console_params root=live:LABEL=$recoverylabel rd.live.dir=/ rd.live.squashimg=$img panic=0 net.ifnames=1"
 else
-    set kernelcmd="$console_params root=LABEL=$label cos-img/filename=$img panic=0 net.ifnames=1 $crash_kernel_params"
+    set kernelcmd="$console_params root=LABEL=$label cos-img/filename=$img panic=0 net.ifnames=1"
 fi
 
 set initramfs=/boot/initrd

--- a/package/harvester-os/files/etc/cos/bootargs.cfg
+++ b/package/harvester-os/files/etc/cos/bootargs.cfg
@@ -1,9 +1,10 @@
 set console_params="console=tty1"
 set kernel=/boot/vmlinuz
+set crash_kernel_params="crashkernel=219M,high crashkernel=72M,low"
 if [ -n "$recoverylabel" ]; then
-    set kernelcmd="$console_params root=live:LABEL=$recoverylabel rd.live.dir=/ rd.live.squashimg=$img panic=5 net.ifnames=1"
+    set kernelcmd="$console_params root=live:LABEL=$recoverylabel rd.live.dir=/ rd.live.squashimg=$img panic=0 net.ifnames=1 $crash_kernel_params"
 else
-    set kernelcmd="$console_params root=LABEL=$label cos-img/filename=$img panic=5 net.ifnames=1"
+    set kernelcmd="$console_params root=LABEL=$label cos-img/filename=$img panic=0 net.ifnames=1 $crash_kernel_params"
 fi
 
 set initramfs=/boot/initrd

--- a/package/harvester-os/files/etc/cos/grub.cfg
+++ b/package/harvester-os/files/etc/cos/grub.cfg
@@ -1,0 +1,74 @@
+# Override this file until https://github.com/rancher-sandbox/cOS-toolkit/issues/766 is done.
+set timeout=10
+
+set env_file="/grubenv"
+search --file --set=env_blk "${env_file}"
+
+if [ "${env_blk}" ] ; then
+  load_env -f "(${env_blk})${env_file}"
+fi
+
+if [ "${next_entry}" ]; then
+  set default="${next_entry}"
+  set next_entry=
+  save_env -f "(${env_blk})${env_file}" next_entry
+else
+  set default="${saved_entry}"
+fi
+
+set fallback="0 1 2"
+set gfxmode=auto
+set gfxpayload=keep
+insmod all_video
+insmod gfxterm
+insmod loopback
+insmod squash4
+
+menuentry "cOS" --id cos {
+  search.fs_label COS_STATE root
+  set img=/cOS/active.img
+  set label=COS_ACTIVE
+  loopback loop0 /$img
+  set root=($root)
+  source (loop0)/etc/cos/bootargs.cfg
+  linux (loop0)$kernel $kernelcmd
+  initrd (loop0)$initramfs
+}
+
+menuentry "cOS (debug)" --id cos-debug {
+  search.fs_label COS_STATE root
+  set img=/cOS/active.img
+  set label=COS_ACTIVE
+  loopback loop0 /$img
+  set root=($root)
+  source (loop0)/etc/cos/bootargs.cfg
+  linux (loop0)$kernel $kernelcmd $crash_kernel_params
+  initrd (loop0)$initramfs
+}
+
+menuentry "cOS (fallback)" --id fallback {
+  search.fs_label COS_STATE root
+  set img=/cOS/passive.img
+  set label=COS_PASSIVE
+  loopback loop0 /$img
+  set root=($root)
+  source (loop0)/etc/cos/bootargs.cfg
+  linux (loop0)$kernel $kernelcmd
+  initrd (loop0)$initramfs
+}
+
+menuentry "cOS recovery" --id recovery {
+  if search.file /cOS/recovery.squashfs ; then
+    set img=/cOS/recovery.squashfs
+    set recoverylabel=COS_RECOVERY
+  else
+    set img=/cOS/recovery.img
+  fi
+  search.fs_label COS_RECOVERY root
+  set label=COS_SYSTEM
+  loopback loop0 /$img
+  set root=($root)
+  source (loop0)/etc/cos/bootargs.cfg
+  linux (loop0)$kernel $kernelcmd
+  initrd (loop0)$initramfs
+}

--- a/package/harvester-os/files/etc/systemd/system/kdump.service.d/override.conf
+++ b/package/harvester-os/files/etc/systemd/system/kdump.service.d/override.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecStartPre=/usr/sbin/gen-kdump-initrd

--- a/package/harvester-os/files/system/oem/07_kdump.yaml
+++ b/package/harvester-os/files/system/oem/07_kdump.yaml
@@ -3,6 +3,10 @@ stages:
   initramfs:
     - name: "enable kdump"
       if: 'grep -q root=LABEL=COS_ACTIVE /proc/cmdline && [ -n "$(blkid -L COS_ACTIVE)" ]'
-      systemctl:
-        enable:
-          - kdump
+      commands:
+        - |
+          if grep -q "crashkernel=" /proc/cmdline; then
+            systemctl enable kdump
+          else
+            systemctl disable kdump
+          fi

--- a/package/harvester-os/files/system/oem/07_kdump.yaml
+++ b/package/harvester-os/files/system/oem/07_kdump.yaml
@@ -1,0 +1,8 @@
+name: "Kernel crash dump"
+stages:
+  initramfs:
+    - name: "enable kdump"
+      if: 'grep -q root=LABEL=COS_ACTIVE /proc/cmdline && [ -n "$(blkid -L COS_ACTIVE)" ]'
+      systemctl:
+        enable:
+          - kdump

--- a/package/harvester-os/files/usr/sbin/gen-kdump-initrd
+++ b/package/harvester-os/files/usr/sbin/gen-kdump-initrd
@@ -1,0 +1,52 @@
+#!/bin/bash -ex
+
+KERNEL_VERSION=$(uname -r)
+INITRD_KDUMP_NAME="initrd-$KERNEL_VERSION-kdump"
+INITRD_CACHE_DIR="/usr/local/cache/kdump"
+
+if [ -e /boot/$INITRD_KDUMP_NAME ]; then
+  echo /boot/$INITRD_KDUMP_NAME exists. Skip generating a new one.
+  exit 0
+fi
+
+if [ -e $INITRD_CACHE_DIR/$INITRD_KDUMP_NAME ]; then
+  echo "Using cache: $INITRD_CACHE_DIR/$INITRD_KDUMP_NAME"
+  cp $INITRD_CACHE_DIR/$INITRD_KDUMP_NAME /boot/$INITRD_KDUMP_NAME
+  exit 0
+fi
+
+mkdir -p $INITRD_CACHE_DIR
+
+TMP_DIR=$(mktemp -d)
+trap "rm -rf $TMP_DIR" exit
+
+TMP_INITRD=$TMP_DIR/initrd
+INITRD_EXTRACTED_DIR=$TMP_DIR/extracted
+DRACUT_CONFDIR=$TMP_DIR/dracut.conf.d
+
+mkdir -p $INITRD_EXTRACTED_DIR
+mkdir -p $DRACUT_CONFDIR
+
+
+# specify a new dracut config dir to avoid including cOS configs in /etc/dracut.conf.d
+cat > $DRACUT_CONFDIR/99-tmp.conf <<EOF
+early_microcode="no"
+host_only="yes"
+EOF
+/usr/bin/dracut --confdir $DRACUT_CONFDIR --force --omit "plymouth resume usrmount" --add kdump $TMP_INITRD $KERNEL_VERSION
+
+# extract initrd and replace fstab and kdump config
+cd $INITRD_EXTRACTED_DIR
+xzcat $TMP_INITRD | cpio -idm
+
+PERSISTENT_PARTITION=$(lsblk -n -o UUID /dev/disk/by-label/COS_PERSISTENT)
+cat > etc/fstab <<EOF
+UUID=$PERSISTENT_PARTITION /kdump/mnt0 auto defaults 0 0
+EOF
+
+sed -i 's,KDUMP_SAVEDIR.*,KDUMP_SAVEDIR="file:///mnt0/.state/var-crash.bind",' etc/sysconfig/kdump
+
+# pack initrd again
+find . -print0| sort -z | cpio --null -H newc --quiet -o > $TMP_DIR/initramfs.img 
+cat $TMP_DIR/initramfs.img | xz -0 --check=crc32 --memlimit-compress=50% >> $INITRD_CACHE_DIR/$INITRD_KDUMP_NAME
+cp $INITRD_CACHE_DIR/$INITRD_KDUMP_NAME /boot/$INITRD_KDUMP_NAME

--- a/package/harvester-os/files/usr/sbin/harv-install
+++ b/package/harvester-os/files/usr/sbin/harv-install
@@ -196,6 +196,24 @@ do_preload()
     done
 }
 
+get_crashkernel_params()
+{
+    local low=$(kdumptool calibrate | sed -n 's/^Low:\s\(.*\)/\1/p')
+    local high=$(kdumptool calibrate | sed -n 's/^High:\s\(.*\)/\1/p')
+
+    if [ -z "$low" ] || [ -z "$high" ]; then
+      return
+    fi
+
+    # https://doc.opensuse.org/documentation/leap/tuning/html/book-tuning/cha-tuning-kexec.html#sec-tuning-kexec-crashkernel
+    # Let's assume maximum 100 luns for now.
+    local size_low=$low
+    local size_high
+    let size_high=($high + 100/2)
+
+    echo "crashkernel=${size_high}M,high crashkernel=${size_low}M,low"
+}
+
 update_grub_settings()
 {
     if [ -z "${COS_INSTALL_TTY}" ]; then
@@ -206,6 +224,12 @@ update_grub_settings()
 
     if [ -e "/dev/${TTY%,*}" ] && [ "$TTY" != tty1 ] && [ "$TTY" != console ] && [ -n "$TTY" ]; then
         sed -i "s/console_params=\"console=tty1\"/console_params=\"console=${TTY} console=tty1\"/g" ${TARGET}/etc/cos/bootargs.cfg
+    fi
+
+    # calculate recommended crashkernel allocation size
+    CRASH_KERNEL_PARAMS=$(get_crashkernel_params || true)
+    if [ -n "$CRASH_KERNEL_PARAMS" ]; then
+        sed -i "s/^set crash_kernel_params=.*/crash_kernel_params=\"${CRASH_KERNEL_PARAMS}\"/" ${TARGET}/etc/cos/bootargs.cfg
     fi
 }
 


### PR DESCRIPTION
- Calculate crash kernel memory parameters at post-installation time.
- Generate a kdump initrd file before kdump service starts.
  mkdumprd and dracut kdump module don't work well with current file system layout.
  Customize the fstab file in the result initrd by ourself.

Required OS change: https://github.com/harvester/os2/pull/17
Related issue: https://github.com/harvester/harvester/issues/1335

** How to test **
Build a new ISO with the change and boot into the OS
- [ ] `cat /proc/cmdline`: `crashkernel=244M,high crashkernel=72M,low` parameters should be included (values varies from machine to machine)
- [ ] `echo c > /proc/sysrq-trigger` to simulate a crash. After rebooting, a crash dump should be store in`/var/crash` directory.