### PR TITLE
Add workaround for https://github.com/rancher/rancher/issues/37113

### DIFF
--- a/package/harvester-os/files/usr/share/rancher/rancherd/config.yaml.d/50-defaults.yaml
+++ b/package/harvester-os/files/usr/share/rancher/rancherd/config.yaml.d/50-defaults.yaml
@@ -6,4 +6,7 @@ rancherValues:
   features: multi-cluster-management=false,multi-cluster-management-agent=false
   useBundledSystemChart: true
   bootstrapPassword: admin
+  extraEnv:
+  - name: CATTLE_RANCHER_WEBHOOK_MIN_VERSION
+    value: "1.0.3+up0.2.5"
 rancherInstallerImage: rancher/system-agent-installer-rancher:v2.6.4-harvester1

--- a/scripts/collect-deps.sh
+++ b/scripts/collect-deps.sh
@@ -74,7 +74,11 @@ update_rancher_deps()
   # Get the latest version >= min_version and update it to yaml file
   update_chart_app_versions $repo_index fleet $CATTLE_FLEET_MIN_VERSION $output_file
   update_chart_app_versions $repo_index fleet-crd $CATTLE_FLEET_MIN_VERSION $output_file
-  update_chart_app_versions $repo_index rancher-webhook $CATTLE_RANCHER_WEBHOOK_MIN_VERSION $output_file
+
+  # temporary workaround for https://github.com/rancher/rancher/issues/37113
+  # update_chart_app_versions $repo_index rancher-webhook $CATTLE_RANCHER_WEBHOOK_MIN_VERSION $output_file
+  yq e ".rancherDependencies.rancher-webhook.chart = \"1.0.3+up0.2.5\"" -i $output_file
+  yq e ".rancherDependencies.rancher-webhook.app = \"0.2.5\"" -i $output_file
 }
 
 


### PR DESCRIPTION
- We need to temporarily hard-code the generated rancher-webhook versions in harvester-release.yaml.
- Also specify the minimum rancher-webhook chart versions via env variables when creating applying the rancher chart.

To test upgrade, the PR is needed: https://github.com/harvester/harvester/pull/2097