### PR TITLE
fix 1531: expose resource config of prometheus-node-exporter and increase memory limit

### DIFF
--- a/pkg/config/templates/rancherd-13-monitoring.yaml
+++ b/pkg/config/templates/rancherd-13-monitoring.yaml
@@ -50,3 +50,11 @@ bootstrapResources:
                     storage: 50Gi
                 storageClassName: longhorn
                 volumeMode: Filesystem
+      prometheus-node-exporter:
+        resources:
+          limits:
+            cpu: 200m
+            memory: 180Mi
+          requests:
+            cpu: 100m
+            memory: 30Mi


### PR DESCRIPTION
Related issue:
https://github.com/harvester/harvester/issues/1531

https://github.com/harvester/harvester/issues/1531#issuecomment-1068183732
https://github.com/harvester/harvester/issues/1531#issuecomment-1073812670

The CPU and memory limit of prometheus-node-exporter need also be customized in Harvester, they are exposed to managedchart now, WebUI may also add configuration for it.

The default memoy limit of prometheus-node-exporter, `50Mi`, is not fully fit for Harvester usage, which is increased to 180Mi.

**Validation**:
The managedchart has those config, the memory limit is increased for the prometheus-node-exporter POD.
```
harv41:~ # kubectl get managedchart rancher-monitoring -n fleet-local -o JSON | more
{
    "apiVersion": "management.cattle.io/v3",
    "kind": "ManagedChart",

            },
            "prometheus-node-exporter": {
                "resources": {
                    "limits": {
                        "cpu": "200m",           (default value per Rancher)
                        "memory": "180Mi"     (default value is 50Mi)
                    },
                    "requests": {
                        "cpu": "100m",       (default value per Rancher)
                        "memory": "30Mi"  (default value per Rancher)
                    }
                }
            }
        },
        
harv41:~ # kubectl get pods -n cattle-monitoring-system -o JSON rancher-monitoring-prometheus-node-exporter-xrfdt | grep memory\" -2 --colour
                    "limits": {
                        "cpu": "200m",
                        "memory": "180Mi"
                    },
                    "requests": {
                        "cpu": "100m",
                        "memory": "30Mi"
                    }
                },
harv41:~ # 
        
```