### PR TITLE
Disable systemd messages before starting the installer

### DIFF
--- a/package/harvester-os/files/usr/bin/setup-installer.sh
+++ b/package/harvester-os/files/usr/bin/setup-installer.sh
@@ -18,6 +18,15 @@ EnvironmentFile=-/etc/rancher/installer/env
 # NOTE: it doesn't work for serial console
 ExecStartPre=/usr/bin/setterm --msg off
 
+# Disable systemd messages before starting the installer
+# See https://www.freedesktop.org/software/systemd/man/systemd.html#SIGRTMIN+21
+# Send SIGRTMIN+21
+ExecStartPre=/usr/bin/kill -s 55 1
+
+# Enable systemd messager after stopping the installer
+# Send SIGRTMIN+20
+ExecStopPost=/usr/bin/kill -s 54 1
+
 # clear the original command in getty@.service
 ExecStart=
 


### PR DESCRIPTION
The systemd messages can be hidden with the kernel parameter `systemd.show_status=0`.
But I don't think it's a good idea because the booting messages prior to the Harvester dashboard/installer are quite useful.
So the idea is to turn off the messager before starting the installer and turn it on after the installer is stooped. This makes messages before shutdown or reboots visible.

References:
https://www.freedesktop.org/software/systemd/man/systemd.html#systemd.show_status
https://www.freedesktop.org/software/systemd/man/systemd.html#SIGRTMIN+21

To get current show status:
```
# busctl get-property org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager ShowStatus
b false
```

**Related Issue**
https://github.com/harvester/harvester/issues/1132