### PR TITLE
Bump OS version

### DIFF
--- a/package/harvester-os/files/usr/sbin/cos-installer-shutdown
+++ b/package/harvester-os/files/usr/sbin/cos-installer-shutdown
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-if [ "$COS_INSTALL_POWER_OFF" = true ] || grep -q 'cos.install.power_off=true' /proc/cmdline; then
+if [ "$_COS_INSTALL_POWER_OFF" = true ] || grep -q 'cos.install.power_off=true' /proc/cmdline; then
     poweroff -f
 else
     echo " * Rebooting system in 5 seconds (CTRL+C to cancel)"

--- a/package/harvester-os/files/usr/sbin/harv-install
+++ b/package/harvester-os/files/usr/sbin/harv-install
@@ -19,7 +19,7 @@ cleanup2()
     sync
     umount_target || true
     umount ${STATEDIR}
-    [ -n "COS_INSTALL_ISO_URL" ] && umount ${ISOMNT} || true
+    [ -n "_COS_INSTALL_ISO_URL" ] && umount ${ISOMNT} || true
 }
 
 cleanup()
@@ -53,10 +53,10 @@ get_url()
 
 get_iso()
 {
-    if [ -n "$COS_INSTALL_ISO_URL" ]; then
+    if [ -n "$_COS_INSTALL_ISO_URL" ]; then
         ISOMNT=$(mktemp -d -p /tmp cos.XXXXXXXX.isomnt)
         TEMP_FILE=$(mktemp -p /tmp cos.XXXXXXXX.iso)
-        get_url ${COS_INSTALL_ISO_URL} ${TEMP_FILE}
+        get_url ${_COS_INSTALL_ISO_URL} ${TEMP_FILE}
         ISO_DEVICE=$(losetup --show -f $TEMP_FILE)
         mount -o ro ${ISO_DEVICE} ${ISOMNT}
     fi
@@ -229,10 +229,10 @@ EOF
 
 update_grub_settings()
 {
-    if [ -z "${COS_INSTALL_TTY}" ]; then
+    if [ -z "${_COS_INSTALL_TTY}" ]; then
         TTY=$(tty | sed 's!/dev/!!')
     else
-        TTY=$COS_INSTALL_TTY
+        TTY=$_COS_INSTALL_TTY
     fi
 
     if [ -e "/dev/${TTY%,*}" ] && [ "$TTY" != tty1 ] && [ "$TTY" != console ] && [ -n "$TTY" ]; then
@@ -269,13 +269,13 @@ trap cleanup exit
 get_iso
 
 # Follow the symbolic link to the real device
-install_device="$COS_INSTALL_DEVICE"
-if [ -L "$COS_INSTALL_DEVICE" ]; then
-  install_device=$(readlink -f "$COS_INSTALL_DEVICE")
+install_device="$_COS_INSTALL_DEVICE"
+if [ -L "$_COS_INSTALL_DEVICE" ]; then
+  install_device=$(readlink -f "$_COS_INSTALL_DEVICE")
 fi
 
 # Run cOS installer but do not let it fetch ISO and shutdown
-COS_INSTALL_ISO_URL="" INTERACTIVE=yes COS_INSTALL_DEVICE="$install_device" cos-installer
+_COS_BOOTING_FROM_LIVE="true" _COS_INSTALL_ISO_URL="" INTERACTIVE=yes _COS_INSTALL_DEVICE="$install_device" cos install
 
 # Preload images
 do_detect

--- a/pkg/config/cos.go
+++ b/pkg/config/cos.go
@@ -496,7 +496,7 @@ func getAddStaticDNSServersCmd(servers []string) string {
 }
 
 func (c *HarvesterConfig) ToCosInstallEnv() ([]string, error) {
-	return ToEnv("COS_INSTALL_", c.Install)
+	return ToEnv("_COS_INSTALL_", c.Install)
 }
 
 // Returns Rancherd bootstrap resources

--- a/pkg/console/util.go
+++ b/pkg/console/util.go
@@ -403,7 +403,7 @@ func doInstall(g *gocui.Gui, hvstConfig *config.HarvesterConfig, cosConfig *yipS
 			return err
 		}
 		defer os.Remove(cosPartLayout)
-		env = append(env, fmt.Sprintf("COS_PARTITION_LAYOUT=%s", cosPartLayout))
+		env = append(env, fmt.Sprintf("_COS_PARTITION_LAYOUT=%s", cosPartLayout))
 	}
 
 	if err := execute(ctx, g, env, "/usr/sbin/harv-install"); err != nil {

--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -14,7 +14,7 @@ source ${SCRIPTS_DIR}/version-rancher
 source ${SCRIPTS_DIR}/version-harvester ${TOP_DIR}/../harvester
 source ${SCRIPTS_DIR}/version-monitoring
 
-BASE_OS_IMAGE="rancher/harvester-os:20211215"
+BASE_OS_IMAGE="rancher/harvester-os:20220110"
 HARVESTER_OS_IMAGE=rancher/harvester-os:$VERSION
 
 cd ${PACKAGE_HARVESTER_OS_DIR}


### PR DESCRIPTION
- Bump OS to `20220110`.
- Catch up upstream changes:
  - Environment variable prefix changes: `COS_` to `_COS_`.
  - Use `_COS_BOOTING_FROM_LIVE="true"` to prevent `cos` script from
    downloading OS image from channels.

