### PR TITLE
fix(ntp): update validation

### DIFF
--- a/pkg/console/util.go
+++ b/pkg/console/util.go
@@ -85,6 +85,7 @@ func validatePingServerURL(url string) error {
 
 func validateNTPServers(ntpServerList []string) error {
 	for _, ntpServer := range ntpServerList {
+		var err error
 		host, port, err := net.SplitHostPort(ntpServer)
 		if err != nil {
 			if addrErr, ok := err.(*net.AddrError); ok && addrErr.Err == "missing port in address" {
@@ -96,36 +97,61 @@ func validateNTPServers(ntpServerList []string) error {
 				return err
 			}
 		}
-		// ntp servers use udp protocol
-		// RFC: https://datatracker.ietf.org/doc/html/rfc4330
-		conn, err := net.Dial("udp", fmt.Sprintf("%s:%s", host, port))
+
+		ips, err := net.LookupIP(host)
 		if err != nil {
 			return err
 		}
-		if err := conn.SetDeadline(time.Now().Add(15 * time.Second)); err != nil {
-			return err
+
+		isSuccess := false
+		ipStrings := make([]string, 0, len(ips))
+		for _, ip := range ips {
+			ipString := ip.String()
+			ipStrings = append(ipStrings, ipString)
+			logrus.Infof("try to validate NTP server %s", ipString)
+			// ntp servers use udp protocol
+			// RFC: https://datatracker.ietf.org/doc/html/rfc4330
+			var conn net.Conn
+			address := net.JoinHostPort(ipString, port)
+			conn, err = net.Dial("udp", address)
+			if err != nil {
+				logrus.Errorf("fail to dial %s, err: %v", address, err)
+				continue
+			}
+			defer conn.Close()
+			if err = conn.SetDeadline(time.Now().Add(5 * time.Second)); err != nil {
+				logrus.Errorf("fail to set deadline for connection")
+			}
+
+			// RFC: https://datatracker.ietf.org/doc/html/rfc4330#section-4
+			// NTP Packet is 48 bytes and we set the first byte for request.
+			// 00 100 011 (or 0x2B)
+			// |  |   +-- client mode (3)
+			// |  + ----- version (4)
+			// + -------- leap year indicator, 0 no warning
+			req := make([]byte, 48)
+			req[0] = 0x2B
+
+			// send time request
+			if err = binary.Write(conn, binary.BigEndian, req); err != nil {
+				logrus.Errorf("fail to send NTP request")
+				continue
+			}
+
+			// block to receive server response
+			rsp := make([]byte, 48)
+			if err = binary.Read(conn, binary.BigEndian, &rsp); err != nil {
+				logrus.Errorf("fail to receive NTP response")
+				continue
+			}
+			isSuccess = true
+			break
 		}
 
-		// RFC: https://datatracker.ietf.org/doc/html/rfc4330#section-4
-		// NTP Packet is 48 bytes and we set the first byte for request.
-		// 00 100 011 (or 0x2B)
-		// |  |   +-- client mode (3)
-		// |  + ----- version (4)
-		// + -------- leap year indicator, 0 no warning
-		req := make([]byte, 48)
-		req[0] = 0x2B
-
-		// send time request
-		if err := binary.Write(conn, binary.BigEndian, req); err != nil {
-			return err
+		if !isSuccess {
+			logrus.Errorf("fail to validate NTP servers %v", ipStrings)
+			return fmt.Errorf("fail to validate NTP servers: %v, err: %w", ipStrings, err)
 		}
-
-		// block to receive server response
-		rsp := make([]byte, 48)
-		if err := binary.Read(conn, binary.BigEndian, &rsp); err != nil {
-			return err
-		}
-		conn.Close()
 	}
 
 	return nil


### PR DESCRIPTION
issue: https://github.com/harvester/harvester/issues/1345

* Resolve all addresses and lookup which one can be validated successfully.
* Validate users' input every time when users go back to the NTP setting page.

### Test Cases

Case 1 - default setting can work
* Go to the NTP setting page. Don't change anything. Press Enter.
* Default setting `0.suse.pool.ntp.org` should work.

Case 2 - change to another NTP server can work
* Go to the NTP setting page and change the input to `pool.ntp.org,0.suse.pool.ntp.org` and press Enter.
* NTP servers should be validated successfully.

Case 3 - non-NTP server cannot work
* Go to the NTP setting page and change the input to `8.8.8.8` and press Enter.
* Error message should be shown.

Case 4 - revalidate input when users change it
* Go to the NTP settings age and change the input to `8.8.8.8` and press Enter.
* Error message should be shown.
* Add some spaces to input like `8.8.8.8      ` and press Enter.
* Error message should be shown.
* Change the input back to `8.8.8.8` and press Enter.
* NTP servers should be validated again.

Case 5 - revalidate input when users go back to the NTP setting page
* Go to the NTP setting page. Don't change anything. Press Enter.
* Press ESC to go back to the NTP setting page.
* Press Enter again. NTP servers should be validated again.
* Press ESC twice to go back to the password setting page and press Enter again to go to the NTP setting page.
* Press Enter again. NTP servers should be validated again.