### PR TITLE
Refactor installer UI

### DIFF
--- a/pkg/widgets/dropdown.go
+++ b/pkg/widgets/dropdown.go
@@ -184,8 +184,14 @@ func (s *DropDown) GetMultiData() []string {
 func (d *DropDown) SetData(data string) error {
 	v, err := d.g.View(d.ViewName)
 	if err != nil {
-		return err
+		if err != gocui.ErrUnknownView {
+			return err
+		}
+		// View is not set ready, only update Value
+		d.Value = data
+		return nil
 	}
+
 	v.Clear()
 
 	render := func(text string) {

--- a/pkg/widgets/input.go
+++ b/pkg/widgets/input.go
@@ -4,10 +4,26 @@ import (
 	"github.com/jroimartin/gocui"
 )
 
+// Create an Editor wrapped the default Editor for updating the Value field of Input struct
+// whenever the buffer is updated.
+func createValueUpdateEditor(i *Input) gocui.EditorFunc {
+	return func(v *gocui.View, key gocui.Key, ch rune, mod gocui.Modifier) {
+		gocui.DefaultEditor.Edit(v, key, ch, mod)
+
+		if len(v.BufferLines()) == 0 {
+			i.Value = ""
+		}
+		i.Value, _ = v.Line(0)
+	}
+}
+
 type Input struct {
 	*Panel
 	Value string
 	Mask  bool
+
+	onConfirm EventCallback
+	onLeave   EventCallback
 }
 
 func NewInput(g *gocui.Gui, name string, label string, mask bool) (*Input, error) {
@@ -45,11 +61,15 @@ func (i *Input) Show() error {
 			return err
 		}
 		v.Editable = true
+		v.Editor = gocui.EditorFunc(createValueUpdateEditor(i))
 		v.SelBgColor = gocui.ColorGreen
 		v.SelFgColor = gocui.ColorBlack
 		if i.Mask {
 			v.Mask ^= '*'
 		}
+
+		i.setDefaultKeybindings()
+
 		if i.KeyBindings != nil {
 			for key, f := range i.KeyBindings {
 				if err := i.g.SetKeybinding(inputViewName, key, gocui.ModNone, f); err != nil {
@@ -67,12 +87,6 @@ func (i *Input) Show() error {
 
 func (i *Input) Close() error {
 	inputViewName := i.Name + "-input"
-	// ov, err := i.g.View(inputViewName)
-	// if err != nil {
-	// 	return err
-	// }
-	// ov.Frame = false
-	// ov.Clear()
 	i.g.DeleteKeybindings(inputViewName)
 	if err := i.g.DeleteView(inputViewName); err != nil {
 		return err
@@ -81,24 +95,70 @@ func (i *Input) Close() error {
 }
 
 func (i *Input) GetData() (string, error) {
-	inputViewName := i.Name + "-input"
-	ov, err := i.g.View(inputViewName)
-	if err != nil {
-		return "", err
-	}
-	if len(ov.BufferLines()) == 0 {
-		return "", nil
-	}
-	return ov.Line(0)
+	return i.Value, nil
 }
 
 func (i *Input) SetData(data string) error {
 	inputViewName := i.Name + "-input"
 	ov, err := i.g.View(inputViewName)
 	if err != nil {
-		return err
+		if err != gocui.ErrUnknownView {
+			return err
+		}
+		// View is not created yet, only update Value, don't edit the buffer
+		i.Value = data
+		return nil
 	}
+
+	i.Value = data
 	ov.Clear()
 	_, err = ov.Write([]byte(data))
 	return err
+}
+
+func (i *Input) SetOnConfirm(callback EventCallback) {
+	i.onConfirm = callback
+}
+
+func (i *Input) SetOnLeave(callback EventCallback) {
+	i.onLeave = callback
+}
+
+func (i *Input) setDefaultKeybindings() {
+	i.bindConfirmOnKey(gocui.KeyEnter)
+	i.bindConfirmOnKey(gocui.KeyArrowDown)
+	i.bindLeaveOnKey(gocui.KeyEsc)
+	i.bindLeaveOnKey(gocui.KeyArrowUp)
+}
+
+func (i *Input) bindConfirmOnKey(key gocui.Key) error {
+	inputViewName := i.Name + "-input"
+	return i.g.SetKeybinding(inputViewName, key, gocui.ModNone, func(g *gocui.Gui, v *gocui.View) error {
+		if data, err := i.GetData(); err != nil {
+			return err
+		} else {
+			if i.onConfirm != nil {
+				if err := i.onConfirm(data, key); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+	})
+}
+
+func (i *Input) bindLeaveOnKey(key gocui.Key) error {
+	inputViewName := i.Name + "-input"
+	return i.g.SetKeybinding(inputViewName, key, gocui.ModNone, func(g *gocui.Gui, v *gocui.View) error {
+		if data, err := i.GetData(); err != nil {
+			return err
+		} else {
+			if i.onConfirm != nil {
+				if err := i.onLeave(data, key); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+	})
 }

--- a/pkg/widgets/input.go
+++ b/pkg/widgets/input.go
@@ -153,7 +153,7 @@ func (i *Input) bindLeaveOnKey(key gocui.Key) error {
 		if data, err := i.GetData(); err != nil {
 			return err
 		} else {
-			if i.onConfirm != nil {
+			if i.onLeave != nil {
 				if err := i.onLeave(data, key); err != nil {
 					return err
 				}

--- a/pkg/widgets/page.go
+++ b/pkg/widgets/page.go
@@ -1,0 +1,267 @@
+package widgets
+
+import (
+	"fmt"
+
+	"github.com/jroimartin/gocui"
+	"github.com/sirupsen/logrus"
+)
+
+type EventCallback func(data interface{}, key gocui.Key) error
+
+type ComponentValidator func(data interface{}) error
+
+type PageComponent interface {
+	Element
+	SetLocation(int, int, int, int)
+}
+
+type EditablePageComponent interface {
+	PageComponent
+	SetOnConfirm(EventCallback)
+	SetOnLeave(EventCallback)
+	// TODO: Generalize the SetData interface:
+	// SetData(interface{}) error
+}
+
+func createVerticalLocator(g *gocui.Gui) func(component PageComponent, height int) {
+	maxX, maxY := g.Size()
+	lastY := 0
+	return func(component PageComponent, height int) {
+		var (
+			x0 = maxX / 8
+			y0 = lastY
+			x1 = maxX / 8 * 7
+			y1 int
+		)
+		if height == 0 {
+			y1 = maxY / 8 * 7
+		} else {
+			y1 = y0 + height
+		}
+		lastY += height
+		component.SetLocation(x0, y0, x1, y1)
+	}
+}
+
+type Page struct {
+	g             *gocui.Gui
+	title         *Panel
+	status        *Panel
+	footer        *Panel
+	components    []PageComponent
+	statusSpinner *Spinner
+	currentFocus  PageComponent
+}
+
+func NewPage(g *gocui.Gui, name string) (*Page, error) {
+	title := NewPanel(g, fmt.Sprintf("%s-title", name))
+	title.Focus = false
+	status := NewPanel(g, fmt.Sprintf("%s-status", name))
+	status.Focus = false
+	footer := NewPanel(g, fmt.Sprintf("%s-footer", name))
+	footer.Focus = false
+
+	page := &Page{
+		g:          g,
+		title:      title,
+		status:     status,
+		footer:     footer,
+		components: []PageComponent{},
+	}
+	page.layout()
+
+	return page, nil
+}
+
+func (p *Page) Show() error {
+	if err := p.title.Show(); err != nil {
+		return err
+	}
+	if err := p.status.Show(); err != nil {
+		return err
+	}
+	if err := p.footer.Show(); err != nil {
+		return err
+	}
+	for _, comp := range p.components {
+		if err := comp.Show(); err != nil {
+			return err
+		}
+	}
+
+	if p.currentFocus != nil {
+		p.SetFocus(p.currentFocus)
+	}
+
+	if len(p.components) > 0 {
+		p.SetFocus(p.components[0])
+	}
+
+	return nil
+}
+
+func (p *Page) Close() error {
+	if err := p.title.Close(); err != nil {
+		return err
+	}
+	if err := p.status.Close(); err != nil {
+		return err
+	}
+	if err := p.footer.Close(); err != nil {
+		return err
+	}
+	for _, panel := range p.components {
+		if err := panel.Close(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *Page) SetTitle(msg string) {
+	p.title.SetContent(msg)
+}
+
+func (p *Page) SetStatus(msg string, busy, isError bool) {
+	if p.statusSpinner != nil {
+		p.statusSpinner.Stop()
+		p.statusSpinner = nil
+	}
+
+	if busy {
+		p.statusSpinner = NewFocusSpinner(p.g, p.status.Name, msg)
+		p.statusSpinner.Start()
+	} else {
+		p.g.Update(func(g *gocui.Gui) error {
+			statusView, err := p.g.View(p.status.Name)
+			if err != nil {
+				return err
+			}
+			if isError {
+				statusView.FgColor = errorColor
+			} else {
+				statusView.FgColor = infoColor
+			}
+			p.status.SetContent(msg)
+			return nil
+		})
+	}
+}
+
+func (p *Page) SetFooter(msg string) {
+	p.footer.SetContent(msg)
+}
+
+func (p *Page) SetFocus(targetComp PageComponent) {
+	p.g.Update(func(g *gocui.Gui) error {
+		for _, comp := range p.components {
+			if comp == targetComp {
+				p.currentFocus = targetComp
+				logrus.Info("Focus on:", targetComp)
+				return targetComp.Show()
+			}
+		}
+		return fmt.Errorf("unable to focus on %v: not found", targetComp)
+	})
+}
+
+func (p *Page) AddComponent(comp EditablePageComponent, validator ComponentValidator) error {
+	p.components = append(p.components, comp)
+
+	comp.SetOnConfirm(func(data interface{}, key gocui.Key) error {
+		validateDone := make(chan error)
+		go func() {
+			validateDone <- validator(data)
+		}()
+
+		go func() {
+			err := <-validateDone
+			if err != nil {
+				logrus.Info("Set err")
+				p.SetStatus(err.Error(), false, true)
+				p.SetFocus(comp)
+			} else {
+				logrus.Info("Set noterr")
+				p.SetStatus("", false, false)
+				if nextComp, ok := p.getNextComponent(comp); ok {
+					logrus.Info("Go to next panel")
+					logrus.Info(nextComp)
+					p.SetFocus(nextComp)
+				} else {
+					logrus.Info("No next comp")
+				}
+			}
+		}()
+		return nil
+	})
+
+	comp.SetOnLeave(func(data interface{}, key gocui.Key) error {
+		switch key {
+		case gocui.KeyEsc:
+			logrus.Info("Go to prev page")
+		case gocui.KeyArrowUp:
+			if prevComp, ok := p.getPrevComponent(comp); ok {
+				logrus.Info("Go to prev panel")
+				p.SetFocus(prevComp)
+			} else {
+				logrus.Info("No prev comp")
+			}
+		default:
+			logrus.Warning("Undefined Leave key")
+		}
+		return nil
+	})
+	p.layout()
+	return nil
+}
+
+// TODO: FIX ME
+func (p *Page) RemoveComponent(compToRemove PageComponent) error {
+	for idx, comp := range p.components {
+		if comp == compToRemove {
+			if err := comp.Close(); err != nil {
+				return err
+			}
+			p.components = append(p.components[:idx], p.components[idx+1:]...)
+			p.layout()
+			return nil
+		}
+	}
+
+	return fmt.Errorf("unable to locate component")
+}
+
+func (p *Page) layout() {
+	setLocation := createVerticalLocator(p.g)
+	setLocation(p.title, 3)
+	for _, comp := range p.components {
+		setLocation(comp, 5)
+	}
+	setLocation(p.status, 5)
+
+	maxX, maxY := p.g.Size()
+	p.footer.SetLocation(0, maxY-2, maxX, maxY)
+	p.g.Cursor = true
+}
+
+func (p *Page) getNextComponent(currComp PageComponent) (PageComponent, bool) {
+	lastCompIdx := len(p.components) - 1
+	for idx, comp := range p.components {
+		if comp == currComp && idx < lastCompIdx {
+			return p.components[idx+1], true
+		}
+	}
+
+	return nil, false
+}
+
+func (p *Page) getPrevComponent(currComp PageComponent) (PageComponent, bool) {
+	for idx, comp := range p.components {
+		if comp == currComp && idx != 0 {
+			return p.components[idx-1], true
+		}
+	}
+
+	return nil, false
+}

--- a/pkg/widgets/panel.go
+++ b/pkg/widgets/panel.go
@@ -32,6 +32,7 @@ type Panel struct {
 	KeyBindings    map[gocui.Key]func(*gocui.Gui, *gocui.View) error
 	KeyBindingTips map[string]string
 	FirstPage      bool
+	AdditionalNote string
 }
 
 func NewPanel(g *gocui.Gui, name string) *Panel {
@@ -103,20 +104,7 @@ func (p *Panel) Show() error {
 			}
 		}
 	}
-	tips := "<"
-	if !p.FirstPage {
-		tips += "Use ESC to go back to previous page"
-	}
-	for key, tip := range p.KeyBindingTips {
-		if tips != "<" {
-			tips += ", "
-		}
-		tips += fmt.Sprintf("Use %s to %s", key, tip)
-	}
-	tips += ">"
-	if tips == "<>" {
-		tips = ""
-	}
+	tips := p.GetFooterNote()
 	footerV, err := p.g.View(footerPanel)
 	if err != nil && err != gocui.ErrUnknownView {
 		return err
@@ -140,15 +128,42 @@ func (p *Panel) SetContent(content string) {
 	p.Content = content
 	p.g.Update(func(g *gocui.Gui) error {
 		v, err := p.g.View(p.Name)
-		if err != nil && err != gocui.ErrUnknownView {
+		if err != nil {
+			if err != gocui.ErrUnknownView {
+				return err
+			}
+
+			return nil
+		} else {
+			v.Clear()
+			_, err = fmt.Fprint(v, p.Content)
 			return err
 		}
-		v.Clear()
-		_, err = fmt.Fprint(v, p.Content)
-		return err
 	})
 }
 
 func (p *Panel) GetData() (string, error) {
 	return p.Content, nil
+}
+
+func (p *Panel) GetNote() string {
+	return p.AdditionalNote
+}
+
+func (p *Panel) GetFooterNote() string {
+	tips := "<"
+	if !p.FirstPage {
+		tips += "Use ESC to go back to previous page"
+	}
+	for key, tip := range p.KeyBindingTips {
+		if tips != "<" {
+			tips += ", "
+		}
+		tips += fmt.Sprintf("Use %s to %s", key, tip)
+	}
+	tips += ">"
+	if tips == "<>" {
+		tips = ""
+	}
+	return tips
 }

--- a/pkg/widgets/select.go
+++ b/pkg/widgets/select.go
@@ -165,20 +165,17 @@ func (s *Select) SetData(data string) error {
 		return nil
 	}
 
+	// If the given data is not found, we consider it as "nothing selected",
+	// and Value would be an empty string
 	ox, oy := ov.Origin()
-	optFound := false
 	for i, option := range s.options {
 		if option.Value == data {
 			if err = ov.SetCursor(ox, oy+i); err != nil {
 				return err
 			}
 			s.Value = data
-			optFound = true
 			break
 		}
-	}
-	if !optFound {
-		return fmt.Errorf("option for data %v not found", data)
 	}
 
 	return nil

--- a/pkg/widgets/select.go
+++ b/pkg/widgets/select.go
@@ -25,6 +25,10 @@ type Select struct {
 	values          []string
 	multi           bool
 	selectedIndexes []bool
+
+	// Event callback
+	onConfirm EventCallback
+	onLeave   EventCallback
 }
 
 func NewSelect(g *gocui.Gui, name string, text string, getOptionsFunc GetOptionsFunc) (*Select, error) {
@@ -57,7 +61,7 @@ func (s *Select) Show() error {
 		if err != gocui.ErrUnknownView {
 			return err
 		}
-
+		// Initialize
 		v.Wrap = true
 
 		if s.multi {
@@ -77,13 +81,10 @@ func (s *Select) Show() error {
 			}
 		}
 
-		if _, err := s.g.SetCurrentView(optionViewName); err != nil {
-			return err
-		}
-
 		if err := s.setOptionsKeyBindings(optionViewName); err != nil {
 			return err
 		}
+		/* Don't allow custom keybindings for now
 		if s.KeyBindings != nil {
 			for key, f := range s.KeyBindings {
 				if err := s.g.SetKeybinding(optionViewName, key, gocui.ModNone, f); err != nil {
@@ -91,13 +92,18 @@ func (s *Select) Show() error {
 				}
 			}
 		}
+		*/
+	}
+
+	// If Show() is called, focus this view no matter what
+	if _, err := s.g.SetCurrentView(optionViewName); err != nil {
+		return err
 	}
 
 	if s.multi {
 		return nil
 	}
 	return s.SetData(s.Value)
-
 }
 
 func (s *Select) Close() error {
@@ -149,16 +155,45 @@ func (s *Select) SetData(data string) error {
 	if err != nil {
 		return err
 	}
-	cx, cy := ov.Cursor()
+	// FIXED: Should be relative to origin, not current cursor position
+	ox, oy := ov.Origin()
 	for i, option := range s.options {
 		if option.Value == data {
-			if err = ov.SetCursor(cx, cy+i); err != nil {
+			if err = ov.SetCursor(ox, oy+i); err != nil {
 				return err
 			}
 			break
 		}
 	}
 	return nil
+}
+
+/* TODO: Support set multi-select data
+func (s *Select) Set MultiData(data string) error {
+}
+*/
+
+func (s *Select) getDataGeneric() (interface{}, error) {
+	var data interface{}
+	var err error
+
+	if s.multi {
+		return s.GetMultiData(), nil
+	} else {
+		if data, err = s.GetData(); err != nil {
+			return nil, err
+		} else {
+			return data, err
+		}
+	}
+}
+
+func (s *Select) SetOnConfirm(callback EventCallback) {
+	s.onConfirm = callback
+}
+
+func (s *Select) SetOnLeave(callback EventCallback) {
+	s.onLeave = callback
 }
 
 func (s *Select) updateSelectedStatus(v *gocui.View) error {
@@ -182,7 +217,8 @@ func (s *Select) updateSelectedStatus(v *gocui.View) error {
 }
 
 func (s *Select) setOptionsKeyBindings(viewName string) error {
-	setOptionsKeyBindings(s.g, viewName)
+	// Update value
+	// TODO: Generic handler for both multi and not-multi
 	if s.multi {
 		handler := func(g *gocui.Gui, v *gocui.View) error {
 			_, cy := v.Cursor()
@@ -195,16 +231,100 @@ func (s *Select) setOptionsKeyBindings(viewName string) error {
 		if err := s.g.SetKeybinding(viewName, gocui.KeySpace, gocui.ModNone, handler); err != nil {
 			return err
 		}
+	} else {
+		handler := func(g *gocui.Gui, v *gocui.View) error {
+			_, cy := v.Cursor()
+			if len(s.options) >= cy+1 {
+				s.Value = s.options[cy].Value
+			}
+			s.SetData(s.Value)
+			return nil
+		}
+		if err := s.g.SetKeybinding(viewName, gocui.KeyEnter, gocui.ModNone, handler); err != nil {
+			return err
+		}
 	}
-	return nil
-}
 
-func setOptionsKeyBindings(g *gocui.Gui, viewName string) error {
-	if err := g.SetKeybinding(viewName, gocui.KeyArrowUp, gocui.ModNone, ArrowUp); err != nil {
-		return err
-	}
-	if err := g.SetKeybinding(viewName, gocui.KeyArrowDown, gocui.ModNone, ArrowDown); err != nil {
-		return err
-	}
+	// Submit value
+	s.g.SetKeybinding(viewName, gocui.KeyEnter, gocui.ModNone, func(g *gocui.Gui, v *gocui.View) error {
+		data, err := s.getDataGeneric()
+		if err != nil {
+			return err
+		}
+
+		if s.onConfirm != nil {
+			if err := s.onConfirm(data, gocui.KeyEnter); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	s.g.SetKeybinding(viewName, gocui.KeyEsc, gocui.ModNone, func(g *gocui.Gui, v *gocui.View) error {
+		data, err := s.getDataGeneric()
+		if err != nil {
+			return err
+		}
+
+		if s.onLeave != nil {
+			if err := s.onLeave(data, gocui.KeyEsc); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	s.g.SetKeybinding(viewName, gocui.KeyArrowUp, gocui.ModNone, func(g *gocui.Gui, v *gocui.View) error {
+		if v == nil {
+			return nil
+		}
+
+		if isAtTop(v) {
+			data, err := s.getDataGeneric()
+			if err != nil {
+				return err
+			}
+			// TODO: Should be generic
+			if !s.multi {
+				value, ok := data.(string)
+				if !ok {
+					return fmt.Errorf("data is not string type: %T", data)
+				} else {
+					// TODO: Fix this s.Value stuff
+					s.Value = value
+					s.SetData(value)
+				}
+			}
+
+			if s.onLeave != nil {
+				if err := s.onLeave(data, gocui.KeyArrowUp); err != nil {
+					return err
+				}
+			}
+		} else {
+			cx, cy := v.Cursor()
+			if err := v.SetCursor(cx, cy-1); err != nil {
+				ox, oy := v.Origin()
+				if err := v.SetOrigin(ox, oy-1); err != nil {
+					return err
+				}
+			}
+		}
+
+		return nil
+	})
+	s.g.SetKeybinding(viewName, gocui.KeyArrowDown, gocui.ModNone, func(g *gocui.Gui, v *gocui.View) error {
+		if v == nil || isAtEnd(v) {
+			return nil
+		}
+		cx, cy := v.Cursor()
+		if err := v.SetCursor(cx, cy+1); err != nil {
+			ox, oy := v.Origin()
+			if err := v.SetOrigin(ox, oy+1); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+
 	return nil
 }

--- a/pkg/widgets/spinner.go
+++ b/pkg/widgets/spinner.go
@@ -1,0 +1,102 @@
+package widgets
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/jroimartin/gocui"
+	"github.com/sirupsen/logrus"
+)
+
+type Spinner struct {
+	g      *gocui.Gui
+	panel  string
+	prefix string
+	ticker *time.Ticker
+	focus  bool
+
+	stop    chan struct{}
+	stopped chan bool
+}
+
+const (
+	infoColor    = gocui.ColorCyan
+	errorColor   = gocui.ColorRed
+	spinInterval = 100 * time.Millisecond
+)
+
+func NewSpinner(g *gocui.Gui, panel string, prefix string) *Spinner {
+	return &Spinner{
+		g:       g,
+		panel:   panel,
+		prefix:  prefix,
+		stop:    make(chan struct{}),
+		stopped: make(chan bool),
+	}
+}
+
+func NewFocusSpinner(g *gocui.Gui, panel string, prefix string) *Spinner {
+	return &Spinner{
+		g:       g,
+		panel:   panel,
+		prefix:  prefix,
+		stop:    make(chan struct{}),
+		stopped: make(chan bool),
+		focus:   true,
+	}
+}
+
+func (s *Spinner) Start() {
+	s.ticker = time.NewTicker(spinInterval)
+	go func() {
+		s.writePanel(fmt.Sprintf("%s|", s.prefix), true, infoColor)
+		for {
+			for _, symbol := range `\-/|` {
+				select {
+				case <-s.stop:
+					return
+				case <-s.ticker.C:
+					s.writePanel(fmt.Sprintf("\r%s%c", s.prefix, symbol), false, infoColor)
+				}
+			}
+		}
+	}()
+}
+
+func (s *Spinner) Stop() {
+	s.ticker.Stop()
+	s.stop <- struct{}{}
+}
+
+func (s *Spinner) writePanel(message string, clear bool, fgColor gocui.Attribute) {
+	// g.Update spawns a goroutine to notify gocui to update.
+	// wait until cui consumes the notification to make sure any remaining
+	// writePanel calls don't go first
+	ch := make(chan struct{})
+
+	s.g.Update(func(g *gocui.Gui) error {
+		defer func() {
+			ch <- struct{}{}
+		}()
+		v, err := g.View(s.panel)
+		if err == gocui.ErrUnknownView {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
+		if s.focus {
+			logrus.Info("SetCurrentView", s.panel)
+			g.SetCurrentView(s.panel)
+		}
+		if clear {
+			v.Clear()
+		}
+		v.FgColor = fgColor
+		v.Write([]byte(message))
+		return nil
+	})
+
+	<-ch
+}

--- a/pkg/widgets/spinner.go
+++ b/pkg/widgets/spinner.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/jroimartin/gocui"
-	"github.com/sirupsen/logrus"
 )
 
 type Spinner struct {
@@ -20,6 +19,7 @@ type Spinner struct {
 }
 
 const (
+	normalColor  = gocui.ColorDefault
 	infoColor    = gocui.ColorCyan
 	errorColor   = gocui.ColorRed
 	spinInterval = 100 * time.Millisecond
@@ -87,7 +87,6 @@ func (s *Spinner) writePanel(message string, clear bool, fgColor gocui.Attribute
 		}
 
 		if s.focus {
-			logrus.Info("SetCurrentView", s.panel)
 			g.SetCurrentView(s.panel)
 		}
 		if clear {


### PR DESCRIPTION
# Key idea

## Replace key binding configuration with event callback
We shouldn't have to configure the key bindings of each input element (`Input`, `Select`, and `DropDown`) when creating a "page". Instead, these input elements should provide an interface for setting up event callbacks. Each input element should only have two events:
- **On Confirm**: Triggered when users decided to submit the result. For example: Pressed `Enter` or `ArrowDown`.
- **On Leave**: Triggered when users decided to cancel the current operation. For example: Pressed `Esc` or `ArrowUp`
  
The event handler callback has type `func (data interface{}, key gocui.Key) error`. You can create a handler to:
- Validate the `data` sent by the input element, then decide whether go to the next input element.
- Check what key triggered the event. For instance, if it's `Esc` that triggered the On Leave event, then the UI should go to the previous page. But if it's `ArrowUp`, then we should go to the previous input element on the same page.

## Create a "Page" widget to create a page with ease
A `Page` element is responsible for:
- Manage the page-wise components, such as:
    - Title
    - Footer
    - Validator message and the busy-spinner
    - Additional notes for each input element
- Manage the layout of input elements on this page dynamically
- Manage the interaction between input elements on this page, i.e.:
    - Go to the next input element if the current one triggered the On Confirm event and passed the validation
    - Go to the previous input element if the current one triggered the On Leave event
    - Update Validator status (and maybe turn on the busy-spinner) while validating the input

# Some PoC
- Re-create the Network configuration page without any key bindings configuration, only relies on the **On Confirm** and **On Leave** event [LINK](https://github.com/johnliu55tw/harvester-installer/blob/refactor-installer-ui/pkg/console/install_panels.go#L868-L1049)
- Use the `Page` widget to create the DNS configuration page [LINK](https://github.com/johnliu55tw/harvester-installer/blob/9afcc37ecf0e9164311c9f768764a2fe2ab95756/pkg/console/install_panels.go#L1705)
- A simple page with all three types of input element [LINK](https://github.com/johnliu55tw/harvester-installer/blob/9afcc37ecf0e9164311c9f768764a2fe2ab95756/pkg/console/install_panels.go#L1863)
