### PR TITLE
Check iso_url in automatic install mode like iPXE

### DIFF
--- a/package/harvester-os/files/usr/sbin/harv-install
+++ b/package/harvester-os/files/usr/sbin/harv-install
@@ -59,6 +59,11 @@ get_iso()
         get_url ${COS_INSTALL_ISO_URL} ${TEMP_FILE}
         ISO_DEVICE=$(losetup --show -f $TEMP_FILE)
         mount -o ro ${ISO_DEVICE} ${ISOMNT}
+    else
+        if [ -n "$COS_INSTALL_AUTOMATIC" ]; then
+            echo "Failed to read iso_url, it must be set in automatic install mode"
+            return 1
+        fi
     fi
 }
 

--- a/package/harvester-os/files/usr/sbin/harv-install
+++ b/package/harvester-os/files/usr/sbin/harv-install
@@ -59,11 +59,6 @@ get_iso()
         get_url ${COS_INSTALL_ISO_URL} ${TEMP_FILE}
         ISO_DEVICE=$(losetup --show -f $TEMP_FILE)
         mount -o ro ${ISO_DEVICE} ${ISOMNT}
-    else
-        if [ -n "$COS_INSTALL_AUTOMATIC" ]; then
-            echo "Failed to read iso_url, it must be set in automatic install mode"
-            return 1
-        fi
     fi
 }
 

--- a/pkg/console/validator.go
+++ b/pkg/console/validator.go
@@ -16,6 +16,7 @@ var (
 	ErrMsgModeJoinServerURLNotSpecified = fmt.Sprintf("ServerURL can't empty in %s mode", config.ModeJoin)
 	ErrMsgModeUnknown                   = "unknown mode"
 	ErrMsgTokenNotSpecified             = "token not specified"
+	ErrMsgISOURLNotSpecified            = "iso_url is required in automatic installation"
 
 	ErrMsgMgmtInterfaceNotSpecified    = "no management interface specified"
 	ErrMsgMgmtInterfaceInvalidMethod   = "management network must configure with either static or DHCP method"
@@ -232,6 +233,10 @@ func commonCheck(cfg *config.HarvesterConfig) error {
 		}
 	default:
 		return prettyError(ErrMsgModeUnknown, mode)
+	}
+
+	if cfg.Install.Automatic && cfg.Install.ISOURL == "" {
+		return errors.New(ErrMsgISOURLNotSpecified)
 	}
 
 	if cfg.Token == "" {


### PR DESCRIPTION
Problem:
 When iso_url is left blank in harvester automatic install like iPXE, no proper check is done, system goes into unexpected state

Solution:
 Add check in harv-install shell script,  when iso_url is blank in automatic mode, stop install and show error info.

Related issue:  harvester/harvester#1439

Test plan:
1. Set proper iPXE boot environment
2. In config file (e.g. config-create.yaml), set iso_url be blank;  (BTW: given the iso_url is wrong/unreachable, there has already been some checks and error/info prompt)
3. Boot the VM or baremetal via iPXE
4. Expect: Install will stop, and show info "Failed to read iso_url, it must be set in automatic install mode"