### PR TITLE
Use VIP in RKE2 Server URL for agent nodes

### DIFF
--- a/package/harvester-os/files/etc/systemd/system/rke2-agent.service.d/override.conf
+++ b/package/harvester-os/files/etc/systemd/system/rke2-agent.service.d/override.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecStartPre=/usr/sbin/harv-update-rke2-server-url agent

--- a/package/harvester-os/files/etc/systemd/system/rke2-server.service.d/override.conf
+++ b/package/harvester-os/files/etc/systemd/system/rke2-server.service.d/override.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecStartPre=/usr/sbin/harv-update-rke2-server-url server

--- a/package/harvester-os/files/usr/sbin/harv-update-rke2-server-url
+++ b/package/harvester-os/files/usr/sbin/harv-update-rke2-server-url
@@ -1,0 +1,34 @@
+#!/bin/bash -ex
+
+HARVESTER_CONFIG_FILE=/oem/harvester.config
+RKE2_VIP_CONFIG_FILE=/etc/rancher/rke2/config.yaml.d/90-harvester-vip.yaml
+
+
+update_agent_conf()
+{
+  export SERVER_URL="$(yq -e e .serverurl /oem/harvester.config | sed -E 's,^https://(.*):8443,https://\1:9345,')"
+
+  if [ -z "$SERVER_URL" ]; then
+    echo "[Error] fail to get server URL with VIP."
+    exit 1
+  fi
+
+  if [ -e $RKE2_VIP_CONFIG_FILE ]; then
+    yq -e e '.server = strenv(SERVER_URL)' $RKE2_VIP_CONFIG_FILE -i
+  else
+    yq -n e '.server = strenv(SERVER_URL)' > $RKE2_VIP_CONFIG_FILE
+  fi
+}
+
+case $1 in
+  server)
+    rm -f $RKE2_VIP_CONFIG_FILE
+    ;;
+  agent)
+    update_agent_conf
+    ;;
+  *)
+    echo "[Error] role must in server or agent."
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
An agent node should use VIP to reach HA server nodes because
a server node might fail.

**Related issue**
https://github.com/harvester/harvester/issues/1521