### PR TITLE
Add SystemSettings to overwrite system settings

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -106,7 +106,8 @@ type HarvesterConfig struct {
 
 	OS             `json:"os,omitempty"`
 	Install        `json:"install,omitempty"`
-	RuntimeVersion string `json:"runtimeVersion,omitempty"`
+	RuntimeVersion string            `json:"runtimeVersion,omitempty"`
+	SystemSettings map[string]string `json:"systemSetting,omitempty"`
 }
 
 func NewHarvesterConfig() *HarvesterConfig {

--- a/pkg/config/templates/harvester-config.yaml
+++ b/pkg/config/templates/harvester-config.yaml
@@ -14,3 +14,7 @@ spec:
         mode: "{{ .VipMode }}"
         ip: "{{ .Vip }}"
         hwAddress: "{{ .VipHwAddr }}"
+      installerProvidedSettings:
+      {{- range $key, $value := .SystemSettings }}
+        {{ $key }}: {{ $value | printf "%q" -}}
+      {{ end }}


### PR DESCRIPTION
Store the SystemSettings map as ConfigMap for Harvester to update its setting CRs.

To add settings to overwrite system default, update `HarvesterConfig.SystemSettings` with key set to Setting CR name and value to update. See [here](https://github.com/johnliu55tw/harvester-installer/blob/1e5b464a628ca2b96753810b65a184be8bca81e1/pkg/console/console.go#L58-L68) for an example.

**Related issues**:
- https://github.com/harvester/harvester/pull/1491