### PR TITLE
Remove config "NoDataPartition"

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -249,10 +249,11 @@ func TestHarvesterRootfsRendering(t *testing.T) {
 			},
 		},
 		{
-			name: "Test NoDataPartition true",
+			name: "Test ForceMBR=true and no DataDisk -> No need to mount data partition",
 			harvConfig: HarvesterConfig{
 				Install: Install{
-					NoDataPartition: true,
+					ForceMBR: true,
+					DataDisk: "",
 				},
 			},
 			assertion: func(t *testing.T, rootfs *Rootfs) {
@@ -262,10 +263,11 @@ func TestHarvesterRootfsRendering(t *testing.T) {
 			},
 		},
 		{
-			name: "Test DataDisk configured",
+			name: "Test ForceMBR=true but has DataDisk -> Still need to mount data partition",
 			harvConfig: HarvesterConfig{
 				Install: Install{
-					DataDisk: "/dev/sda",
+					ForceMBR: true,
+					DataDisk: "/dev/sdb",
 				},
 			},
 			assertion: func(t *testing.T, rootfs *Rootfs) {

--- a/pkg/config/templates/cos-rootfs.yaml
+++ b/pkg/config/templates/cos-rootfs.yaml
@@ -3,7 +3,7 @@ if: '[ ! -f "/run/cos/recovery_mode" ]'
 name: "Rootfs layout overwrite"
 environment_file: /run/cos/cos-layout.env
 environment:
-  VOLUMES: "LABEL=COS_OEM:/oem LABEL=COS_PERSISTENT:/usr/local{{ if not .NoDataPartition }} LABEL=HARV_LH_DEFAULT:/var/lib/harvester/defaultdisk{{ end }}"
+  VOLUMES: "LABEL=COS_OEM:/oem LABEL=COS_PERSISTENT:/usr/local{{ if .ShouldMountDataPartition }} LABEL=HARV_LH_DEFAULT:/var/lib/harvester/defaultdisk{{ end }}"
   OVERLAY: "tmpfs:25%"
   RW_PATHS: "/var /etc /srv /boot"
   PERSISTENT_STATE_PATHS: >-
@@ -23,7 +23,7 @@ environment:
     /var/lib/cni
     /var/crash
     /var/lib/longhorn
-    {{- if .NoDataPartition }}
+    {{- if not .ShouldMountDataPartition }}
     /var/lib/harvester/defaultdisk
     {{- end }}
   PERSISTENT_STATE_BIND: "true"

--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -1537,25 +1537,9 @@ func addInstallPanel(c *Console) error {
 			// We need ForceGPT because cOS only supports ForceGPT (--force-gpt) flag, not ForceMBR!
 			c.config.ForceGPT = !c.config.ForceMBR
 
-			// If Forcing MBR, VM data (Longhorn) partition will NOT be created
-			if c.config.ForceMBR {
-				msg := "Use MBR partitioning scheme, will not create VM Data partition"
-				printToPanel(c.Gui, msg, installPanel)
-				logrus.Info(msg)
-				c.config.NoDataPartition = true
-			}
-
 			// Clear the DataDisk field if it's identical to the installation disk
 			if c.config.DataDisk == c.config.Device {
 				c.config.DataDisk = ""
-			}
-			// If DataDisk is specified and it's different from the install device, NoDataPartition
-			// should be set to "false" as we DO have a VM data partition, just on other disk.
-			if c.config.DataDisk != "" {
-				msg := fmt.Sprintf("Use %s as default VM data disk", c.config.DataDisk)
-				printToPanel(c.Gui, msg, installPanel)
-				logrus.Info(msg)
-				c.config.NoDataPartition = false
 			}
 
 			// case insensitive for network method and vip mode

--- a/pkg/console/util.go
+++ b/pkg/console/util.go
@@ -428,9 +428,8 @@ func doInstall(g *gocui.Gui, hvstConfig *config.HarvesterConfig, webhooks Render
 	env = append(env, fmt.Sprintf("HARVESTER_CONFIG=%s", hvstConfigFile))
 	env = append(env, fmt.Sprintf("HARVESTER_INSTALLATION_LOG=%s", defaultLogFilePath))
 
-	if !hvstConfig.NoDataPartition && hvstConfig.DataDisk == "" {
-		// Only use custom layout (which also creates Longhorn partition) when VM Disk is also
-		// not given
+	if hvstConfig.ShouldCreateDataPartitionOnOsDisk() {
+		// Use custom layout (which also creates Longhorn partition) when needed
 		cosPartLayout, err := config.CreateRootPartitioningLayout(hvstConfig.Install.Device)
 		if err != nil {
 			return err


### PR DESCRIPTION
- Remove a user-configurable config "Install.NoDataPartition" to reduce system complexity. It's now a derived setting from other config fields: "ForceMBR" and "DataDisk".

- Add methods "ShouldCreateDataPartitionOnOsDisk" and "ShouldMountDataPartition" for accessing the derived setting.

## Related issues
- https://github.com/harvester/harvester/issues/1907