### PR TITLE
Build version defaults to master

### DIFF
--- a/scripts/version
+++ b/scripts/version
@@ -6,7 +6,7 @@ if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
 fi
 
 COMMIT=$(git rev-parse --short HEAD)
-VERSION=${DRONE_TAG:-$(git rev-parse --abbrev-ref HEAD)}
+VERSION=${DRONE_TAG:-master}
 
 if [[ -n "$DIRTY" ]]; then
     VERSION="${COMMIT}${DIRTY}"


### PR DESCRIPTION
Fix the vagrant CI failure. See https://github.com/harvester/harvester-installer/pull/200#issuecomment-997611719