### PR TITLE
Run "rke2-killall.sh" before shutdown

### DIFF
--- a/package/harvester-os/files/etc/systemd/system/rke2-shutdown.service
+++ b/package/harvester-os/files/etc/systemd/system/rke2-shutdown.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Kill RKE2 Containers for clean unmount
+DefaultDependencies=no
+RefuseManualStart=yes
+Before=reboot.target halt.target shutdown.target poweroff.target umount.target final.target
+
+[Install]
+RequiredBy=reboot.target halt.target shutdown.target poweroff.target umount.target final.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=-/usr/local/bin/rke2-killall.sh

--- a/package/harvester-os/files/etc/systemd/system/rke2-shutdown.service
+++ b/package/harvester-os/files/etc/systemd/system/rke2-shutdown.service
@@ -10,4 +10,4 @@ RequiredBy=reboot.target halt.target shutdown.target poweroff.target umount.targ
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=-/usr/local/bin/rke2-killall.sh
+ExecStart=/usr/sbin/rke2-kill-containers.sh

--- a/package/harvester-os/files/system/oem/91_rke2-shutdown.yaml
+++ b/package/harvester-os/files/system/oem/91_rke2-shutdown.yaml
@@ -1,0 +1,7 @@
+name: "Enable RKE2 shutdown service"
+stages:
+  initramfs:
+    - name: "enable rke2-shutdown.service"
+      if: 'grep -q root=LABEL=COS_ACTIVE /proc/cmdline && [ -n "$(blkid -L COS_ACTIVE)" ]'
+      commands:
+        - systemctl enable rke2-shutdown.service

--- a/package/harvester-os/files/usr/sbin/rke2-kill-containers.sh
+++ b/package/harvester-os/files/usr/sbin/rke2-kill-containers.sh
@@ -1,0 +1,50 @@
+#!/bin/bash -x
+
+# make sure we run as root
+if [ ! $(id -u) -eq 0 ]; then
+    echo "$(basename "${0}"): must be run as root" >&2
+    exit 1
+fi
+
+pschildren() {
+    ps -e -o ppid= -o pid= | \
+    sed -e 's/^\s*//g; s/\s\s*/\t/g;' | \
+    grep -w "^$1" | \
+    cut -f2
+}
+
+pstree() {
+    for pid in "$@"; do
+        echo ${pid}
+        for child in $(pschildren ${pid}); do
+            pstree ${child}
+        done
+    done
+}
+
+killtree_term() {
+    kill $(
+        { set +x; } 2>/dev/null;
+        pstree "$@";
+        set -x;
+    ) 2>/dev/null
+}
+
+killtree() {
+    kill -9 $(
+        { set +x; } 2>/dev/null;
+        pstree "$@";
+        set -x;
+    ) 2>/dev/null
+}
+
+getshims() {
+    ps -e -o pid= -o args= | sed -e 's/^ *//; s/\s\s*/\t/;' | grep -w 'rke2/data/[^/]*/bin/containerd-shim' | cut -f1
+}
+
+systemctl stop rke2-server.service || true
+systemctl stop rke2-agent.service || true
+
+killtree_term $({ set +x; } 2>/dev/null; getshims; set -x)
+sleep 15
+killtree $({ set +x; } 2>/dev/null; getshims; set -x)


### PR DESCRIPTION
Create a `rke2-shutdown.service` to run script `rke2-killall.sh` to stop all the running pods (containers) before system shutdown or reboot. One of the benefits is that system shutdown and reboot would be much faster.

The key component is the `Before=umount.target` so that the service will run `rke2-killall.sh` before systems started to unmount everything, including those Pods' volumes.

## Test plan
1. Deploy Harvester (one node would be sufficient). Wait for it to be Ready
2. Switch to Shell by pressing `F12`
3. Initiate the **graceful** shutdown process, e.g. by running the command `poweroff`
4. The system should be shut down **fairly quickly compared to the old version of Harvester**. One way to tell the difference is that in **an older Harvester**, the terminal would show the following message while shutting down:
![image](https://user-images.githubusercontent.com/5047724/162681321-8326d813-4584-44b2-990d-5aa03ea231bb.png)
and the shutdown process would be blocked for around 1 minute. **With this PR, those messages will not show at all.**
5. You can further test `reboot` command or operation such as *Press power button* to initiate the graceful shutdown/reboot process, and they all shouldn't be affected by the message shown above.

## TODOs
- [x] Upgrade: Validated that when upgrading from an older version of Harvester, the `rke2-shutdown.service` will be installed and enabled.

## Related
- https://github.com/harvester/harvester/issues/1876
- https://github.com/rancher/rke2/issues/2411#issue-1117223202 The `rke2-shutdown` service is inspired by the `systemd-unit.txt` provided by the author of the issue