### PR TITLE
Generate supportconfig for failed installations

### DIFF
--- a/package/harvester-os/files/usr/lib/supportconfig/plugins/harvester_plugin_console
+++ b/package/harvester-os/files/usr/lib/supportconfig/plugins/harvester_plugin_console
@@ -1,0 +1,7 @@
+#!/bin/bash
+if [ -f /var/log/console.log ]
+then
+  cat /var/log/console.log
+else
+  echo "no /var/log/console.log available yet"
+fi

--- a/package/harvester-os/files/usr/lib/supportconfig/plugins/harvester_plugin_rke2
+++ b/package/harvester-os/files/usr/lib/supportconfig/plugins/harvester_plugin_rke2
@@ -1,0 +1,7 @@
+#!/bin/bash
+if [ -f /run/cos/target/rke2.log ]
+then
+  cat /run/cos/target/rke2.log
+else
+  echo "no /run/cos/target/rke2.log available yet"
+fi

--- a/pkg/console/util.go
+++ b/pkg/console/util.go
@@ -448,6 +448,12 @@ func doInstall(g *gocui.Gui, hvstConfig *config.HarvesterConfig, webhooks Render
 	if err := execute(ctx, g, env, "/usr/sbin/harv-install"); err != nil {
 		webhooks.Handle(EventInstallFailed)
 		printToPanel(g, fmt.Sprintf(installFailureMessage, defaultLogFilePath), installPanel)
+		if hvstConfig.Debug {
+			err = execute(ctx, g, []string{}, "/sbin/supportconfig")
+			if err != nil {
+				printToPanel(g, fmt.Sprintf("support bundle collection failed %v", err), installPanel)
+			}
+		}
 		return err
 	}
 	webhooks.Handle(EventInstallSuceeded)

--- a/pkg/console/util.go
+++ b/pkg/console/util.go
@@ -453,7 +453,7 @@ func doInstall(g *gocui.Gui, hvstConfig *config.HarvesterConfig, webhooks Render
 			fileSuffix := fmt.Sprintf("harvester_%s", rand.String(5))
 			scErr := executeSupportconfig(ctx, fileSuffix)
 			if scErr != nil {
-				printToPanel(g, fmt.Sprintf("support bundle collection failed %v", err), installPanel)
+				printToPanel(g, fmt.Sprintf("support config collection failed %v", err), installPanel)
 			}
 			printToPanel(g, fmt.Sprintf("support config is available at /var/log/scc_%s.txz", fileSuffix), installPanel)
 		}


### PR DESCRIPTION
This PR is related to issue: https://github.com/harvester/harvester/issues/1864

The aim is to auto generate a supportconfig when `debug` is enabled in the installation, and the installation fails.

The PR also introduces two custom plugins to copy the rke2.log and console.log into the generated supportconfig to make it easier to troubleshoot failures.

To test:
* patch /usr/sbin/harv-install to `exit 1`
* pass a minimal config via a http endpoint to enable debug. This would look as follows:
```yaml
install:
  debug: true
```
* on installation failure, harvester-installer will trigger the generation of support config, and also run the two packaged plugins

![image](https://user-images.githubusercontent.com/19664014/163506179-24c23d8e-13b5-41d0-8272-ede9baba6439.png)

![image](https://user-images.githubusercontent.com/19664014/163506184-0659edf6-8acb-4837-81f5-bf903b2924d1.png)
