### PR TITLE
Add version.yaml

### DIFF
--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -74,3 +74,25 @@ xorriso -osirrox on -indev ${ARTIFACTS_DIR}/${ISO_PREFIX}.iso -extract /rootfs.s
 cd ${ARTIFACTS_DIR}
 CHECKSUM_FILE=${ISO_PREFIX}.sha512
 sha512sum ${PROJECT_PREFIX}* > $CHECKSUM_FILE
+
+ISO_CHECKSUM=$(awk -viso_name="${ISO_PREFIX}.iso" '$2~iso_name{print $1}' $CHECKSUM_FILE)
+if [ -z "$ISO_CHECKSUM" ]; then
+  echo "Fail to find Harvester ISO file checksum."
+  exit 1
+fi
+
+# Write version.yaml
+if [[ -n "${DRONE_TAG}" ]]; then
+	RELEASE_DATE=$(date +'%Y%m%d')
+	cat > version.yaml <<EOF
+apiVersion: harvesterhci.io/v1beta1
+kind: Version
+metadata:
+  name: ${VERSION}
+  namespace: harvester-system
+spec:
+  isoChecksum: ${ISO_CHECKSUM}
+  isoURL: https://releases.rancher.com/harvester/${VERSION}/${ISO_PREFIX}.iso
+  releaseDate: ${RELEASE_DATE}
+EOF
+fi


### PR DESCRIPTION
Generate `version.yaml` when we have a released tag for it.

Related issue: https://github.com/harvester/harvester/issues/2091

Test steps:

1. `export DRONE_TAG=v1.0.1`.
2. `make ci`
3. Check whether we have `version.yaml` under `dist/artifacts` and it format should be like the following.
```
apiVersion: harvesterhci.io/v1beta1
kind: Version
metadata:
  name: v1.0.1
  namespace: harvester-system
spec:
  isoChecksum: cf8d14804fedeae564a881344865357110d32fc03614bc9337518b814e23f46f6979d59ef0c04199f4bed2c88be187541e46f0bf168af8bcce9dc1def3d906ff
  isoURL: https://releases.rancher.com/harvester/v1.0.1/harvester-v1.0.1-amd64.iso
```