### PR TITLE
Allow OWASP password special characters as token 

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -190,3 +190,41 @@ func TestHarvesterSystemSettingsRendering_AsEmptyArrayIfNoSetting(t *testing.T) 
 	assert.NotNil(t, bootstrapResources)
 	assert.Equal(t, 0, len(bootstrapResources))
 }
+
+func TestHarvesterTokenRendering(t *testing.T) {
+	// Test the Token value is escaped correctly
+	testCases := []struct {
+		name  string
+		token string
+	}{
+		{
+			name:  "Test OWASP password special characters",
+			token: " !\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~",
+		},
+		{
+			name:  "Test mixed characters",
+			token: "Hello, I opened a new bar! It's called \"FOOBAR\". \\YES/",
+		},
+	}
+
+	for _, testCase := range testCases {
+		// Renders the config into YAML manifest, then decode the YAML manifest and verify the content
+		conf := HarvesterConfig{
+			Token: testCase.token,
+			// RuntimeVersion: "DoesNotMatter",
+		}
+		content, err := render("rancherd-config.yaml", conf)
+		assert.Nil(t, err)
+		t.Log("Rendered content:")
+		t.Log(content)
+
+		loadedConf := map[string]interface{}{}
+		t.Log("Loaded Config:")
+		t.Log(loadedConf)
+
+		err = yaml.Unmarshal([]byte(content), &loadedConf)
+		assert.Nil(t, err)
+
+		assert.Equal(t, loadedConf["token"].(string), testCase.token)
+	}
+}

--- a/pkg/config/templates/rancherd-config.yaml
+++ b/pkg/config/templates/rancherd-config.yaml
@@ -4,7 +4,7 @@ role: agent
 {{- else -}}
 role: cluster-init
 {{- end }}
-token: '{{ .Token }}'
+token: {{ printf "%q" .Token }}
 kubernetesVersion: {{ .RuntimeVersion }}
 labels:
  - harvesterhci.io/managed=true

--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -664,6 +664,9 @@ func addTokenPanel(c *Console) error {
 			if token == "" {
 				return c.setContentByName(validatorPanel, "Cluster token is required")
 			}
+			if err := checkToken(token); err != nil {
+				return c.setContentByName(validatorPanel, err.Error())
+			}
 			c.config.Token = token
 			closeThisPage()
 			return showNext(c, passwordConfirmPanel, passwordPanel)

--- a/pkg/console/validator_test.go
+++ b/pkg/console/validator_test.go
@@ -162,3 +162,38 @@ func TestValidateConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckToken(t *testing.T) {
+	testCases := []struct {
+		name       string
+		tokenValue string
+		expectErr  bool
+	}{
+		{
+			name:       "Some regular string",
+			tokenValue: "AlphanumericValue12345",
+			expectErr:  false,
+		},
+		{
+			name:       "Some special characters",
+			tokenValue: "Hello, @Harvester, you're \"awesome\"! [md](url)",
+			expectErr:  false,
+		},
+		{
+			name:       "Non-ASCII characters are invalid",
+			tokenValue: "Äöé",
+			expectErr:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkToken(tc.tokenValue)
+			if tc.expectErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Properly escape the token value to allow using OWASP password special characters as cluster token value.

See https://owasp.org/www-community/password-special-characters

## Test plan
### Positive test case
1. Use ISO to install Harvester in "create" mode
2. Enter any combination of alphanumeric and [OWASP password special characters](https://owasp.org/www-community/password-special-characters) as Cluster Token
3. Use ISO to install Harvester in "join" mode
4. Enter the same cluster token.
5. Make sure it can join a cluster using the same token value.

### Negative test case
**NOTE:** It's not that easy to enter non-ASCII characters using installer GUI, so here I recommend using iPXE to perform the negative test case.

1. Use iPXE to install Harvester: Change the token value of config file to something invalid, such as `Äöê`
2. Verify that the installation process failed with an error message showing the token value is invalid.

## TODOs
- [ ] Add a troubleshooting guide for "Entered incorrect cluster token during the installation process.": https://github.com/harvester/docs/pull/81