### PR TITLE
Bump Rancher to v2.6.4-harvester3

### DIFF
--- a/package/harvester-os/files/usr/share/rancher/rancherd/config.yaml.d/50-defaults.yaml
+++ b/package/harvester-os/files/usr/share/rancher/rancherd/config.yaml.d/50-defaults.yaml
@@ -1,9 +1,9 @@
 rancherValues:
   rancherImagePullPolicy: IfNotPresent
   rancherImage: rancher/rancher
-  rancherImageTag: v2.6.4-harvester2
+  rancherImageTag: v2.6.4-harvester3
   noDefaultAdmin: false
   features: multi-cluster-management=false,multi-cluster-management-agent=false
   useBundledSystemChart: true
   bootstrapPassword: admin
-rancherInstallerImage: rancher/system-agent-installer-rancher:v2.6.4-harvester2
+rancherInstallerImage: rancher/system-agent-installer-rancher:v2.6.4-harvester3

--- a/scripts/images/rancher-images.txt
+++ b/scripts/images/rancher-images.txt
@@ -14,7 +14,7 @@ docker.io/rancher/mirrored-prometheus-operator-prometheus-config-reloader:v0.50.
 docker.io/rancher/mirrored-prometheus-operator-prometheus-operator:v0.50.0
 docker.io/rancher/mirrored-prometheus-prometheus:v2.28.1
 docker.io/rancher/rancher-webhook:v0.2.5
-docker.io/rancher/rancher:v2.6.4-harvester2
+docker.io/rancher/rancher:v2.6.4-harvester3
 docker.io/rancher/shell:v0.1.16
 docker.io/rancher/shell:v0.1.8
 docker.io/rancher/system-agent:v0.2.3-suc

--- a/scripts/images/rancherd-bootstrap-images.txt
+++ b/scripts/images/rancherd-bootstrap-images.txt
@@ -1,2 +1,2 @@
-docker.io/rancher/system-agent-installer-rancher:v2.6.4-harvester2
+docker.io/rancher/system-agent-installer-rancher:v2.6.4-harvester3
 docker.io/rancher/system-agent-installer-rke2:$RKE2_VERSION

--- a/scripts/version-rancher
+++ b/scripts/version-rancher
@@ -1,1 +1,1 @@
-RANCHER_VERSION="v2.6.4-harvester2"
+RANCHER_VERSION="v2.6.4-harvester3"


### PR DESCRIPTION
v2.6.4-harvester2 image doesn't contain rancher-webhook 1.0.4+up0.2.5