### PR TITLE
Ability to process kernel arguments containing harvester-mgmt NetworkInterface details

### DIFF
--- a/pkg/config/read.go
+++ b/pkg/config/read.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -18,10 +17,6 @@ const (
 func ReadConfig() (HarvesterConfig, error) {
 	result := NewHarvesterConfig()
 	data, err := util.ReadCmdline(kernelParamPrefix)
-	if err != nil {
-		return *result, err
-	}
-	err = ToNetworkInterface(data)
 	if err != nil {
 		return *result, err
 	}
@@ -50,34 +45,4 @@ func mapToEnv(prefix string, data map[string]interface{}) []string {
 		}
 	}
 	return result
-}
-
-func ToNetworkInterface(data map[string]interface{}) error {
-	if installInterface, ok := data["install"]; ok {
-		if networksInterface, ok := installInterface.(map[string]interface{})["networks"]; ok {
-			if mgmtInterface, ok := networksInterface.(map[string]interface{})["harvester-mgmt"]; ok {
-				if interfaces, ok := mgmtInterface.(map[string]interface{})["interfaces"]; ok {
-					var ifDetails []string
-					var outDetails []NetworkInterface
-					switch interfaces.(type) {
-					case string:
-						ifDetails = append(ifDetails, interfaces.(string))
-					case []string:
-						ifDetails = interfaces.([]string)
-					}
-					for _, v := range ifDetails {
-						tmpStrings := strings.SplitN(v, ":", 2)
-						n := NetworkInterface{}
-						err := json.Unmarshal([]byte(fmt.Sprintf("{\"%s\":\"%s\"}", tmpStrings[0], strings.ReplaceAll(tmpStrings[1], " ", ""))), &n)
-						if err != nil {
-							return err
-						}
-						outDetails = append(outDetails, n)
-					}
-					mgmtInterface.(map[string]interface{})["interfaces"] = outDetails
-				}
-			}
-		}
-	}
-	return nil
 }

--- a/pkg/config/read.go
+++ b/pkg/config/read.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -17,6 +18,10 @@ const (
 func ReadConfig() (HarvesterConfig, error) {
 	result := NewHarvesterConfig()
 	data, err := util.ReadCmdline(kernelParamPrefix)
+	if err != nil {
+		return *result, err
+	}
+	err = ToNetworkInterface(data)
 	if err != nil {
 		return *result, err
 	}
@@ -45,4 +50,34 @@ func mapToEnv(prefix string, data map[string]interface{}) []string {
 		}
 	}
 	return result
+}
+
+func ToNetworkInterface(data map[string]interface{}) error {
+	if installInterface, ok := data["install"]; ok {
+		if networksInterface, ok := installInterface.(map[string]interface{})["networks"]; ok {
+			if mgmtInterface, ok := networksInterface.(map[string]interface{})["harvester-mgmt"]; ok {
+				if interfaces, ok := mgmtInterface.(map[string]interface{})["interfaces"]; ok {
+					var ifDetails []string
+					var outDetails []NetworkInterface
+					switch interfaces.(type) {
+					case string:
+						ifDetails = append(ifDetails, interfaces.(string))
+					case []string:
+						ifDetails = interfaces.([]string)
+					}
+					for _, v := range ifDetails {
+						tmpStrings := strings.SplitN(v, ":", 2)
+						n := NetworkInterface{}
+						err := json.Unmarshal([]byte(fmt.Sprintf("{\"%s\":\"%s\"}", tmpStrings[0], strings.ReplaceAll(tmpStrings[1], " ", ""))), &n)
+						if err != nil {
+							return err
+						}
+						outDetails = append(outDetails, n)
+					}
+					mgmtInterface.(map[string]interface{})["interfaces"] = outDetails
+				}
+			}
+		}
+	}
+	return nil
 }

--- a/pkg/util/cmdline_test.go
+++ b/pkg/util/cmdline_test.go
@@ -1,9 +1,10 @@
 package util
 
 import (
-	"testing"
-
+	"fmt"
+	"github.com/rancher/mapper/values"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func Test_parseCmdLineWithPrefix(t *testing.T) {
@@ -32,4 +33,30 @@ func Test_parseCmdLineWithoutPrefix(t *testing.T) {
 		"console": []string{"tty1", "ttyS0,115200n8"},
 	}
 	assert.Equal(t, want, m)
+}
+
+func Test_parseCmdLineWithNetworkInterface(t *testing.T) {
+
+	cmdline := `harvester.os.sshAuthorizedKeys=a  harvester.install.networks.harvester-mgmt.method=dhcp harvester.install.networks.harvester-mgmt.bond_options.mode=balance-tlb harvester.install.networks.harvester-mgmt.bond_options.miimon=100 harvester.os.sshAuthorizedKeys=b harvester.install.mode=create harvester.install.networks.harvester-mgmt.interfaces="hwAddr: ab:cd:ef:gh" harvester.install.networks.harvester-mgmt.interfaces="hwAddr:   de:fg:hi:jk"`
+
+	m, err := parseCmdLine(cmdline, "harvester")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []interface{}{
+		map[string]interface{}{
+			"hwAddr": "ab:cd:ef:gh",
+		},
+		map[string]interface{}{
+			"hwAddr": "de:fg:hi:jk",
+		},
+	}
+
+	have, ok := values.GetValue(m, "install", "networks", "harvester-mgmt", "interfaces")
+	if !ok {
+		t.Fatal(fmt.Errorf("no network interfaces found"))
+	}
+
+	assert.Equal(t, want, have)
 }


### PR DESCRIPTION
The PR is in relation to feature request: https://github.com/harvester/harvester/issues/1889

With this minor tweak to the harvester-installer, the mass PXE booting of nodes is easier as the ${net0/mac} PXE variable can be passed to kernel arguments to allow harvester-installer to use hwAddr based address lookup to find the correct interface.

This makes it easy to PXE boot a full multi node harvester cluster quickly using something like terraform. A sample of the same using a custom squashfs build is here: https://github.com/ibrokethecloud/harvester-equinix-terraform-sample