### PR TITLE
Get VIP through DHCP for PXE boot

### DIFF
--- a/pkg/console/util.go
+++ b/pkg/console/util.go
@@ -645,3 +645,7 @@ func createVerticalLocator(c *Console) func(p *widgets.Panel, height int) {
 		p.SetLocation(x0, y0, x1, y1)
 	}
 }
+
+func needToGetVIPFromDHCP(mode, vip, hwAddr string) bool {
+	return strings.ToLower(mode) == config.NetworkMethodDHCP && (vip == "" || hwAddr == "")
+}


### PR DESCRIPTION
Issue https://github.com/harvester/harvester/issues/1410

### Test Case

* Comment `vip` and `vip_hw_addr` in `ipxe-examples/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-create.yaml.j2`
* Start vagrant-pxe-harvester
* Run `kubectl get cm -n harvester-system vip`
  * Check whether we can get `ip` and `hwAddress` in it
* Run `ip a show harvester-mgmt`
  * Check whether there is two IP in it and one is vip.