### PR TITLE
Move SSH key configuration stage to "network"

### DIFF
--- a/pkg/config/cos.go
+++ b/pkg/config/cos.go
@@ -54,7 +54,6 @@ func ConvertToCOS(config *HarvesterConfig) (*yipSchema.YipConfig, error) {
 	}
 
 	initramfs := yipSchema.Stage{
-		SSHKeys:   make(map[string][]string),
 		Users:     make(map[string]yipSchema.User),
 		TimeSyncd: make(map[string]string),
 	}
@@ -65,8 +64,6 @@ func ConvertToCOS(config *HarvesterConfig) (*yipSchema.YipConfig, error) {
 	}
 
 	// OS
-	initramfs.SSHKeys[cosLoginUser] = cfg.OS.SSHAuthorizedKeys
-
 	for _, ff := range cfg.OS.WriteFiles {
 		perm, err := strconv.ParseUint(ff.RawFilePermissions, 8, 0)
 		if err != nil {
@@ -128,11 +125,18 @@ func ConvertToCOS(config *HarvesterConfig) (*yipSchema.YipConfig, error) {
 		})
 	}
 
+	// After network is available
+	afterNetwork := yipSchema.Stage{
+		SSHKeys: make(map[string][]string),
+	}
+	afterNetwork.SSHKeys[cosLoginUser] = cfg.OS.SSHAuthorizedKeys
+
 	cosConfig := &yipSchema.YipConfig{
 		Name: "Harvester Configuration",
 		Stages: map[string][]yipSchema.Stage{
 			"rootfs":    {rootfs},
 			"initramfs": {initramfs},
+			"network":   {afterNetwork},
 		},
 	}
 

--- a/pkg/config/cos_test.go
+++ b/pkg/config/cos_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"testing"
 
+	"github.com/harvester/harvester-installer/pkg/util"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -100,4 +101,15 @@ func TestCalcCosPersistentPartSize(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConvertToCos_SSHKeysInYipNetworkStage(t *testing.T) {
+	conf, err := LoadHarvesterConfig(util.LoadFixture(t, "harvester-config.yaml"))
+	assert.NoError(t, err)
+
+	yipConfig, err := ConvertToCOS(conf)
+	assert.NoError(t, err)
+
+	assert.Equal(t, yipConfig.Stages["network"][0].SSHKeys["rancher"], conf.OS.SSHAuthorizedKeys)
+	assert.Nil(t, yipConfig.Stages["initramfs"][0].SSHKeys)
 }


### PR DESCRIPTION
Move the configuration of SSH keys to the "network" stage, to ensure network is available in case remote SSH key fetching is required.

Also add some unit tests.

## Test plan
1. Prepare a PXE installation environment
2. Ensure the config.yaml requires fetching SSH key remotely from GitHub:
    ```
    ...
    os:
      ssh_authorized_keys:
      - github:<A GitHub Username>
    ...
    ```
3. Run the PXE installation
4. After installation is finished, SSH into the Harvester and make sure the file `/home/rancher/.ssh/authorized_keys` existed and contains the public keys of the GitHub user specified in the config.

See https://docs.harvesterhci.io/v1.0/install/harvester-configuration/#osssh_authorized_keys for information about the config.

## Related issues
- https://github.com/harvester/harvester/issues/1903

## Reference
- `yip` command for configuring SSH keys: https://github.com/mudler/yip#stagesstageidstepnauthorized_keys
- cOS-toolkit `network` stage: https://rancher-sandbox.github.io/cos-toolkit-docs/docs/customizing/stages/#network