### PR TITLE
Bump harvester-os version to 20211214

### DIFF
--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -14,7 +14,7 @@ source ${SCRIPTS_DIR}/version-rancher
 source ${SCRIPTS_DIR}/version-harvester ${TOP_DIR}/../harvester
 source ${SCRIPTS_DIR}/version-monitoring
 
-BASE_OS_IMAGE="rancher/harvester-os:20211213"
+BASE_OS_IMAGE="rancher/harvester-os:20211214"
 HARVESTER_OS_IMAGE=rancher/harvester-os:$VERSION
 
 cd ${PACKAGE_HARVESTER_OS_DIR}


### PR DESCRIPTION
The OS update contains the files to bring up an upgrade repo VM. https://github.com/harvester/os2/pull/27