### PR TITLE
Bump Rancher to v2.6.4-rc15 

### DIFF
--- a/package/harvester-os/files/usr/share/rancher/rancherd/config.yaml.d/50-defaults.yaml
+++ b/package/harvester-os/files/usr/share/rancher/rancherd/config.yaml.d/50-defaults.yaml
@@ -1,9 +1,9 @@
 rancherValues:
   rancherImagePullPolicy: IfNotPresent
   rancherImage: rancher/rancher
-  rancherImageTag: v2.6.4-harvester1
+  rancherImageTag: v2.6.4-rc15
   noDefaultAdmin: false
   features: multi-cluster-management=false,multi-cluster-management-agent=false
   useBundledSystemChart: true
   bootstrapPassword: admin
-rancherInstallerImage: rancher/system-agent-installer-rancher:v2.6.4-harvester1
+rancherInstallerImage: rancher/system-agent-installer-rancher:v2.6.4-rc15

--- a/package/harvester-os/files/usr/share/rancher/rancherd/config.yaml.d/50-defaults.yaml
+++ b/package/harvester-os/files/usr/share/rancher/rancherd/config.yaml.d/50-defaults.yaml
@@ -6,7 +6,4 @@ rancherValues:
   features: multi-cluster-management=false,multi-cluster-management-agent=false
   useBundledSystemChart: true
   bootstrapPassword: admin
-  extraEnv:
-  - name: CATTLE_RANCHER_WEBHOOK_MIN_VERSION
-    value: "1.0.3+up0.2.5"
 rancherInstallerImage: rancher/system-agent-installer-rancher:v2.6.4-harvester1

--- a/scripts/collect-deps.sh
+++ b/scripts/collect-deps.sh
@@ -74,11 +74,7 @@ update_rancher_deps()
   # Get the latest version >= min_version and update it to yaml file
   update_chart_app_versions $repo_index fleet $CATTLE_FLEET_MIN_VERSION $output_file
   update_chart_app_versions $repo_index fleet-crd $CATTLE_FLEET_MIN_VERSION $output_file
-
-  # temporary workaround for https://github.com/rancher/rancher/issues/37113
-  # update_chart_app_versions $repo_index rancher-webhook $CATTLE_RANCHER_WEBHOOK_MIN_VERSION $output_file
-  yq e ".rancherDependencies.rancher-webhook.chart = \"1.0.3+up0.2.5\"" -i $output_file
-  yq e ".rancherDependencies.rancher-webhook.app = \"0.2.5\"" -i $output_file
+  update_chart_app_versions $repo_index rancher-webhook $CATTLE_RANCHER_WEBHOOK_MIN_VERSION $output_file
 }
 
 

--- a/scripts/images/rancher-images.txt
+++ b/scripts/images/rancher-images.txt
@@ -14,7 +14,7 @@ docker.io/rancher/mirrored-prometheus-operator-prometheus-config-reloader:v0.50.
 docker.io/rancher/mirrored-prometheus-operator-prometheus-operator:v0.50.0
 docker.io/rancher/mirrored-prometheus-prometheus:v2.28.1
 docker.io/rancher/rancher-webhook:v0.2.5
-docker.io/rancher/rancher:v2.6.4-harvester1
+docker.io/rancher/rancher:v2.6.4-rc15
 docker.io/rancher/shell:v0.1.16
 docker.io/rancher/shell:v0.1.8
 docker.io/rancher/system-agent:v0.2.3-suc

--- a/scripts/images/rancherd-bootstrap-images.txt
+++ b/scripts/images/rancherd-bootstrap-images.txt
@@ -1,2 +1,2 @@
-docker.io/rancher/system-agent-installer-rancher:v2.6.4-harvester1
+docker.io/rancher/system-agent-installer-rancher:v2.6.4-rc15
 docker.io/rancher/system-agent-installer-rke2:$RKE2_VERSION

--- a/scripts/version-rancher
+++ b/scripts/version-rancher
@@ -1,1 +1,1 @@
-RANCHER_VERSION="v2.6.4-harvester1"
+RANCHER_VERSION="v2.6.4-rc15"


### PR DESCRIPTION
- Bump rancher to v2.6.4-rc15
- Remove workaround https://github.com/harvester/harvester-installer/pull/259 because issues are resolved.

To test upgrade, please include https://github.com/harvester/harvester/pull/2100