### PR TITLE
Use harvester code info to patch harvester chart version and harvester image tag

### DIFF
--- a/scripts/build-bundle
+++ b/scripts/build-bundle
@@ -34,6 +34,9 @@ fi
 # This must be placed after cloning `harvester/harvester`` in case `make build-bundle` is run directly.
 source ${SCRIPTS_DIR}/version-harvester ${TOP_DIR}/../harvester
 
+# Replace harvester chart version
+${SCRIPTS_DIR}/patch-harvester ${TOP_DIR}/../harvester
+# Package harvester chart
 harvester_chart_path=${harvester_path}/deploy/charts/harvester
 harvester_crd_chart_path=${harvester_path}/deploy/charts/harvester-crd
 helm package ${harvester_chart_path} -d ${CHARTS_DIR}
@@ -135,8 +138,13 @@ if [ "$upgrade_image_tag" != "$HARVESTER_VERSION" ]; then
   docker tag "${upgrade_image_repo}:${upgrade_image_tag}" "${upgrade_image_repo}:${HARVESTER_VERSION}"
   image_list_file="${IMAGES_DIR}/harvester-extra-${VERSION}.txt"
   image_archive="${IMAGES_DIR}/harvester-extra-${VERSION}.tar"
-  echo "docker.io/${upgrade_image_repo}:${HARVESTER_VERSION}" > ${image_list_file}
+  echo "${upgrade_image_repo}:${HARVESTER_VERSION}" | awk -F '/' '{if(NF>=3){print $0} else if(NF==2){print "docker.io/"$0}}' > ${image_list_file}
   docker image save -o $image_archive $(<$image_list_file)
   zstd --rm $image_archive -o "${image_archive}.zst"
   add_image_list_to_metadata "common" $BUNDLE_DIR $image_list_file "${image_archive}.zst"
 fi
+
+# Revert harvester chart version patch to clean dirty git status
+pushd ${harvester_path}
+git checkout -- ./deploy/charts
+popd

--- a/scripts/patch-harvester
+++ b/scripts/patch-harvester
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+cd "${1}" || exit
+source ./scripts/version
+
+echo "Replace the Harvester chart version to ${CHART_VERSION}"
+yq e -i '.version = "'"${CHART_VERSION}"'"' ./deploy/charts/harvester/Chart.yaml
+yq e -i '.version = "'"${CHART_VERSION}"'"' ./deploy/charts/harvester-crd/Chart.yaml
+
+echo "Replace the Harvester appVersion to ${APP_VERSION}"
+yq e -i '.appVersion = "'"${APP_VERSION}"'"' ./deploy/charts/harvester/Chart.yaml
+yq e -i '.appVersion = "'"${APP_VERSION}"'"' ./deploy/charts/harvester-crd/Chart.yaml
+
+echo "Replace the Harvester image tag to ${IMAGE_PUSH_TAG}"
+yq e -i '.containers.apiserver.image.tag = "'"${IMAGE_PUSH_TAG}"'"' ./deploy/charts/harvester/values.yaml
+yq e -i '.webhook.image.tag = "'"${IMAGE_PUSH_TAG}"'"' ./deploy/charts/harvester/values.yaml
+yq e -i '.upgrade.image.tag = "'"${IMAGE_PUSH_TAG}"'"' ./deploy/charts/harvester/values.yaml

--- a/scripts/version
+++ b/scripts/version
@@ -6,8 +6,8 @@ if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
 fi
 
 COMMIT=$(git rev-parse --short HEAD)
-COMMIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-VERSION=${DRONE_TAG:-${COMMIT_BRANCH}}
+VERSION=${DRONE_TAG:-${DRONE_BRANCH}}
+VERSION=${VERSION:-"master"}
 
 if [[ -n "$DIRTY" ]]; then
     VERSION="${COMMIT}${DIRTY}"

--- a/scripts/version
+++ b/scripts/version
@@ -6,7 +6,8 @@ if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
 fi
 
 COMMIT=$(git rev-parse --short HEAD)
-VERSION=${DRONE_TAG:-master}
+COMMIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+VERSION=${DRONE_TAG:-${COMMIT_BRANCH}}
 
 if [[ -n "$DIRTY" ]]; then
     VERSION="${COMMIT}${DIRTY}"

--- a/scripts/version-harvester
+++ b/scripts/version-harvester
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 HARVESTER_VERSION=$(cd $1; source ./scripts/version &> /dev/null; echo $VERSION)
-HARVESTER_CHART_VERSION=$(cd $1; yq e .version ./deploy/charts/harvester/Chart.yaml --exit-status)
+HARVESTER_CHART_VERSION=$(cd $1; source ./scripts/version &> /dev/null; echo $CHART_VERSION)


### PR DESCRIPTION
We want to build iso for [harvester v1.0 branch](https://github.com/harvester/harvester/tree/v1.0)

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
1. If not a harvester-installer release, the default version of harvester-installer is always `master`. 
each iso build on different branches has the same name.
1. If not a harvester release, the default image tag of harvester chart is always `master-head`. 
1. If not a harvester release, the default chart version of harvester chart is always `0.0.0-dev`. 
1. If not a harvester release, the default chart appVersion of harvester chart is always `v0.0.0-dev`. 

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
1. In harvester, build chart version, image tag in `script/version`
1. In harvester-installer, try to use `DRONE_BRANCH` as the iso version
1. In harvester-installer, Add a script `patch-harvester` to patch harvester chart version and harvester image tag uses the harvester code info.

**Related issues**
https://github.com/harvester/harvester/issues/1817

**Dependent PR**
https://github.com/harvester/harvester/pull/1990

**Test plan**