### PR TITLE
Add Node labels config

### DIFF
--- a/pkg/config/templates.go
+++ b/pkg/config/templates.go
@@ -25,3 +25,7 @@ func render(template string, context interface{}) (string, error) {
 	}
 	return util.RenderTemplate(string(templBytes), context)
 }
+
+func Render(template string, context interface{}) (string, error) {
+	return render(template, context)
+}

--- a/pkg/config/templates/rke2-90-harvester-agent.yaml
+++ b/pkg/config/templates/rke2-90-harvester-agent.yaml
@@ -1,2 +1,6 @@
-node-label+:
- - harvesterhci.io/managed=true
+{{- with $args :=  .GetKubeletArgs }}
+kubelet-arg:
+{{- range $arg := $args }}
+- {{ printf "%q" $arg }}
+{{- end }}
+{{- end }}

--- a/pkg/config/templates/rke2-90-harvester-server.yaml
+++ b/pkg/config/templates/rke2-90-harvester-server.yaml
@@ -5,3 +5,9 @@ service-cidr: 10.53.0.0/16
 cluster-dns: 10.53.0.10
 tls-san:
   - {{ .Vip }}
+{{- with $args :=  .GetKubeletArgs }}
+kubelet-arg:
+{{- range $arg := $args }}
+- {{ printf "%q" $arg }}
+{{- end }}
+{{- end }}

--- a/pkg/console/validator.go
+++ b/pkg/console/validator.go
@@ -215,6 +215,10 @@ func (v ConfigValidator) Validate(cfg *config.HarvesterConfig) error {
 		}
 	}
 
+	if _, err := cfg.GetKubeletArgs(); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
* Use `kubelet-arg` in RKE2 config to bootstrap node labels. See https://github.com/rancher/rancherd/issues/16.

* Remove `node-label+` from `rke2-90-harvester-agent.yaml` because we already have those default labels defined in `rancherd-config.yaml`.

## TODOs
- [x] Add documents for this config: https://github.com/harvester/docs/pull/76

## Related issues
- https://github.com/harvester/harvester/issues/1416