### PR TITLE
Check iso_url in automatic install mode like iPXE

### DIFF
--- a/pkg/console/validator.go
+++ b/pkg/console/validator.go
@@ -16,6 +16,7 @@ var (
 	ErrMsgModeJoinServerURLNotSpecified = fmt.Sprintf("ServerURL can't empty in %s mode", config.ModeJoin)
 	ErrMsgModeUnknown                   = "unknown mode"
 	ErrMsgTokenNotSpecified             = "token not specified"
+	ErrMsgISOURLNotSpecified            = "iso_url is required in automatic installation"
 
 	ErrMsgMgmtInterfaceNotSpecified    = "no management interface specified"
 	ErrMsgMgmtInterfaceInvalidMethod   = "management network must configure with either static or DHCP method"
@@ -232,6 +233,10 @@ func commonCheck(cfg *config.HarvesterConfig) error {
 		}
 	default:
 		return prettyError(ErrMsgModeUnknown, mode)
+	}
+
+	if cfg.Install.Automatic && cfg.Install.ISOURL == "" {
+		return errors.New(ErrMsgISOURLNotSpecified)
 	}
 
 	if cfg.Token == "" {


### PR DESCRIPTION
Problem:
When iso_url is left blank in harvester automatic installation like iPXE, no proper check is done, system goes into unexpected state

Solution:
Add check in validator, when iso_url is blank in automatic mode, stop installation and show related error message.

Related issue: harvester/harvester#1439

Test plan:

Set proper iPXE boot environment
In config file (e.g. config-create.yaml), set iso_url be blank; (BTW: given the iso_url is wrong/unreachable, there has already been some checks and error/info prompt)
Boot the VM / baremetal via iPXE
Expect: Install will stop, and show info `iso_url is required in automatic installation`