### PR TITLE
VIP interface isn't needed after kube-vip v0.4.1

### DIFF
--- a/pkg/config/templates/rancherd-10-harvester.yaml
+++ b/pkg/config/templates/rancherd-10-harvester.yaml
@@ -123,16 +123,6 @@ bootstrapResources:
         enabled: true
       kube-vip:
         enabled: true
-        {{- if .Vip }}
-        config:
-          {{- $vipInterface := "harvester-mgmt" }}
-          {{- $mgmtNetwork := (index .Networks "harvester-mgmt") }}
-          {{- if ne $mgmtNetwork.VlanID 0 }}
-            {{- $vlanStr := print "vlan" $mgmtNetwork.VlanID }}
-            {{- $vipInterface = (print $vlanStr "@harvester-mgmt") }}
-          {{- end }}
-          vip_interface: {{ $vipInterface }}
-        {{- end }}
       kube-vip-cloud-provider:
         enabled: true
 - apiVersion: management.cattle.io/v3


### PR DESCRIPTION
After kube-vip v0.4.1, since the kube-vip can use the VIP based on the default route automatically, the VIP interface parameter is not required anymore.

Related issue: 
https://github.com/harvester/harvester/issues/1681

Dependency: https://github.com/harvester/harvester/pull/1805