### PR TITLE
Show console dashboard on tty other than tty1

### DIFF
--- a/package/harvester-os/files/etc/tty-dashboard-override.conf
+++ b/package/harvester-os/files/etc/tty-dashboard-override.conf
@@ -1,0 +1,13 @@
+# The folder will be renamed to the getty service that needs to start TTY Dashboard
+[Service]
+EnvironmentFile=-/etc/rancher/installer/env
+
+# Do not show kernel messages on this TTY, it messes up the installer UI
+# NOTE: it doesn't work for serial console
+ExecStartPre=/usr/bin/setterm --msg off
+
+# clear the original command in getty@.service
+ExecStart=
+
+# override with the new command
+ExecStart=-/sbin/agetty -n -l /usr/bin/start-installer.sh %I $TERM

--- a/package/harvester-os/files/system/oem/91_installer.yaml
+++ b/package/harvester-os/files/system/oem/91_installer.yaml
@@ -1,10 +1,11 @@
 name: "Setup installer"
 stages:
-  boot:
-    - commands:
-      - setup-installer.sh
   initramfs:
-    - environment_file: "/etc/rancher/installer/env"
+    - name: "Set up installer"
+      commands:
+      - setup-installer.sh
+    - name: "Set up installer environment if installed finished"
+      environment_file: "/etc/rancher/installer/env"
       environment:
         HARVESTER_DASHBOARD: "true"
         KUBECONFIG: /etc/rancher/rke2/rke2.yaml

--- a/package/harvester-os/files/usr/bin/start-installer.sh
+++ b/package/harvester-os/files/usr/bin/start-installer.sh
@@ -6,6 +6,12 @@ fi
 
 export TERM=linux
 
+tty_num=${TTY#/dev/tty}
+if [[ ${tty_num} =~ ^[0-9]+$ ]]; then
+  # Switch virtual terminal
+  chvt ${tty_num}
+fi
+
 harvester-installer
 # Do not allow bash prompt if the installer doesn't exit with status 0
 bash -l


### PR DESCRIPTION
- The console for showing the dashboard will be "the next available virtual console" (`tty2`, `tty3`, ...), or `tty2` if designated system console is `tty6`

- If a serial console is chosen as system console (i.e. system console = `ttySN`, where `N` is `0`, `1`, ...), the dashboard will show on the designated serial console.

- Need to move `setup-installer.sh` to initramfs stage for enabling/disabling getty services

- Because cOS' initramfs stage runs in chroot env and /tmp is not in BindPaths, here-document can't be used. Thus we need to store that override.conf as "/etc/tty-dashboard-override.conf", then copy this file to the correct service.d directory as drop-ins.

TODOs:

- How to determine which tty to show console dashboard?

  - Provide a Harvester config such as `console_tty` for users to choose
    which tty to show the dashboard