### PR TITLE
feat(install_panels): move DNS config page before management address page

### DIFF
--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -318,7 +318,7 @@ func addServerURLPanel(c *Console) error {
 		gocui.KeyEsc: func(g *gocui.Gui, v *gocui.View) error {
 			g.Cursor = false
 			serverURLV.Close()
-			return showNetworkPage(c)
+			return showNext(c, dnsServersPanel)
 		},
 	}
 	serverURLV.PostClose = func() error {
@@ -406,7 +406,7 @@ func addPasswordPanels(c *Console) error {
 				return err
 			}
 			c.config.Password = encrypted
-			return showNext(c, dnsServersPanel)
+			return showNext(c, ntpServersPanel)
 		},
 		gocui.KeyEsc: func(g *gocui.Gui, v *gocui.View) error {
 			passwordV.Close()
@@ -675,10 +675,7 @@ func addNetworkPanel(c *Console) error {
 	}
 
 	getNextPagePanel := func() []string {
-		if c.config.Install.Mode == config.ModeCreate {
-			return []string{vipTextPanel, vipPanel, askVipMethodPanel}
-		}
-		return []string{serverURLPanel}
+		return []string{dnsServersPanel}
 	}
 
 	gotoNextPage := func(fromPanel string) error {
@@ -1320,7 +1317,7 @@ func addVIPPanel(c *Console) error {
 
 	gotoPrevPage := func(g *gocui.Gui, v *gocui.View) error {
 		closeThisPage()
-		return showNetworkPage(c)
+		return showNext(c, dnsServersPanel)
 	}
 	gotoNextPage := func(g *gocui.Gui, v *gocui.View) error {
 		closeThisPage()
@@ -1442,7 +1439,7 @@ func addNTPServersPanel(c *Console) error {
 	gotoPrevPage := func(g *gocui.Gui, v *gocui.View) error {
 		c.config.OS.NTPServers = []string{}
 		closeThisPage()
-		return showNext(c, dnsServersPanel)
+		return showNext(c, passwordConfirmPanel, passwordPanel)
 	}
 	gotoNextPage := func() error {
 		closeThisPage()
@@ -1521,7 +1518,7 @@ func addNTPServersPanel(c *Console) error {
 }
 
 func addDNSServersPanel(c *Console) error {
-	dnsServersV, err := widgets.NewInput(c.Gui, dnsServersLabel, dnsServersLabel, false)
+	dnsServersV, err := widgets.NewInput(c.Gui, dnsServersPanel, dnsServersLabel, false)
 	if err != nil {
 		return err
 	}
@@ -1541,11 +1538,14 @@ func addDNSServersPanel(c *Console) error {
 	}
 	gotoPrevPage := func(g *gocui.Gui, v *gocui.View) error {
 		closeThisPage()
-		return showNext(c, passwordConfirmPanel, passwordPanel)
+		return showNetworkPage(c)
 	}
 	gotoNextPage := func() error {
 		closeThisPage()
-		return showNext(c, ntpServersPanel)
+		if c.config.Install.Mode == config.ModeCreate {
+			return showNext(c, vipTextPanel, vipPanel, askVipMethodPanel)
+		}
+		return showNext(c, serverURLPanel)
 	}
 	gotoSpinnerErrorPage := func(g *gocui.Gui, spinner *Spinner, msg string) {
 		spinner.Stop(true, msg)


### PR DESCRIPTION
Move DNS config page after Network page and before VIP/Management address page.

### Node 1
![node1](https://user-images.githubusercontent.com/4927361/136497010-4d0239ea-d4b8-4179-a794-eca0425a1f9d.gif)

### Node 2
![node2](https://user-images.githubusercontent.com/4927361/136497017-7f56e5c0-b508-440c-b7a2-ed9a9b4928f6.gif)

