### PR TITLE
Download ISO to OS system disk

### DIFF
--- a/package/harvester-os/files/usr/sbin/harv-install
+++ b/package/harvester-os/files/usr/sbin/harv-install
@@ -18,19 +18,36 @@ umount_target() {
 cleanup2()
 {
     sync
+    [ -n "$_COS_INSTALL_ISO_URL" ] && umount "$ISOMNT" || true
+    [ -n "$ISOTEMP" ] && rm -f "$ISOTEMP"
     umount_target || true
     umount ${STATEDIR}
-    [ -n "_COS_INSTALL_ISO_URL" ] && umount ${ISOMNT} || true
 }
 
 cleanup()
 {
     EXIT=$?
-    if [ -n "$ISOTEMP" ]; then
-        rm -f "$ISOTEMP"
-    fi
     cleanup2 2>/dev/null || true
     return $EXIT
+}
+
+check_url()
+{
+    local url=$1
+    case $url in
+        tftp*)
+            # There's no way verify whether the URL exists on TFTP server without
+            # actually download the file. Always pass the check.
+            echo "WARNING: Unable check TFTP URL. Assumed file exists"
+            ;;
+        ftp*|http*)
+            # Don't show anything if file exists, but show error messasge when it's not
+            curl -I -fL --progress-bar ${url} > /dev/null
+            ;;
+        *)
+            test -f $url
+            ;;
+    esac
 }
 
 get_url()
@@ -55,9 +72,17 @@ get_url()
     esac
 }
 
+check_iso(){
+    if [ -n "$_COS_INSTALL_ISO_URL" ]; then
+        echo "Checking ISO URL.."
+        check_url "$_COS_INSTALL_ISO_URL"
+    fi
+}
+
 get_iso()
 {
     if [ -n "$_COS_INSTALL_ISO_URL" ]; then
+        echo "Downloading ISO.."
         ISOMNT=$(mktemp -d -p /tmp cos.XXXXXXXX.isomnt)
         ISOTEMP=$(mktemp -p ${TARGET}/usr/local cos.XXXXXXXX.iso)
         get_url ${_COS_INSTALL_ISO_URL} ${ISOTEMP}
@@ -268,6 +293,8 @@ save_wicked_state()
 }
 
 trap cleanup exit
+
+check_iso
 
 # Follow the symbolic link to the real device
 install_device="$_COS_INSTALL_DEVICE"

--- a/package/harvester-os/files/usr/sbin/harv-install
+++ b/package/harvester-os/files/usr/sbin/harv-install
@@ -1,5 +1,6 @@
 #!/bin/bash -e
 
+ISOTEMP=""
 ISOMNT=/run/initramfs/live
 TARGET=/run/cos/target
 
@@ -25,6 +26,9 @@ cleanup2()
 cleanup()
 {
     EXIT=$?
+    if [ -n "$ISOTEMP" ]; then
+        rm -f "$ISOTEMP"
+    fi
     cleanup2 2>/dev/null || true
     return $EXIT
 }
@@ -55,9 +59,9 @@ get_iso()
 {
     if [ -n "$_COS_INSTALL_ISO_URL" ]; then
         ISOMNT=$(mktemp -d -p /tmp cos.XXXXXXXX.isomnt)
-        TEMP_FILE=$(mktemp -p /tmp cos.XXXXXXXX.iso)
-        get_url ${_COS_INSTALL_ISO_URL} ${TEMP_FILE}
-        ISO_DEVICE=$(losetup --show -f $TEMP_FILE)
+        ISOTEMP=$(mktemp -p ${TARGET}/usr/local cos.XXXXXXXX.iso)
+        get_url ${_COS_INSTALL_ISO_URL} ${ISOTEMP}
+        ISO_DEVICE=$(losetup --show -f $ISOTEMP)
         mount -o ro ${ISO_DEVICE} ${ISOMNT}
     fi
 }
@@ -265,9 +269,6 @@ save_wicked_state()
 
 trap cleanup exit
 
-# For PXE Boot
-get_iso
-
 # Follow the symbolic link to the real device
 install_device="$_COS_INSTALL_DEVICE"
 if [ -L "$_COS_INSTALL_DEVICE" ]; then
@@ -280,6 +281,7 @@ _COS_BOOTING_FROM_LIVE="true" _COS_INSTALL_ISO_URL="" INTERACTIVE=yes _COS_INSTA
 # Preload images
 do_detect
 do_mount
+get_iso  # For PXE Boot
 save_config
 save_wicked_state
 do_preload

--- a/pkg/console/util.go
+++ b/pkg/console/util.go
@@ -408,6 +408,7 @@ func doInstall(g *gocui.Gui, hvstConfig *config.HarvesterConfig, cosConfig *yipS
 
 	if err := execute(ctx, g, env, "/usr/sbin/harv-install"); err != nil {
 		webhooks.Handle(EventInstallFailed)
+		return err
 	}
 	webhooks.Handle(EventInstallSuceeded)
 


### PR DESCRIPTION
For PXE installation, we need to download and mount the ISO in order to preload container images. However, as the ISO gets larger, we can no longer download it into the /tmp folder on machines with little RAM installed. We would have to download it somewhere else.

* Download the ISO onto the system disk, after we mounted it for the purpose of preloading images. The ISO is too large to fit into /tmp for machines with little RAM installed.

* Fix the issue of the installer won't error out if encountered errors while running `harv-install` script.

Signed-off-by: John Liu <john.liu@suse.com>