### PR TITLE
fix1531 sync init value from charts for UI config usage

### DIFF
--- a/pkg/config/templates/rancherd-13-monitoring.yaml
+++ b/pkg/config/templates/rancherd-13-monitoring.yaml
@@ -31,8 +31,12 @@ bootstrapResources:
         prometheusSpec:
           evaluationInterval: 1m
           resources:
+            limits:
+              cpu: 1000m
+              memory: 2500Mi
             requests:
-              cpu: 500m
+              cpu: 750m
+              memory: 1750Mi
           retention: 5d
           retentionSize: 50GiB
           scrapeInterval: 1m


### PR DESCRIPTION
Harvester will open setting of monitoring for user config from UI, it is necessary to have init values for all fields, avoid blank values in WebUI.

Those values are same with (helm) charts in Harvester now, different value will overwrite (helm) charts and finally be effective in the POD setting.

Harvester issue:
https://github.com/harvester/harvester/issues/1531