### PR TITLE
Add versions of rancher dependencies and KubeVirt to release file

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -17,7 +17,7 @@ ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
 
 RUN zypper -n rm container-suseconnect && \
-    zypper -n install go1.16 git curl docker gzip tar wget zstd squashfs xorriso awk
+    zypper -n install go1.16 git curl docker gzip tar wget zstd squashfs xorriso awk jq
 RUN curl -sfL https://github.com/mikefarah/yq/releases/download/v4.21.1/yq_linux_${ARCH} -o /usr/bin/yq && chmod +x /usr/bin/yq
 RUN go get -u golang.org/x/lint/golint
 RUN go get -u golang.org/x/tools/cmd/goimports

--- a/scripts/collect-deps.sh
+++ b/scripts/collect-deps.sh
@@ -1,0 +1,87 @@
+#!/bin/bash -e
+# This script collets versions of various components for update.
+# For example:
+#
+# $ <script_name> /tmp/test.yaml
+#
+# will generate a YAML file like:
+#
+# ```
+# rancherDependencies:
+#   fleet:
+#     chart: 100.0.3+up0.3.9-rc6
+#     app: 0.3.9-rc6
+#   fleet-crd:
+#     chart: 100.0.3+up0.3.9-rc6
+#     app: 0.3.9-rc6
+#   rancher-webhook:
+#     chart: 1.0.4+up0.2.5-rc3
+#     app: 0.2.5-rc3
+# ```
+
+output_file=$1
+
+TOP_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
+SCRIPTS_DIR="${TOP_DIR}/scripts"
+WORKING_DIR=$(mktemp -d)
+
+source ${SCRIPTS_DIR}/version-rancher
+
+update_chart_app_versions()
+{
+  local index_file=$1
+  local name=$2
+  local min_version=$3
+  local output_file=$4
+  local chart_version
+  local app_version
+
+  local versions=$(mktemp)
+
+  yq e ".entries.${name}[].version" $index_file > $versions
+  echo $min_version >> $versions
+  chart_version="$(sort -V -r $versions | head -n1)"
+  app_version="$(CHART_VERSION=$chart_version yq e ".entries.${name}[] | select(.version == strenv(CHART_VERSION)) | .appVersion" $index_file)"
+
+  yq e ".rancherDependencies.$name.chart = \"$chart_version\"" -i $output_file
+  yq e ".rancherDependencies.$name.app = \"$app_version\"" -i $output_file
+}
+
+update_rancher_deps()
+{
+  local rancher_version=$1
+  local output_file=$2
+
+  local repo_hash
+  local cid_file="${WORKING_DIR}/rancher-cid"
+  local repo_index="${WORKING_DIR}/rancher-charts.yaml"
+  local fleet_versions="${WORKING_DIR}/fleet-versions.txt"
+  local webhook_versions="${WORKING_DIR}/webhook-versions.txt"
+  local rancher_image_envs="${WORKING_DIR}/rancher-envs.txt"
+  local rancher_image="rancher/rancher:$rancher_version"
+
+  # Get min verseion from rancher image's env variables
+  docker image inspect $rancher_image | jq '.[0].Config.Env' | yq e '.[]' - > "$rancher_image_envs"
+  CATTLE_FLEET_MIN_VERSION=$(bash -c "source $rancher_image_envs && echo \$CATTLE_FLEET_MIN_VERSION")
+  CATTLE_RANCHER_WEBHOOK_MIN_VERSION=$(bash -c "source $rancher_image_envs && echo \$CATTLE_RANCHER_WEBHOOK_MIN_VERSION")
+
+  # Extract rancher-charts helm index file
+  repo_hash=$(docker run --entrypoint=/bin/bash "$rancher_image" -c "ls /var/lib/rancher-data/local-catalogs/v2/rancher-charts | head -n1")
+  docker create --cidfile="$cid_file" "$rancher_image"
+  docker cp $(<$cid_file):/var/lib/rancher-data/local-catalogs/v2/rancher-charts/$repo_hash/index.yaml $repo_index
+  docker rm $(<$cid_file)
+
+  # Get the latest version >= min_version and update it to yaml file
+  update_chart_app_versions $repo_index fleet $CATTLE_FLEET_MIN_VERSION $output_file
+  update_chart_app_versions $repo_index fleet-crd $CATTLE_FLEET_MIN_VERSION $output_file
+  update_chart_app_versions $repo_index rancher-webhook $CATTLE_RANCHER_WEBHOOK_MIN_VERSION $output_file
+}
+
+
+if [ ! -e $output_file ]; then
+  touch $output_file
+fi
+
+update_rancher_deps "$RANCHER_VERSION" "$output_file"
+
+rm -rf $WORKING_DIR

--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -28,7 +28,11 @@ os: ${PRETTY_NAME}
 kubernetes: ${RKE2_VERSION}
 rancher: ${RANCHER_VERSION}
 monitoringChart: ${MONITORING_VERSION}
+kubevirt: ${HARVESTER_KUBEVIRT_VERSION}
 EOF
+
+# Collect dependencies' versions
+${SCRIPTS_DIR}/collect-deps.sh harvester-release.yaml
 
 docker build --pull \
 	--build-arg BASE_OS_IMAGE="${BASE_OS_IMAGE}" \

--- a/scripts/version-harvester
+++ b/scripts/version-harvester
@@ -2,3 +2,4 @@
 
 HARVESTER_VERSION=$(cd $1; source ./scripts/version &> /dev/null; echo $VERSION)
 HARVESTER_CHART_VERSION=$(cd $1; source ./scripts/version &> /dev/null; echo $CHART_VERSION)
+HARVESTER_KUBEVIRT_VERSION=$(yq e '.kubevirt-operator.containers.operator.image.tag' $1/deploy/charts/harvester/values.yaml)


### PR DESCRIPTION
During an upgrade, the upgrade script will check if various components
are upgraded to target versions.

`harvester-release.yaml` sample:
```
harvester: 2a65703
harvesterChart: 0.0.0-master-2a65703
os: Harvester e49d98d-dirty
kubernetes: v1.22.7+rke2r1
rancher: v2.6.4-rc10
monitoringChart: 100.1.0+up19.0.3

# new-added fields

kubevirt: 0.49.0-2
rancherDependencies:
  fleet:
    chart: 100.0.3+up0.3.9-rc6
    app: 0.3.9-rc6
  fleet-crd:
    chart: 100.0.3+up0.3.9-rc6
    app: 0.3.9-rc6
  rancher-webhook:
    chart: 1.0.4+up0.2.5-rc3
    app: 0.2.5-rc3
```

**Related Issue**

https://github.com/harvester/harvester/issues/1982