### PR TITLE
Add upgrade repository feature

### DIFF
--- a/package/harvester-os/files/usr/sbin/harv-install
+++ b/package/harvester-os/files/usr/sbin/harv-install
@@ -116,7 +116,12 @@ preload_rke2_images()
       trap "rm -rf $inst_tmp" exit
 
       # extract rke2 tarball from image
-      rke2_image=$(grep 'docker.io/rancher/system-agent-installer-rke2:' /var/lib/rancher/agent/images/rancherd-bootstrap-images.txt)
+      image_list=$(ls /var/lib/rancher/agent/images/rancherd-bootstrap-images-*.txt | head -n 1)
+      if [ -z "$image_list" ]; then
+        echo "[ERROR] Fail to get rancherd bootstrap images list."
+        exit 1
+      fi
+      rke2_image=$(grep 'docker.io/rancher/system-agent-installer-rke2:' $image_list)
       wharfie --images-dir /var/lib/rancher/agent/images/ $rke2_image $inst_tmp
 
       # extract rke2 binary

--- a/scripts/build-bundle
+++ b/scripts/build-bundle
@@ -9,6 +9,8 @@ PACKAGE_HARVESTER_REPO_DIR="${TOP_DIR}/package/harvester-repo"
 cd ${TOP_DIR}
 
 source ${SCRIPTS_DIR}/version
+source ${SCRIPTS_DIR}/version-rke2
+source ${SCRIPTS_DIR}/version-rancher
 source ${SCRIPTS_DIR}/lib/http
 source ${SCRIPTS_DIR}/lib/image
 
@@ -31,12 +33,6 @@ fi
 harvester_chart_path=${harvester_path}/deploy/charts/harvester
 helm package ${harvester_chart_path} -d ${CHARTS_DIR}
 
