### PR TITLE
Bump vmdp driver image

### DIFF
--- a/scripts/build-bundle
+++ b/scripts/build-bundle
@@ -108,7 +108,7 @@ done
 cat <<EOF >> ${image_list_file}
 busybox:1.32.0
 alpine:3
-registry.suse.com/harvester-beta/vmdp:latest
+registry.suse.com/suse/vmdp/vmdp:2.5.3
 EOF
 
 # get longhorn image list


### PR DESCRIPTION
Bump Windows VMDP driver image due to old image will encounter the `not verified digital signature` issue.
![image](https://user-images.githubusercontent.com/4569037/156563262-7ec25cbe-1e36-4840-84c0-656f52004d41.png)
Related Issue: https://github.com/harvester/harvester/issues/1767
Related PR: https://github.com/harvester/harvester/pull/1960