### PR TITLE
Record install panel output in the installer log

### DIFF
--- a/package/harvester-os/files/usr/sbin/harv-install
+++ b/package/harvester-os/files/usr/sbin/harv-install
@@ -293,10 +293,29 @@ update_grub_settings()
     add_debug_grub_entry
 }
 
-save_config()
+save_configs()
 {
+    save_dir=${TARGET}/oem
+
+    # When saving files to /oem, do not use yaml as the extension name because cos-setup will load them.
     if [ -e "$HARVESTER_CONFIG" ]; then
-        cp $HARVESTER_CONFIG ${TARGET}/oem/harvester.config
+        # harvester.config has to be stored in /oem/, it will be use by the harv-update-rke2-server-url script
+        cp $HARVESTER_CONFIG $save_dir/harvester.config
+    fi
+
+    if [ -e "$_COS_PARTITION_LAYOUT" ]; then
+        cp $_COS_PARTITION_LAYOUT $save_dir/part-layout.config
+    fi
+}
+
+save_installation_log()
+{
+    save_dir=${TARGET}/oem/install
+    mkdir -p $save_dir
+
+    if [ -e "$HARVESTER_INSTALLATION_LOG" ]; then
+        fsync $HARVESTER_INSTALLATION_LOG
+        cp $HARVESTER_INSTALLATION_LOG $save_dir
     fi
 }
 
@@ -347,8 +366,11 @@ do_data_disk_format
 do_detect
 do_mount
 get_iso  # For PXE Boot
-save_config
+save_configs
 save_wicked_state
 do_preload
 
 update_grub_settings
+
+# This needs to be the at the last because the log file captures the output of this script
+save_installation_log


### PR DESCRIPTION
- Record the harv-install output into installer log.

Example:
```
time="2022-02-23T16:55:58Z" level=info msg="[stdout]: Formatting drives.."
time="2022-02-23T16:55:58Z" level=info msg="[stderr]: 1+0 records in"
time="2022-02-23T16:55:58Z" level=info msg="[stderr]: 1+0 records out"
time="2022-02-23T16:55:58Z" level=info msg="[stderr]: 1048576 bytes (1.0 MB, 1.0 MiB) copied, 0.00506754 s, 207 MB/s"
time="2022-02-23T16:55:58Z" level=info msg="[stderr]: Warning: The resulting partition is not properly aligned for best performance."
time="2022-02-23T16:56:03Z" level=info msg="[stdout]: time=\"2022-02-23T16:56:03Z\" level=info msg=\"Running stage: partitioning\\n\""
time="2022-02-23T16:56:03Z" level=info msg="[stdout]: time=\"2022-02-23T16:56:03Z\" level=info msg=\"Executing /tmp/part-layout.040633848\""
time="2022-02-23T16:56:03Z" level=info msg="[stdout]: time=\"2022-02-23T16:56:03Z\" level=info msg=\"Applying 'Root partitioning layout' for stage 'partitioning'. Total stages: 1\\n\""
time="2022-02-23T16:56:03Z" level=info msg="[stdout]: time=\"2022-02-23T16:56:03Z\" level=info msg=\"Processing stage step 'Root partitioning layout'. ( commands: 0, files: 0, ... )\\n\""
time="2022-02-23T16:56:03Z" level=info msg="[stdout]: time=\"2022-02-23T16:56:03Z\" level=info msg=\"Creating COS_OEM partition\""
time="2022-02-23T16:56:05Z" level=info msg="[stdout]: time=\"2022-02-23T16:56:05Z\" level=info msg=\"Creating COS_STATE partition\""
time="2022-02-23T16:56:06Z" level=info msg="[stdout]: time=\"2022-02-23T16:56:06Z\" level=info msg=\"Creating COS_RECOVERY partition\""
time="2022-02-23T16:56:07Z" level=info msg="[stdout]: time=\"2022-02-23T16:56:07Z\" level=info msg=\"Creating COS_PERSISTENT partition\""
time="2022-02-23T16:56:10Z" level=info msg="[stdout]: time=\"2022-02-23T16:56:10Z\" level=info msg=\"Creating HARV_LH_DEFAULT partition\""
time="2022-02-23T16:56:12Z" level=info msg="[stdout]: time=\"2022-02-23T16:56:12Z\" level=info msg=\"Stage 'partitioning'. Defined stages: 1. Errors: false\\n\""
time="2022-02-23T16:56:12Z" level=info msg="[stdout]: time=\"2022-02-23T16:56:12Z\" level=info msg=\"Done executing stage 'partitioning'\\n\""
```


- Save the installer log to $TARGET/oem/install/console.log.
- Output content of harvester config and partition layout in the installer log.
   These files are temporary, logging them to ease debugging.
- If the installation fails, the console will suggest users check the log:
![Screen Shot 2022-02-23 at 11 06 29 PM](https://user-images.githubusercontent.com/1691518/155461679-1748863b-b20c-480d-a1c7-781a6f1b566c.png)





**Related issue**
https://github.com/harvester/harvester/issues/1800

**NOTE** the issue description also suggests we can make the installer panel scrollable. I'll leave it as future enhancement since now we can get the installer panel output from console.log.
