### PR TITLE
Use map to store bond options

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,10 +15,6 @@ type NetworkInterface struct {
 	HwAddr string `json:"hwAddr,omitempty"`
 }
 
-type BondOption struct {
-	Mode string `json:"mode,omitempty"`
-}
-
 const (
 	BondModeBalanceRR    = "balance-rr"
 	BondModeActiveBackup = "active-backup"
@@ -36,7 +32,7 @@ type Network struct {
 	SubnetMask   string             `json:"subnetMask,omitempty"`
 	Gateway      string             `json:"gateway,omitempty"`
 	DefaultRoute bool               `json:"defaultRoute,omitempty"`
-	BondOption   BondOption         `json:"bondOption,omitempty"`
+	BondOptions  map[string]string  `json:"bondOptions,omitempty"`
 }
 
 type HTTPBasicAuth struct {
@@ -148,4 +144,17 @@ func (c *HarvesterConfig) String() string {
 		return err.Error()
 	}
 	return fmt.Sprintf("%+v", *s)
+}
+
+func (n Network) AddDefaultBondOptions() Network {
+	// Create a BondOptions with default values for the Network.
+	// You normally don't need to use this method, it's here to bypass some limitations while
+	// updating the "Network" object in "Install.Networks" map.
+	// See https://stackoverflow.com/q/32751537
+	n.BondOptions = map[string]string{
+		"mode":   BondModeBalanceTLB,
+		"miimon": "100",
+	}
+
+	return n
 }

--- a/pkg/config/templates/wicked-ifcfg-bond-master
+++ b/pkg/config/templates/wicked-ifcfg-bond-master
@@ -8,10 +8,7 @@ NETMASK={{ .SubnetMask }}
 {{ range $i, $interface := .Interfaces -}}
 BONDING_SLAVE_{{ $i }}='{{ $interface.Name }}'
 {{ end }}
-{{  with .BondOption -}}
-{{- $bondMode := or .Mode "balance-tlb" -}}
-BONDING_MODULE_OPTS='mode={{ $bondMode }} miimon=100'
-{{- end }}
+BONDING_MODULE_OPTS='{{ range $key, $value := .BondOptions }}{{ $key }}={{ $value }} {{ end }}'
 {{ $defaultRoute := "no" -}}
 {{- if .DefaultRoute -}}
   {{- $defaultRoute = "yes" -}}

--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -805,14 +805,17 @@ func addNetworkPanel(c *Console) error {
 
 	// askBondModeV
 	askBondModeV.PreShow = func() error {
-		if mgmtNetwork.BondOption.Mode == "" {
+		if mgmtNetwork.BondOptions == nil {
 			askBondModeV.Value = config.BondModeBalanceTLB
 		}
 		return nil
 	}
 	askBondModeVConfirm := func(g *gocui.Gui, v *gocui.View) error {
 		mode, err := askBondModeV.GetData()
-		mgmtNetwork.BondOption.Mode = mode
+		mgmtNetwork.BondOptions = map[string]string{
+			"mode":   mode,
+			"miimon": "100",
+		}
 		if err != nil {
 			return err
 		}
@@ -1263,6 +1266,19 @@ func addInstallPanel(c *Console) error {
 				}
 				logrus.Info("Local config (merged): ", c.config)
 			}
+
+			// Adding default NIC bonding options for every network config if missing
+			// TODO (John): Consider moving this to config.updateBond function to only add bond
+			// options to Bond NICs.
+			for netName, network := range c.config.Install.Networks {
+				if network.BondOptions == nil {
+					msg := fmt.Sprintf("Adding default NIC bonding options for \"%s\"", netName)
+					logrus.Info(msg)
+					printToPanel(c.Gui, msg, installPanel)
+					c.config.Install.Networks[netName] = network.AddDefaultBondOptions()
+				}
+			}
+
 			if c.config.Hostname == "" {
 				c.config.Hostname = generateHostName()
 			}


### PR DESCRIPTION
## Todos
- [x] Test on manual installation
- [x] Test on PXE instalaltion
- [x] Update documents: https://github.com/harvester/docs/pull/28

## Notes
While installing via ISO and a remote config is supplied, the bond options `mode` and `miimon` will not be overwritten by the remote config due to the merging policy we have right now. The remote config can only be used to supply additional options. I think this is the default behavior.

Related issue: https://github.com/harvester/harvester/issues/1324