### PR TITLE
Fix Ready status

### DIFF
--- a/pkg/console/util.go
+++ b/pkg/console/util.go
@@ -35,7 +35,6 @@ import (
 const (
 	rancherManagementPort = "443"
 	defaultHTTPTimeout    = 15 * time.Second
-	harvesterNodePort     = "30443"
 	automaticCmdline      = "harvester.automatic"
 	installFailureMessage = `
 ** Installation Failed **


### PR DESCRIPTION
Signed-off-by: futuretea <Hang.Yu@suse.com>

- check the Ready status by
```bash
curl -fk https://managementURL/version
```

- remove unused logics: `getFirstReadyMasterIP`

**Related issues**
https://github.com/harvester/harvester/issues/2022

**Test plan**

- Install harvester on a machine
- wait for it to show the 1st ready status
- try to access harvester via the URL
- harvester should only show ready status once it is fully ready.