### PR TITLE
Check whether ntpServers input is empty

### DIFF
--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -1759,10 +1759,8 @@ func addNTPServersPanel(c *Console) error {
 				return err
 			}
 
-			// Go to next page when user give an empty input or
-			// when input servers can't be reached and users don't want to change it, we continue the process.
-			if ntpServers == "" ||
-				(userInputData.NTPServers == ntpServers && userInputData.HasCheckedNTPServers == true) {
+			// When input servers can't be reached and users don't want to change it, we continue the process.
+			if userInputData.NTPServers == ntpServers && userInputData.HasCheckedNTPServers == true {
 				return gotoNextPage()
 			}
 			// reset HasCheckedNTPServers if users change input
@@ -1791,6 +1789,11 @@ func addNTPServersPanel(c *Console) error {
 				userInputData.NTPServers = ntpServers
 				ntpServerList := strings.Split(ntpServers, ",")
 				c.config.OS.NTPServers = ntpServerList
+
+				if ntpServers == "" {
+					gotoSpinnerErrorPage(g, spinner, fmt.Sprintf("Empty NTP Server is not recommended. Press Enter to continue."))
+					return
+				}
 
 				if err = validateNTPServers(ntpServerList); err != nil {
 					logrus.Errorf("validate ntp servers: %v", err)


### PR DESCRIPTION
### Test steps

1. Install Harvester by ISO.
2. In the NTP page, remove default input.
3. Press Enter and we can see a warning message "Empty NTP Server is not recommended. Press Enter to continue.".
4. Press Enter again and we can go to the next page.
5. Press Esc and we can go back to the NTP page.
6. Press Enter and we can see the warning message.
7. Input a valid NTP server.
8. Press Enter. There should not have any error message and we can go to next page.

related issue:
https://github.com/harvester/harvester/issues/2119