### PR TITLE
Use branch name instead of installer tag for artifacts version

### DIFF
--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -36,9 +36,9 @@ docker build --pull \
 	-t ${HARVESTER_OS_IMAGE} .
 
 PROJECT_PREFIX="harvester"
-if [ -n "$GIT_TAG" ];
+if [ -n "$VERSION" ];
 then
-  PROJECT_PREFIX+="-${GIT_TAG}"
+  PROJECT_PREFIX+="-${VERSION}"
 else
   PROJECT_PREFIX+="-master"
 fi

--- a/scripts/version
+++ b/scripts/version
@@ -6,11 +6,9 @@ if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
 fi
 
 COMMIT=$(git rev-parse --short HEAD)
-GIT_TAG=${DRONE_TAG:-$(git tag -l --contains HEAD | head -n 1)}
+VERSION=${DRONE_TAG:-$(git rev-parse --abbrev-ref HEAD)}
 
-if [[ -z "$DIRTY" && -n "$GIT_TAG" ]]; then
-    VERSION=$GIT_TAG
-else
+if [[ -n "$DIRTY" ]]; then
     VERSION="${COMMIT}${DIRTY}"
 fi
 


### PR DESCRIPTION
Problem:
Generated file name uses installer tag instead of master when the head commit is tagged.
https://drone-publish.rancher.io/harvester/harvester/500/3/3

Solution:
Use branch name for the version when DRONE_TAG is not available.