### PR TITLE
Add boot test document

### DIFF
--- a/tests/boot.md
+++ b/tests/boot.md
@@ -1,0 +1,30 @@
+## Testing the ISO image
+
+This repo uses [luet-makeiso](https://github.com/Luet-lab/luet-makeiso) to produce a hybrid ISO image.
+A hybrid ISO image should be able to boot on older computers that boot with legacy BIOS as well as 
+newer computers that boot with UEFI BIOS.
+
+To test that the build artefact is bootable, here are two test cases you can execute. Both test cases
+depend on qemu and the UEFI test depends on the ovmf package, which is a port of the UEFI firmware to 
+the qemu virtual machine.
+
+## Legacy BIOS Boot Test
+
+```
+qemu-system-x86_64 -m 2048 \
+  -cdrom ../dist/artifacts/harvester-master-amd64.iso
+```
+
+This test passes only if it reaches the point where you choose between "Create Harvester cluster" or "Join Harvester Cluster"
+
+## UEFI BIOS Boot Test
+
+```
+qemu-system-x86_64 -m 2048 \
+  -cdrom ../dist/artifacts/harvester-master-amd64.iso
+  -bios ovmf-x86_64.bin
+```
+
+Note: On OpenSUSE, the `ovmf-x86_64.bin` file is in `/usr/share/qemu/`, on Ubuntu I had to use `find`.
+
+This test passes only if it reaches the point where you choose between "Create Harvester cluster" or "Join Harvester Cluster"


### PR DESCRIPTION
In the course of trying to resolve [Issue 2023 on the Harvester repo](https://github.com/harvester/harvester/issues/2023), I found a reliable way to test the two different boot modes of the build artifact of this repo. Currently the legacy BIOS boot mode __does not work__.

The reason there was some confusion about this was that newer motherboards with UEFI and the CSM (Compatibility Support Module) can technically boot the installer, but older motherboards without any UEFI option cannot.

These two tests I documented here reliably reproduce this issue, and they should be part of the installer repo.