### PR TITLE
Bump rancher to v2.6.4-harvester1

### DIFF
--- a/package/harvester-os/files/usr/share/rancher/rancherd/config.yaml.d/50-defaults.yaml
+++ b/package/harvester-os/files/usr/share/rancher/rancherd/config.yaml.d/50-defaults.yaml
@@ -1,9 +1,9 @@
 rancherValues:
   rancherImagePullPolicy: IfNotPresent
   rancherImage: rancher/rancher
-  rancherImageTag: v2.6.4-rc10
+  rancherImageTag: v2.6.4-harvester1
   noDefaultAdmin: false
   features: multi-cluster-management=false,multi-cluster-management-agent=false
   useBundledSystemChart: true
   bootstrapPassword: admin
-rancherInstallerImage: rancher/system-agent-installer-rancher:v2.6.4-rc10
+rancherInstallerImage: rancher/system-agent-installer-rancher:v2.6.4-harvester1

--- a/scripts/images/rancher-images.txt
+++ b/scripts/images/rancher-images.txt
@@ -1,5 +1,5 @@
-docker.io/rancher/fleet-agent:v0.3.9-rc6
-docker.io/rancher/fleet:v0.3.9-rc6
+docker.io/rancher/fleet-agent:v0.3.9
+docker.io/rancher/fleet:v0.3.9
 docker.io/rancher/gitjob:v0.1.26
 docker.io/rancher/kubectl:v1.20.2
 docker.io/rancher/mirrored-grafana-grafana:7.5.11
@@ -13,8 +13,8 @@ docker.io/rancher/mirrored-prometheus-node-exporter:v1.2.2
 docker.io/rancher/mirrored-prometheus-operator-prometheus-config-reloader:v0.50.0
 docker.io/rancher/mirrored-prometheus-operator-prometheus-operator:v0.50.0
 docker.io/rancher/mirrored-prometheus-prometheus:v2.28.1
-docker.io/rancher/rancher-webhook:v0.2.5-rc3
-docker.io/rancher/rancher:v2.6.4-rc10
+docker.io/rancher/rancher-webhook:v0.2.5
+docker.io/rancher/rancher:v2.6.4-harvester1
 docker.io/rancher/shell:v0.1.16
 docker.io/rancher/shell:v0.1.8
 docker.io/rancher/system-agent:v0.2.3-suc

--- a/scripts/images/rancherd-bootstrap-images.txt
+++ b/scripts/images/rancherd-bootstrap-images.txt
@@ -1,2 +1,2 @@
-docker.io/rancher/system-agent-installer-rancher:v2.6.4-rc10
+docker.io/rancher/system-agent-installer-rancher:v2.6.4-harvester1
 docker.io/rancher/system-agent-installer-rke2:$RKE2_VERSION

--- a/scripts/version-rancher
+++ b/scripts/version-rancher
@@ -1,1 +1,1 @@
-RANCHER_VERSION="v2.6.4-rc10"
+RANCHER_VERSION="v2.6.4-harvester1"


### PR DESCRIPTION
Bump rancher to `v2.6.4-harvester1`.

Known issues
- https://github.com/rancher/rancher/issues/37113
- https://github.com/rancher/rancher/issues/37114
  - **Need to test the PR with Internet connectivity**