### PR TITLE
Support using symbolic link as the install device

### DIFF
--- a/package/harvester-os/files/usr/sbin/harv-install
+++ b/package/harvester-os/files/usr/sbin/harv-install
@@ -246,8 +246,14 @@ trap cleanup exit
 # For PXE Boot
 get_iso
 
+# Follow the symbolic link to the real device
+install_device="$COS_INSTALL_DEVICE"
+if [ -L "$COS_INSTALL_DEVICE" ]; then
+  install_device=$(readlink -f "$COS_INSTALL_DEVICE")
+fi
+
 # Run cOS installer but do not let it fetch ISO and shutdown
-COS_INSTALL_ISO_URL="" INTERACTIVE=yes cos-installer
+COS_INSTALL_ISO_URL="" INTERACTIVE=yes COS_INSTALL_DEVICE="$install_device" cos-installer
 
 # Preload images
 do_detect

--- a/pkg/console/validator.go
+++ b/pkg/console/validator.go
@@ -2,7 +2,10 @@ package console
 
 import (
 	"fmt"
+	"io/fs"
 	"net"
+	"os"
+	"path/filepath"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -70,12 +73,27 @@ func checkDevice(device string) error {
 	if device == "" {
 		return errors.New(ErrMsgDeviceNotSpecified)
 	}
+
+	fileInfo, err := os.Lstat(device)
+	if err != nil {
+		return err
+	}
+
+	targetDevice := device
+	// Support using path like `/dev/disks/by-id/xxx`
+	if fileInfo.Mode()&fs.ModeSymlink != 0 {
+		targetDevice, err = filepath.EvalSymlinks(device)
+		if err != nil {
+			return err
+		}
+	}
+
 	options, err := getDiskOptions()
 	if err != nil {
 		return err
 	}
 	for _, option := range options {
-		if device == option.Value {
+		if targetDevice == option.Value {
 			return nil
 		}
 	}


### PR DESCRIPTION
Users can use a symbolic link like `/dev/disk/by-id/xxx` to select an install device.
This is useful when device enumeration (`/dev/sda`...) is not persistent across reboots.

**Related issue**
https://github.com/harvester/harvester/issues/1462

**Test plan**
1. In a running OS, select a symbolic link to a disk. You can run the following command to see the links:
   ```
   ls /dev/disk/by-id -alh
   ```
   
   To test in a VM with Virtio disks, you can choose links in `/dev/disk/by-path/` because Virtio disks don't have ID.
2. Use symbolic link name as `os.install.device` to perform a PXE boot installation.