-if [ -n "$HARVESTER_INSTALLER_OFFLINE_BUILD" -a -e /bundle ]; then
- cp -rf /bundle/* ${BUNDLE_DIR}/
- exit 0
-fi
-
-
 # Prepare monitoring chart
 source ${SCRIPTS_DIR}/version-monitoring
 helm pull https://charts.rancher.io/assets/rancher-monitoring/rancher-monitoring-crd-${MONITORING_VERSION}.tgz -d ${CHARTS_DIR}
@@ -49,44 +45,46 @@ tar zxvf ${CHARTS_DIR}/rancher-monitoring-${MONITORING_VERSION}.tgz >/dev/null
 # Create Helm repo index after charts are ready
 helm repo index ${CHARTS_DIR}
 
+if [ -n "$HARVESTER_INSTALLER_OFFLINE_BUILD" -a -e /bundle ]; then
+ cp -rf /bundle/* ${BUNDLE_DIR}/
+ exit 0
+fi
+
 # Offline images
 
-source ${SCRIPTS_DIR}/version-rke2
-
 # Rancherd bootstrap images
-# FIXME(kiefer): most images are still under devlopment
-cp ${SCRIPTS_DIR}/images/rancherd-bootstrap-images.txt ${RANCHERD_IMAGES_DIR}
-RKE2_IMAGE_TAG=${RKE2_VERSION/+/-} # v1.21.3-rc6+rke2r2 -> v1.21.3-rc6-rke2r2
-sed -i "s,\$RKE2_VERSION,${RKE2_IMAGE_TAG}," ${RANCHERD_IMAGES_DIR}/rancherd-bootstrap-images.txt
-save_image ${RANCHERD_IMAGES_DIR}/rancherd-bootstrap-images.txt ${RANCHERD_IMAGES_DIR}
+image_list_file=${RANCHERD_IMAGES_DIR}/rancherd-bootstrap-images-${VERSION}.txt
+cp ${SCRIPTS_DIR}/images/rancherd-bootstrap-images.txt $image_list_file
+RKE2_VERSION_NORMALIZED=${RKE2_VERSION/+/-} # v1.21.3-rc6+rke2r2 -> v1.21.3-rc6-rke2r2
+sed -i "s,\$RKE2_VERSION,${RKE2_VERSION_NORMALIZED}," ${image_list_file}
+save_image "agent" $BUNDLE_DIR ${image_list_file} ${RANCHERD_IMAGES_DIR}
 
-# Images needed during rancherd cluster-init stage.
-cp ${SCRIPTS_DIR}/images/rancher-images.txt ${IMAGES_DIR}
-save_image ${IMAGES_DIR}/rancher-images.txt ${IMAGES_DIR}
+# Rancher images
+image_list_file=${IMAGES_DIR}/rancher-images-${RANCHER_VERSION}.txt
+cp ${SCRIPTS_DIR}/images/rancher-images.txt $image_list_file
+save_image "common" $BUNDLE_DIR $image_list_file ${IMAGES_DIR}
 
 # RKE2 images
 RKE2_IMAGES_URL="https://github.com/rancher/rke2/releases/download/${RKE2_VERSION}"
-if [ -f "${SCRIPTS_DIR}/images/rke2-images.linux-amd64.txt" ] && [ -f "${SCRIPTS_DIR}/images/rke2-images.linux-amd64.tar.zst" ]; then
-  mv "${SCRIPTS_DIR}/images/rke2-images.linux-amd64.txt" "${IMAGES_DIR}/rke2-images.linux-amd64.txt"
-  mv "${SCRIPTS_DIR}/images/rke2-images.linux-amd64.tar.zst" "${IMAGES_DIR}/rke2-images.linux-amd64.tar.zst"
-else
-  get_url "${RKE2_IMAGES_URL}/rke2-images.linux-amd64.txt" "${IMAGES_DIR}/rke2-images.linux-amd64.txt"
-  get_url "${RKE2_IMAGES_URL}/rke2-images.linux-amd64.tar.zst" "${IMAGES_DIR}/rke2-images.linux-amd64.tar.zst"
-fi
+image_list_file="${IMAGES_DIR}/rke2-images.linux-amd64-${RKE2_VERSION_NORMALIZED}.txt"
+image_archive="${IMAGES_DIR}/rke2-images.linux-amd64-${RKE2_VERSION_NORMALIZED}.tar.zst"
+get_url "${RKE2_IMAGES_URL}/rke2-images.linux-amd64.txt" $image_list_file
+get_url "${RKE2_IMAGES_URL}/rke2-images.linux-amd64.tar.zst" $image_archive
+add_image_list_to_metadata "rke2" $BUNDLE_DIR $image_list_file $image_archive
 
 # exclude SR-IOV images
+image_list_file="${IMAGES_DIR}/rke2-images-multus.linux-amd64-${RKE2_VERSION_NORMALIZED}.txt"
 # save_image_list "rke2-images-multus" "${RKE2_IMAGES_URL}/rke2-images-multus.linux-amd64.txt" ${IMAGES_DIR}/rke2-images-multus.linux-amd64.txt
-
 # Workaround for https://github.com/rancher/rke2/issues/2229
-cat > ${IMAGES_DIR}/rke2-images-multus.linux-amd64.txt <<EOF
+cat > $image_list_file <<EOF
 docker.io/rancher/hardened-cni-plugins:v0.9.1-build20211119
 docker.io/rancher/hardened-multus-cni:v3.7.1-build20211119
 EOF
 
-save_image ${IMAGES_DIR}/rke2-images-multus.linux-amd64.txt ${IMAGES_DIR}
+save_image "rke2" $BUNDLE_DIR $image_list_file ${IMAGES_DIR}
 
 # Harvester images: get image list from harvester chart's values file
-image_list_file='harvester-images.txt'
+image_list_file="harvester-images-${VERSION}.txt"
 values_file="${harvester_chart_path}/values.yaml"
 touch ${image_list_file}
 repositories=( $(yq eval ' explode(.) | .. | select(has("repository")) |select(has("tag")) | .repository' ${values_file}) )
@@ -122,4 +120,4 @@ sort -u "${image_list_file}.tmp" | \
 grep -Ev "local-path-provisioner|library-traefik|klipper-lb|multus" >"${image_list_file}"
 
 cp ${image_list_file} ${IMAGES_DIR}
-save_image ${IMAGES_DIR}/${image_list_file} ${IMAGES_DIR}
+save_image "common" $BUNDLE_DIR ${IMAGES_DIR}/${image_list_file} ${IMAGES_DIR}

--- a/scripts/lib/image
+++ b/scripts/lib/image
@@ -45,12 +45,54 @@ save_image_list()
 
 save_image()
 {
-  local image_list=$1
-  local save_dir=$2
+  local image_type=$1
+  local bundle_dir=$2
+  local image_list=$3
+  local save_dir=$4
 
   local archive_name="$(basename ${image_list%.txt}).tar"
   local archive_file="${save_dir}/${archive_name}"
   xargs -n1 -t docker image pull --quiet < $image_list
   docker image save -o $archive_file $(<${image_list})
   zstd --rm $archive_file
+
+  add_image_list_to_metadata $image_type $bundle_dir $image_list "${archive_file}.zst"
+}
+
+# Add image list to bundle metadata
+add_image_list_to_metadata() {
+  local image_type=$1
+  local bundle_dir=$2
+  local image_list=$3
+  local image_archive=$4
+
+  local metadata="$bundle_dir/metadata.yaml"
+  local rel_image_list
+  local rel_image_archive
+
+  rel_image_list="${image_list#"$bundle_dir"}"
+
+  if [ "$rel_image_list" = "$image_list" ]; then
+    echo "Image list file $image_list is not in $bundle_dir"
+    exit 1
+  fi
+
+  rel_image_archive="${image_archive#"$bundle_dir"}"
+  if [ "$rel_image_archive" = "$image_archive" ]; then
+    echo "Image archive $image_archive is not in $bundle_dir"
+    exit 1
+  fi
+
+  if [ ! -e  $metadata ]; then
+    cat > $metadata <<'EOF'
+images:
+  common: []
+  rke2: []
+  agent: []
+EOF
+  fi
+
+  IMAGE_LIST="$rel_image_list" \
+    IMAGE_ARCHIVE="$rel_image_archive" \
+    yq -e --prettyPrint e ".images.$image_type += [{\"list\": strenv(IMAGE_LIST), \"archive\": strenv(IMAGE_ARCHIVE)}]" $metadata -i
 }

--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -68,6 +68,5 @@ xorriso -osirrox on -indev ${ARTIFACTS_DIR}/${ISO_PREFIX}.iso -extract /rootfs.s
 
 # Write checksum
 cd ${ARTIFACTS_DIR}
-CHECKSUM_FILE=${ISO_PREFIX}.sha256
-sha256sum ${PROJECT_PREFIX}* > $CHECKSUM_FILE
-
+CHECKSUM_FILE=${ISO_PREFIX}.sha512
+sha512sum ${PROJECT_PREFIX}* > $CHECKSUM_FILE

--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -4,6 +4,7 @@ TOP_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
 ARTIFACTS_DIR="${TOP_DIR}/dist/artifacts"
 SCRIPTS_DIR="${TOP_DIR}/scripts"
 PACKAGE_HARVESTER_OS_DIR="${TOP_DIR}/package/harvester-os"
+BUNDLE_DIR="${PACKAGE_HARVESTER_OS_DIR}/iso/bundle"
 
 mkdir -p ${ARTIFACTS_DIR}
 
@@ -50,6 +51,9 @@ docker cp $(<os-img-container):/boot/${KERNEL} ${ARTIFACTS_DIR}/${PROJECT_PREFIX
 docker cp $(<os-img-container):/boot/${INITRD} ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-initrd-${ARCH}
 chmod +r ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-initrd-${ARCH}
 docker rm $(<os-img-container) && rm -f os-img-container
+
+# Make sure files under bundle dir can be read by nginx
+find $BUNDLE_DIR -type f -exec chmod +r {} +
 
 # build ISO
 ISO_PREFIX="${PROJECT_PREFIX}-${ARCH}"

--- a/scripts/package-harvester-repo
+++ b/scripts/package-harvester-repo
@@ -8,19 +8,24 @@ BUNDLE_DIR="${PACKAGE_HARVESTER_OS_DIR}/iso/bundle"
 IMAGES_DIR="${BUNDLE_DIR}/harvester/images"
 
 mkdir -p ${IMAGES_DIR}
-
 source ${SCRIPTS_DIR}/version
+source ${SCRIPTS_DIR}/lib/image
+
 cd ${PACKAGE_HARVESTER_REPO_DIR}
 
 CLUSTER_REPO_IMAGE=rancher/harvester-cluster-repo:${VERSION}
 docker build -t ${CLUSTER_REPO_IMAGE} .
 
+repo_image_list_file="${IMAGES_DIR}/harvester-repo-images-${VERSION}.txt"
+repo_image_archive="${IMAGES_DIR}/harvester-repo-images-${VERSION}.tar"
+
 # Save the image
-cat << EOF > ${IMAGES_DIR}/harvester-repo-images.txt
+cat << EOF > $repo_image_list_file
 docker.io/${CLUSTER_REPO_IMAGE}
 EOF
-docker image save -o ${IMAGES_DIR}/harvester-repo-images.tar $(<${IMAGES_DIR}/harvester-repo-images.txt)
-zstd --rm ${IMAGES_DIR}/harvester-repo-images.tar -o ${IMAGES_DIR}/harvester-repo-images.tar.zst
+docker image save -o $repo_image_archive $(<$repo_image_list_file)
+zstd --rm $repo_image_archive -o "${repo_image_archive}.zst"
+add_image_list_to_metadata "common" $BUNDLE_DIR $repo_image_list_file "${repo_image_archive}.zst"
 
 # Update image name in Rancherd bootstrap resources
 sed "s,\$CLUSTER_REPO_IMAGE,${CLUSTER_REPO_IMAGE}," \


### PR DESCRIPTION
The PR contains two features:
## Add versions to image archives and record archives in metadata 

- Appending versions to archives file names, this makes image clean-up possible.
- Record image archives with a metadata file. When preloading a node, it's easier
  to get what's included in an ISO. e.g.:
    ```
    $ cat /srv/www/htdocs/harvester/iso/bundle/metadata.yaml
    images:
      common:
        - list: /harvester/images/rancher-images-v2.6-638b29a687f3818e7de676a573ec9b9156f193a9-head.txt
          archive: /harvester/images/rancher-images-v2.6-638b29a687f3818e7de676a573ec9b9156f193a9-head.tar.zst
        - list: /harvester/images/harvester-images-b62f9f8-dirty.txt
          archive: /harvester/images/harvester-images-b62f9f8-dirty.tar.zst
        - list: /harvester/images/harvester-repo-images-b62f9f8-dirty.txt
          archive: /harvester/images/harvester-repo-images-b62f9f8-dirty.tar.zst
      rke2:
        - list: /harvester/images/rke2-images.linux-amd64-v1.21.5-rke2r1.txt
          archive: /harvester/images/rke2-images.linux-amd64-v1.21.5-rke2r1.tar.zst
        - list: /harvester/images/rke2-images-multus.linux-amd64-v1.21.5-rke2r1.txt
          archive: /harvester/images/rke2-images-multus.linux-amd64-v1.21.5-rke2r1.tar.zst
      agent:
        - list: /rancherd/images/rancherd-bootstrap-images-b62f9f8-dirty.txt
          archive: /rancherd/images/rancherd-bootstrap-images-b62f9f8-dirty.tar.zst

## Allow serving ISO content with the live OS 

Setup an Nginx server to server ISO content if:
- `harvester.serve_iso=true` kernel parameter is provided, or
- `/harvester-serve-iso` file exists.

During Harvester upgrade, we'll provision a VM with userdata to create
`/harvester-server-iso` file.


**Related issue**
https://github.com/harvester/harvester/issues/1022

**Depends on**
https://github.com/harvester/os2/pull/27