### PR TITLE
Use managedchart to deploy setting CR

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -109,9 +109,10 @@ type HarvesterConfig struct {
 
 	OS                     `json:"os,omitempty"`
 	Install                `json:"install,omitempty"`
-	RuntimeVersion         string `json:"runtimeVersion,omitempty"`
-	HarvesterChartVersion  string `json:"harvesterChartVersion,omitempty"`
-	MonitoringChartVersion string `json:"monitoringChartVersion,omitempty"`
+	RuntimeVersion         string            `json:"runtimeVersion,omitempty"`
+	HarvesterChartVersion  string            `json:"harvesterChartVersion,omitempty"`
+	MonitoringChartVersion string            `json:"monitoringChartVersion,omitempty"`
+	SystemSettings         map[string]string `json:"systemSettings,omitempty"`
 }
 
 func NewHarvesterConfig() *HarvesterConfig {

--- a/pkg/config/cos.go
+++ b/pkg/config/cos.go
@@ -472,6 +472,7 @@ func genBootstrapResources(config *HarvesterConfig) (map[string]string, error) {
 		"10-harvester.yaml",
 		"11-monitoring-crd.yaml",
 		"13-monitoring.yaml",
+		"20-harvester-settings.yaml",
 	} {
 		rendered, err := render("rancherd-"+templateName, config)
 		if err != nil {

--- a/pkg/config/templates/rancherd-10-harvester.yaml
+++ b/pkg/config/templates/rancherd-10-harvester.yaml
@@ -72,8 +72,6 @@ bootstrapResources:
           pullPolicy: "IfNotPresent"
         labelFilter:
           - "COS_*"
-        autoProvisionFilter:
-          - "/dev/installer/default"
       rancherEmbedded: true
       webhook:
         image:

--- a/pkg/config/templates/rancherd-20-harvester-settings.yaml
+++ b/pkg/config/templates/rancherd-20-harvester-settings.yaml
@@ -1,0 +1,9 @@
+bootstrapResources: {{ if not .SystemSettings -}} [] {{- else }}
+{{- range $name, $value := .SystemSettings }}
+- apiVersion: harvesterhci.io/v1beta1
+  kind: Setting
+  metadata:
+    name: {{ printf "%q" $name }}
+  value: {{ printf "%q" $value }}
+{{- end }}
+{{- end -}}


### PR DESCRIPTION
Now we have `ManagedChart`, we could easily deploy these Setting CR not worrying RKE2 manifests reboot overwriting issue.

## TODOs
- [x] Revert "preconfig-loader" commit: https://github.com/harvester/harvester/pull/1563