### PR TITLE
add ClusterNetworks config in installer

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -117,6 +117,11 @@ type OS struct {
 	Labels         map[string]string `json:"labels,omitempty"`
 }
 
+type ClusterNetwork struct {
+	Description string            `json:"description,omitempty"`
+	Config      map[string]string `json:"config,omitempty"`
+}
+
 type HarvesterConfig struct {
 	ServerURL string `json:"serverUrl,omitempty"`
 	Token     string `json:"token,omitempty"`
@@ -127,6 +132,7 @@ type HarvesterConfig struct {
 	HarvesterChartVersion  string            `json:"harvesterChartVersion,omitempty"`
 	MonitoringChartVersion string            `json:"monitoringChartVersion,omitempty"`
 	SystemSettings         map[string]string `json:"systemSettings,omitempty"`
+	ClusterNetworks        map[string]ClusterNetwork `json:"clusterNetworks,omitempty"`
 }
 
 func NewHarvesterConfig() *HarvesterConfig {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -118,6 +118,8 @@ type OS struct {
 }
 
 type ClusterNetwork struct {
+	// by default: false
+	Enable      bool              `json:"enable,omitempty"`
 	Description string            `json:"description,omitempty"`
 	Config      map[string]string `json:"config,omitempty"`
 }

--- a/pkg/config/cos.go
+++ b/pkg/config/cos.go
@@ -511,6 +511,7 @@ func genBootstrapResources(config *HarvesterConfig) (map[string]string, error) {
 		"11-monitoring-crd.yaml",
 		"13-monitoring.yaml",
 		"20-harvester-settings.yaml",
+		"21-harvester-clusternetworks.yaml",
 	} {
 		rendered, err := render("rancherd-"+templateName, config)
 		if err != nil {

--- a/pkg/config/templates/rancherd-21-harvester-clusternetworks.yaml
+++ b/pkg/config/templates/rancherd-21-harvester-clusternetworks.yaml
@@ -1,0 +1,20 @@
+bootstrapResources: {{ if not .ClusterNetworks -}} [] {{- else }}
+{{- range $name, $network := .ClusterNetworks }}
+- apiVersion: harvesterhci.io/v1beta1
+  kind: ClusterNetwork
+  enable: true
+  metadata:
+    name: {{ printf "%q" $name }}
+{{- with $network }}
+{{- if .Description }}
+  description: {{ printf "%q" .Description }}
+{{- end }}
+{{- if .Config }}
+  config:
+{{- range $name, $value := .Config }}
+    {{ $name }}: {{ $value }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/pkg/config/templates/rancherd-21-harvester-clusternetworks.yaml
+++ b/pkg/config/templates/rancherd-21-harvester-clusternetworks.yaml
@@ -2,10 +2,10 @@ bootstrapResources: {{ if not .ClusterNetworks -}} [] {{- else }}
 {{- range $name, $network := .ClusterNetworks }}
 - apiVersion: harvesterhci.io/v1beta1
   kind: ClusterNetwork
-  enable: true
   metadata:
     name: {{ printf "%q" $name }}
 {{- with $network }}
+  enable: {{ if .Enable }} true {{- else }} false {{- end }}
 {{- if .Description }}
   description: {{ printf "%q" .Description }}
 {{- end }}


### PR DESCRIPTION
cluster network only allow one type of entry in same cluster.
also check dup name or not

address https://github.com/harvester/harvester/issues/1739

## Test method

1. Install a node of new cluster with ISO or PXE and put the config below into `config.yaml` and provide it to installer 
```yaml
cluster_networks:
  vlan:
    enable: true
    description: "some description about this cluster network"
    config:
      defaultPhysicalNIC: ens3
```

2. verify no error occurs and finish the installation
3. verify `ClusterNetwork` resource named `vlan` is created.
```bash
kubectl get clusternetworks.network.harvesterhci.io vlan -o yaml
```

4. verify the fields of `ClusterNetwork` resource named `vlan`  are correct.
```bash
kubectl get clusternetworks.network.harvesterhci.io vlan -o yaml
```

Result should contain `name`, `enable`, `config`, `defaultPhysicalNIC` with pre-defined value.
```
apiVersion: network.harvesterhci.io/v1beta1
config:
  defaultPhysicalNIC: ens3
description: "some description about this cluster network"
enable: true
kind: ClusterNetwork
metadata:
  creationTimestamp: "2022-01-25T07:18:21Z"
  finalizers:
  - wrangler.cattle.io/harvester-clusternetwork-controller
  generation: 6
  name: vlan
  resourceVersion: "252459"
  uid: 9d2c473e-f11a-474b-9189-8889df1076c6

```

5. verify UI in `Settings` page VLAN entry. Click into vlan option setup page and verify that show `ClusterNetwork: vlan`. Please refer to the picture and check the resource type in the red frame
![image](https://user-images.githubusercontent.com/2821179/153542788-cc5bb5f2-0fff-40f4-9a10-3b1d156a85bc.png)

6. verify UI of VLAN setup page in Settings page. 
    - verify `Enabled`, `Disabled` button.
    - verify it shows correct interface name in `Default Network Interface`
    - verify changing value in `Default Network Interface` and apply config
        - after setting new value for `Default Network Interface`, verify step 4 again to confirm that resource is updated


Signed-off-by: Date Huang <date.huang@suse.com>