### PR TITLE
Allow to installing on 64 GB USB Flash Disks

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,7 +30,7 @@ const (
 
 const (
 	SoftMinDiskSizeGiB   = 140
-	HardMinDiskSizeGiB   = 60
+	HardMinDiskSizeGiB   = 56
 	MinCosPartSizeGiB    = 25
 	NormalCosPartSizeGiB = 50
 )

--- a/pkg/config/cos_test.go
+++ b/pkg/config/cos_test.go
@@ -22,7 +22,7 @@ func TestCalcCosPersistentPartSize(t *testing.T) {
 		},
 		{
 			name:        "Disk meet hard requirement",
-			input:       60,
+			input:       56,
 			output:      25,
 			expectError: false,
 		},


### PR DESCRIPTION
HardMinDiskSizeGiB value decreased to 56

Because usable capacity is 57 GB on most devices.