### PR TITLE
Quote releaseDate as string in version file

### DIFF
--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -91,8 +91,8 @@ metadata:
   name: ${VERSION}
   namespace: harvester-system
 spec:
-  isoChecksum: ${ISO_CHECKSUM}
+  isoChecksum: '${ISO_CHECKSUM}'
   isoURL: https://releases.rancher.com/harvester/${VERSION}/${ISO_PREFIX}.iso
-  releaseDate: ${RELEASE_DATE}
+  releaseDate: '${RELEASE_DATE}'
 EOF
 fi


### PR DESCRIPTION
Fix error:

```
╰─$ kubectl apply -f https://releases.rancher.com/harvester/v1.0.1-rc2/version.yaml
The Version "v1.0.1-rc2" is invalid: spec.releaseDate: Invalid value: "integer": spec.releaseDate in body must be of type string: "integer"
```