### PR TITLE
Stop installer if DNS is unset for static IP

### DIFF
--- a/pkg/console/constant.go
+++ b/pkg/console/constant.go
@@ -61,7 +61,7 @@ const (
 	proxyNote              = "Note: In the form of \"http://[[user][:pass]@]host[:port]/\"."
 	sshKeyNote             = "For example: https://github.com/<username>.keys"
 	ntpServersNote         = "Note: You can use comma to add more NTP servers."
-	dnsServersNote         = "Note: You can use comma to add more DNS servers."
+	dnsServersNote         = "Note: You can use comma to add more DNS servers. Leave blank to use default DNS."
 	bondNote               = "Note: Select one or more NICs for the Management NIC.\nUse the default value for the Bond Mode if only one NIC is selected."
 	forceMBRNote           = "Note: GPT is used by default. You can use MBR if you encountered compatibility issues."
 

--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -1718,7 +1718,7 @@ func addDNSServersPanel(c *Console) error {
 	dnsServersV.PreShow = func() error {
 		c.Gui.Cursor = true
 		dnsServersV.Value = userInputData.DNSServers
-		if err = c.setContentByName(titlePanel, "Optional: Configure DNS Servers"); err != nil {
+		if err = c.setContentByName(titlePanel, "Configure DNS Servers"); err != nil {
 			return err
 		}
 		return c.setContentByName(notePanel, dnsServersNote)
@@ -1770,6 +1770,10 @@ func addDNSServersPanel(c *Console) error {
 			spinner.Start()
 
 			go func(g *gocui.Gui) {
+				if mgmtNetwork.Method == config.NetworkMethodStatic && dnsServers == "" {
+					gotoSpinnerErrorPage(g, spinner, "DNS servers are required for static IP address")
+					return
+				}
 				if dnsServers != "" {
 					// check input syntax
 					dnsServerList := strings.Split(dnsServers, ",")


### PR DESCRIPTION
If DNS servers are not provided by the config file in PXE installation or from ISO Installer while the management network has static IP, the installer would stop users from proceeding with the installation.

## Test plan
### ISO Installation
1. Install Harvester using ISO
2. While configuring networking, set up a **static IP address**
3. Verify that while configuring DNS servers, if no DNS servers are provided, the installer will **show a warning message and stop users from proceeding with the installation**
4. Verify that if DNS servers are given, installation can proceed
5. Go back to the network configuration page. This time set it up with **DHCP**
6. Verify that if no DNS servers are provided, the installer would still allow users to proceed

### PXE Installation
1. Create a config file with static networking, such as:
    ```
    ...
    install:
      ...
      networks:
        harvester-mgmt:
          interfaces:
          - name: ens6  # The management interface name
          method: static
          ip: 192.168.0.20
          subnet_mask: 255.255.255.0
          gateway: 192.168.0.1
    ...
    ```
2. Start the iPXE installation
3. Verify that installer will stop and show a warning message about "DNS servers are required for static IP address"
4. Add `dns_nameservers` settings to the config file:
    ```
    ...
    os:
      ...
      dns_nameservers:
      - 192.168.0.1
      - 8.8.8.8
    ...
    ```
5. Restart the PXE installation and verify that installation would not be stopped.

## Related issues
- https://github.com/harvester/harvester/issues/1412