### PR TITLE
Increase OEM partition waiting timeout to 120s

### DIFF
--- a/package/harvester-os/files/etc/cos/bootargs.cfg
+++ b/package/harvester-os/files/etc/cos/bootargs.cfg
@@ -2,9 +2,9 @@ set console_params="console=tty1"
 set kernel=/boot/vmlinuz
 set crash_kernel_params="crashkernel=219M,high crashkernel=72M,low"
 if [ -n "$recoverylabel" ]; then
-    set kernelcmd="$console_params root=live:LABEL=$recoverylabel rd.live.dir=/ rd.live.squashimg=$img panic=0 net.ifnames=1"
+    set kernelcmd="$console_params root=live:LABEL=$recoverylabel rd.live.dir=/ rd.live.squashimg=$img panic=0 net.ifnames=1 rd.cos.oemtimeout=120"
 else
-    set kernelcmd="$console_params root=LABEL=$label cos-img/filename=$img panic=0 net.ifnames=1"
+    set kernelcmd="$console_params root=LABEL=$label cos-img/filename=$img panic=0 net.ifnames=1 rd.cos.oemtimeout=120"
 fi
 
 set initramfs=/boot/initrd


### PR DESCRIPTION
Increase the timeout value because it takes longer for a device to appear
on some systems.

**Related issue**
https://github.com/harvester/harvester/issues/1667