### PR TITLE
Switch BCI images

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,7 +1,7 @@
 FROM quay.io/costoolkit/releases-green:luet-toolchain-0.21.2 as luet
 FROM quay.io/costoolkit/releases-green:luet-makeiso-toolchain-0.3.8-16 as makeiso
 
-FROM golang:1.16.5-alpine3.13
+FROM registry.suse.com/bci/bci-base:15.3
 
 ARG http_proxy=$http_proxy
 ARG https_proxy=$https_proxy
@@ -16,8 +16,9 @@ ENV HARVESTER_INSTALLER_OFFLINE_BUILD=$HARVESTER_INSTALLER_OFFLINE_BUILD
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
 
-RUN apk -U add bash git gcc musl-dev docker vim less file curl wget ca-certificates zstd squashfs-tools xorriso
-RUN apk add yq --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
+RUN zypper -n rm container-suseconnect && \
+    zypper -n install go1.16 git curl docker gzip tar wget zstd squashfs xorriso awk
+RUN curl -sfL https://github.com/mikefarah/yq/releases/download/v4.21.1/yq_linux_${ARCH} -o /usr/bin/yq && chmod +x /usr/bin/yq
 RUN go get -u golang.org/x/lint/golint
 RUN go get -u golang.org/x/tools/cmd/goimports
 RUN if [ "${ARCH}" == "amd64" ]; then \
@@ -34,12 +35,12 @@ RUN mkdir /usr/tmp && \
 COPY --from=luet /usr/bin/luet /usr/bin/luet
 COPY --from=makeiso /usr/bin/luet-makeiso /usr/bin/luet-makeiso
 
-ENV GO111MODULE off
 ENV DAPPER_ENV REPO TAG DRONE_TAG CROSS
 ENV DAPPER_SOURCE /go/src/github.com/harvester/harvester-installer/
 ENV DAPPER_OUTPUT ./bin ./dist
 ENV DAPPER_DOCKER_SOCKET true
-ENV DAPPER_RUN_ARGS "-v /run/containerd/containerd.sock:/run/containerd/containerd.sock"
+ENV DAPPER_RUN_ARGS "-v /run/containerd/containerd.sock:/run/containerd/containerd.sock -v harvester-installer-go:/root/go -v harvester-installer-cache:/root/.cache"
+
 ENV HOME ${DAPPER_SOURCE}
 WORKDIR ${DAPPER_SOURCE}
 

--- a/package/harvester-repo/Dockerfile
+++ b/package/harvester-repo/Dockerfile
@@ -1,3 +1,15 @@
-FROM nginx:stable
+FROM registry.suse.com/bci/bci-base:15.3
 
-COPY charts /usr/share/nginx/html/charts
+RUN zypper -n rm container-suseconnect && \
+    zypper -n in nginx && \
+    zypper -n clean -a && rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/* && \
+    ln -sf /dev/stdout /var/log/nginx/access.log && \
+    ln -sf /dev/stderr /var/log/nginx/error.log
+
+COPY charts /srv/www/htdocs/charts
+
+EXPOSE 80
+
+STOPSIGNAL SIGQUIT
+
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
- Build environment:
  - Switch to BCI image and use zypper to install packages.
  - Drop `GO111MODULE=off`.
  - Add go pkg and cache volumes.
- harvester-cluster-repo: switch to BCI image and install nginx.

**Related issue**
https://github.com/harvester/harvester/issues/1868