### PR TITLE
Support MTU config

### DIFF
--- a/pkg/config/templates/wicked-ifcfg-bond-master
+++ b/pkg/config/templates/wicked-ifcfg-bond-master
@@ -19,3 +19,6 @@ BONDING_MODULE_OPTS='{{ range $key, $value := .BondOptions }}{{ $key }}={{ $valu
   {{- $defaultRoute = "yes" -}}
 {{- end }}
 DHCLIENT_SET_DEFAULT_ROUTE='{{ $defaultRoute }}'
+{{ if gt .MTU 0 -}}
+MTU={{ .MTU }}
+{{- end }}

--- a/pkg/config/templates/wicked-ifcfg-eth
+++ b/pkg/config/templates/wicked-ifcfg-eth
@@ -4,3 +4,6 @@ BOOTPROTO='{{ .Method }}'
 IPADDR={{ .IP }}
 NETMASK={{ .SubnetMask }}
 {{- end }}
+{{ if gt .MTU 0 -}}
+MTU={{ .MTU }}
+{{- end }}

--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/imdario/mergo"
 	"github.com/jroimartin/gocui"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -60,7 +59,7 @@ func (c *Console) layoutInstall(g *gocui.Gui) error {
 		if cfg, err := config.ReadConfig(); err == nil {
 			if cfg.Install.Automatic && isFirstConsoleTTY() {
 				logrus.Info("Start automatic installation...")
-				mergo.Merge(c.config, cfg, mergo.WithAppendSlice)
+				c.config.Merge(cfg)
 				initPanel = installPanel
 			}
 		}
@@ -1490,7 +1489,7 @@ func addInstallPanel(c *Console) error {
 					return
 				}
 				logrus.Info("Remote config: ", remoteConfig)
-				if err := mergo.Merge(c.config, remoteConfig, mergo.WithAppendSlice); err != nil {
+				if err := c.config.Merge(*remoteConfig); err != nil {
 					printToPanel(c.Gui, fmt.Sprintf("fail to merge config: %s", err), installPanel)
 					return
 				}


### PR DESCRIPTION
- Add config `MTU` to Network configuration
- Support merging the "Networks" field of HarvesterConfig (because [Mergo](https://github.com/imdario/mergo#usage) does not support merging struct inside maps)

## Test plan
> **NOTE**: Users can only configure MTU via Harvester Configurations. They can't configure this value using Installer UI.
1. Boot the machine via Harvester ISO
2. Supply a remote config with the following YAML:
    ```
    install:
      networks:
        harvester-mgmt:
          mtu: 1400
    ```
    This will set the `harvester-mgmt` interface to have MTU `1400`. Change this value as you wish (default is `1500`).

3. Proceed with the installation
4. SSH into the Harvester node and use the command `ip link show <interface>` to verify:
    - `harvester-mgmt` interface has the MTU `1400` (or whatever value you provided)
    - `enp1s0` (The slave interface of `harvester-mgmt`) also has the MTU `1400` (or whatever value you provided)
5. Reboot the node and verify that the MTU setting is preserved over system reboots.

## Related issues
- https://github.com/harvester/harvester/issues/1934
