### PR TITLE
Fix todo: Add default bonding options in updateBond

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -145,16 +145,3 @@ func (c *HarvesterConfig) String() string {
 	}
 	return fmt.Sprintf("%+v", *s)
 }
-
-func (n Network) AddDefaultBondOptions() Network {
-	// Create a BondOptions with default values for the Network.
-	// You normally don't need to use this method, it's here to bypass some limitations while
-	// updating the "Network" object in "Install.Networks" map.
-	// See https://stackoverflow.com/q/32751537
-	n.BondOptions = map[string]string{
-		"mode":   BondModeBalanceTLB,
-		"miimon": "100",
-	}
-
-	return n
-}

--- a/pkg/config/cos.go
+++ b/pkg/config/cos.go
@@ -369,7 +369,7 @@ func updateBond(stage *yipSchema.Stage, name string, network *Network) error {
 	// Adding default NIC bonding options if no options are provided (usually happened under PXE
 	// installation). Missing them would make bonding interfaces unusable.
 	if network.BondOptions == nil {
-		logrus.Info(fmt.Sprintf("Adding default NIC bonding options for \"%s\"", name))
+		logrus.Infof("Adding default NIC bonding options for \"%s\"", name)
 		network.BondOptions = map[string]string{
 			"mode":   BondModeBalanceTLB,
 			"miimon": "100",

--- a/pkg/config/cos.go
+++ b/pkg/config/cos.go
@@ -366,6 +366,16 @@ func updateNIC(stage *yipSchema.Stage, name string, network *Network) error {
 }
 
 func updateBond(stage *yipSchema.Stage, name string, network *Network) error {
+	// Adding default NIC bonding options if no options are provided (usually happened under PXE
+	// installation). Missing them would make bonding interfaces unusable.
+	if network.BondOptions == nil {
+		logrus.Info(fmt.Sprintf("Adding default NIC bonding options for \"%s\"", name))
+		network.BondOptions = map[string]string{
+			"mode":   BondModeBalanceTLB,
+			"miimon": "100",
+		}
+	}
+
 	ifcfg, err := render("wicked-ifcfg-bond-master", network)
 	if err != nil {
 		return err

--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -1251,18 +1251,6 @@ func addInstallPanel(c *Console) error {
 				logrus.Info("Local config (merged): ", c.config)
 			}
 
-			// Adding default NIC bonding options for every network config if missing
-			// TODO (John): Consider moving this to config.updateBond function to only add bond
-			// options to Bond NICs.
-			for netName, network := range c.config.Install.Networks {
-				if network.BondOptions == nil {
-					msg := fmt.Sprintf("Adding default NIC bonding options for \"%s\"", netName)
-					logrus.Info(msg)
-					printToPanel(c.Gui, msg, installPanel)
-					c.config.Install.Networks[netName] = network.AddDefaultBondOptions()
-				}
-			}
-
 			if c.config.Hostname == "" {
 				c.config.Hostname = generateHostName()
 			}


### PR DESCRIPTION
The current implementation is to add default bonding options for every network interfaces listed in the config. If we want to add default options **only** to bonding interfaces, we have to inspect those network configs. So I moved the adding action to the place where we have finished the inspection.