### PR TITLE
Prompt users to use VIP to join a cluster

### DIFF
--- a/pkg/console/constant.go
+++ b/pkg/console/constant.go
@@ -57,7 +57,7 @@ const (
 
 	clusterTokenCreateNote = "Note: The token is used for adding nodes to the cluster"
 	clusterTokenJoinNote   = "Note: Input the token of the existing cluster"
-	serverURLNote          = "Note: Input IP/domain name of the management node"
+	serverURLNote          = "Note: Input VIP/domain name of the management node"
 	proxyNote              = "Note: In the form of \"http://[[user][:pass]@]host[:port]/\"."
 	sshKeyNote             = "For example: https://github.com/<username>.keys"
 	ntpServersNote         = "Note: You can use comma to add more NTP servers."


### PR DESCRIPTION
Users should use VIP to join a cluster because a server node might fail.

**Related issue**
https://github.com/harvester/harvester/issues/1521