### PR TITLE
Set HOME env. var. while switching to terminal

### DIFF
--- a/package/harvester-os/files/usr/bin/start-installer.sh
+++ b/package/harvester-os/files/usr/bin/start-installer.sh
@@ -8,4 +8,7 @@ export TERM=linux
 
 harvester-installer
 # Do not allow bash prompt if the installer doesn't exit with status 0
+
+# We're not starting the shell using /bin/login, so we need to set $HOME manually
+export HOME=/root
 bash -l


### PR DESCRIPTION
The shell is started without using the /bin/login command so $HOME is not configured. Need to set it up manually.

# Test plan
1. Install Harvester
2. Wait until terminal dashboard is shown (the one with the following logo:)
    ```
    ██╗░░██╗░█████╗░██████╗░██╗░░░██╗███████╗░██████╗████████╗███████╗██████╗░
    ██║░░██║██╔══██╗██╔══██╗██║░░░██║██╔════╝██╔════╝╚══██╔══╝██╔════╝██╔══██╗
    ███████║███████║█████╔╝╚██╗░░██╔╝█████╗░░╚█████╗░░░░██║░░░█████╗░░██████╔╝
    ██╔══██║██╔══██║██╔══██╗░╚████╔╝░██╔══╝░░░╚═══██╗░░░██║░░░██╔══╝░░██╔══██╗
    ██║░░██║██║░░██║██║░░██║░░╚██╔╝░░███████╗██████╔╝░░░██║░░░███████╗██║░░██║
    ╚═╝░░╚═╝╚═╝░░╚═╝╚═╝░░╚═╝░░░╚═╝░░░╚══════╝╚═════╝░░░░╚═╝░░░╚══════╝╚═╝░░╚═╝`
    ```
3. Press F12 to switch to shell
4. Enter command `kubectl get nodes` and verify that **no error messages are shown** and **the response time is reasonable**.

# Related
- https://github.com/harvester/harvester/issues/1617