### PR TITLE
Specify OEM label in kernel parameter

### DIFF
--- a/package/harvester-os/files/etc/cos/bootargs.cfg
+++ b/package/harvester-os/files/etc/cos/bootargs.cfg
@@ -4,7 +4,7 @@ set crash_kernel_params="crashkernel=219M,high crashkernel=72M,low"
 if [ -n "$recoverylabel" ]; then
     set kernelcmd="$console_params root=live:LABEL=$recoverylabel rd.live.dir=/ rd.live.squashimg=$img panic=0 net.ifnames=1 rd.cos.oemtimeout=120"
 else
-    set kernelcmd="$console_params root=LABEL=$label cos-img/filename=$img panic=0 net.ifnames=1 rd.cos.oemtimeout=120"
+    set kernelcmd="$console_params root=LABEL=$label cos-img/filename=$img panic=0 net.ifnames=1 rd.cos.oemtimeout=120 rd.cos.oemlabel=COS_OEM"
 fi
 
 set initramfs=/boot/initrd


### PR DESCRIPTION
The label needs to be explicitly specified after this change in cOS:
https://github.com/rancher-sandbox/cOS-toolkit/pull/894

This fixes the problem that partition with `HARV_LH_DEFAULT` label is not mounted to `/var/lib/longhorn`.