### PR TITLE
Preserve DHCP IP received during installation time

### DIFF
--- a/package/harvester-os/files/usr/sbin/harv-install
+++ b/package/harvester-os/files/usr/sbin/harv-install
@@ -255,6 +255,14 @@ save_config()
     fi
 }
 
+save_wicked_state()
+{
+    # Save wicked state so we could keep the DHCP IP
+    local wicked_state="${TARGET}/usr/local/.state/var-lib-wicked.bind"
+    mkdir -p ${wicked_state}
+    cp -r /var/lib/wicked/. ${wicked_state}
+}
+
 trap cleanup exit
 
 # For PXE Boot
@@ -273,6 +281,7 @@ COS_INSTALL_ISO_URL="" INTERACTIVE=yes COS_INSTALL_DEVICE="$install_device" cos-
 do_detect
 do_mount
 save_config
+save_wicked_state
 do_preload
 
 update_grub_settings

--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -789,6 +789,9 @@ func addNetworkPanel(c *Console) error {
 	}
 
 	preGotoNextPage := func() (string, error) {
+		if err := setHostname(c.config.Hostname); err != nil {
+			return fmt.Sprintf("Failed to set hostname '%s': %s", c.config.Hostname, err), nil
+		}
 		output, err := setupNetwork()
 		if err != nil {
 			return fmt.Sprintf("Configure network failed: %s %s", string(output), err), nil
@@ -1406,8 +1409,6 @@ func addInstallPanel(c *Console) error {
 				network.Interfaces = tmpInterfaces
 				c.config.Networks[key] = network
 			}
-
-
 
 			// We need ForceGPT because cOS only supports ForceGPT (--force-gpt) flag, not ForceMBR!
 			c.config.ForceGPT = !c.config.ForceMBR

--- a/pkg/console/network.go
+++ b/pkg/console/network.go
@@ -2,6 +2,7 @@ package console
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -132,4 +133,16 @@ func listNetworkHardware() (map[string]networkHardwareInfo, error) {
 	}
 
 	return m, nil
+}
+
+func setHostname(hostname string) error {
+	// NOTE: Can't use Golang's syscall.Sethostname
+	// because it sets the "trasient hostname", not "static hostname".
+	// wicked uses static hostname to make the DHCP request.
+	cmd := exec.Command("hostnamectl", "set-hostname", fmt.Sprintf("%q", hostname))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		logrus.Errorf("error running hostnamectl set-hostname: %s", string(out))
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
- Set hostname before configure network using `hostnamectl`

- Copy wicked runtime data (`/var/lib/wicked`) to the installed system.

## Related issues
- https://github.com/harvester/harvester/issues/1682