### PR TITLE
Update environment variables passed to harv-install script

### DIFF
--- a/package/harvester-os/files/usr/sbin/cos-installer-shutdown
+++ b/package/harvester-os/files/usr/sbin/cos-installer-shutdown
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-if [ "$_COS_INSTALL_POWER_OFF" = true ] || grep -q 'cos.install.power_off=true' /proc/cmdline; then
+if [ "$ELEMENTAL_POWER_OFF" = true ] || grep -q 'cos.install.power_off=true' /proc/cmdline; then
     poweroff -f
 else
     echo " * Rebooting system in 5 seconds (CTRL+C to cancel)"

--- a/package/harvester-os/files/usr/sbin/harv-install
+++ b/package/harvester-os/files/usr/sbin/harv-install
@@ -5,6 +5,13 @@ ISOMNT=/run/initramfs/live
 TARGET=/run/cos/target
 DATA_DISK_FSLABEL="HARV_LH_DEFAULT"
 
+# Update environment variables
+export ELEMENTAL_TARGET=$ELEMENTAL_DEVICE
+export ELEMENTAL_ISO=$ELEMENTAL_ISO_URL
+export ELEMENTAL_CLOUD_INIT=$ELEMENTAL_CONFIG_URL
+export QUIET=${ELEMENTAL_SILENT:+"--quiet"}
+export DEBUG=${ELEMENTAL_DEBUG:+"--debug"}
+
 clear_disk_label()
 {
     # Clear the label of partitions that has $DATA_DISK_FSLABEL to prevent misidentification
@@ -34,7 +41,7 @@ umount_target() {
 cleanup2()
 {
     sync
-    [ -n "$_COS_INSTALL_ISO_URL" ] && umount "$ISOMNT" || true
+    [ -n "$ELEMENTAL_ISO" ] && umount "$ISOMNT" || true
     [ -n "$ISOTEMP" ] && rm -f "$ISOTEMP"
     umount_target || true
     umount ${STATEDIR}
@@ -89,19 +96,19 @@ get_url()
 }
 
 check_iso(){
-    if [ -n "$_COS_INSTALL_ISO_URL" ]; then
+    if [ -n "$ELEMENTAL_ISO" ]; then
         echo "Checking ISO URL.."
-        check_url "$_COS_INSTALL_ISO_URL"
+        check_url "$ELEMENTAL_ISO"
     fi
 }
 
 get_iso()
 {
-    if [ -n "$_COS_INSTALL_ISO_URL" ]; then
+    if [ -n "$ELEMENTAL_ISO" ]; then
         echo "Downloading ISO.."
         ISOMNT=$(mktemp -d -p /tmp cos.XXXXXXXX.isomnt)
         ISOTEMP=$(mktemp -p ${TARGET}/usr/local cos.XXXXXXXX.iso)
-        get_url ${_COS_INSTALL_ISO_URL} ${ISOTEMP}
+        get_url ${ELEMENTAL_ISO} ${ISOTEMP}
         ISO_DEVICE=$(losetup --show -f $ISOTEMP)
         mount -o ro ${ISO_DEVICE} ${ISOMNT}
     fi
@@ -274,10 +281,10 @@ EOF
 
 update_grub_settings()
 {
-    if [ -z "${_COS_INSTALL_TTY}" ]; then
+    if [ -z "${ELEMENTAL_TTY}" ]; then
         TTY=$(tty | sed 's!/dev/!!')
     else
-        TTY=$_COS_INSTALL_TTY
+        TTY=$ELEMENTAL_TTY
     fi
 
     if [ -e "/dev/${TTY%,*}" ] && [ "$TTY" != tty1 ] && [ "$TTY" != console ] && [ -n "$TTY" ]; then
@@ -311,8 +318,8 @@ save_configs()
         cp $HARVESTER_CONFIG $save_dir/harvester.config
     fi
 
-    if [ -e "$_COS_PARTITION_LAYOUT" ]; then
-        cp $_COS_PARTITION_LAYOUT $save_dir/part-layout.config
+    if [ -e "$ELEMENTAL_PARTITION_LAYOUT" ]; then
+        cp $ELEMENTAL_PARTITION_LAYOUT $save_dir/part-layout.config
     fi
 }
 
@@ -357,15 +364,15 @@ trap cleanup exit
 check_iso
 
 # Follow the symbolic link to the real device
-install_device="$_COS_INSTALL_DEVICE"
-if [ -L "$_COS_INSTALL_DEVICE" ]; then
-  install_device=$(readlink -f "$_COS_INSTALL_DEVICE")
+install_device="$ELEMENTAL_TARGET"
+if [ -L "$ELEMENTAL_TARGET" ]; then
+  install_device=$(readlink -f "$ELEMENTAL_TARGET")
 fi
 
 clear_disk_label
 
-# Run cOS installer but do not let it fetch ISO and shutdown
-_COS_BOOTING_FROM_LIVE="true" _COS_INSTALL_ISO_URL="" INTERACTIVE=yes _COS_INSTALL_DEVICE="$install_device" cos install
+# Run elemental installer but do not let it fetch ISO and do not shutdown
+ELEMENTAL_ISO="" ELEMENTAL_TARGET="$install_device" ELEMENTAL_POWEROFF="" elemental ${QUIET} ${DEBUG} install
 
 # Format the data disk if needed
 do_data_disk_format

--- a/pkg/config/cos.go
+++ b/pkg/config/cos.go
@@ -476,7 +476,7 @@ func getAddStaticDNSServersCmd(servers []string) string {
 }
 
 func (c *HarvesterConfig) ToCosInstallEnv() ([]string, error) {
-	return ToEnv("_COS_INSTALL_", c.Install)
+	return ToEnv("ELEMENTAL_", c.Install)
 }
 
 // Returns Rancherd bootstrap resources

--- a/pkg/console/util.go
+++ b/pkg/console/util.go
@@ -438,7 +438,7 @@ func doInstall(g *gocui.Gui, hvstConfig *config.HarvesterConfig, webhooks Render
 			return err
 		}
 		defer os.Remove(cosPartLayoutFile)
-		env = append(env, fmt.Sprintf("_COS_PARTITION_LAYOUT=%s", cosPartLayoutFile))
+		env = append(env, fmt.Sprintf("ELEMENTAL_PARTITION_LAYOUT=%s", cosPartLayoutFile))
 	}
 
 	if hvstConfig.DataDisk != "" {

--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -14,7 +14,7 @@ source ${SCRIPTS_DIR}/version-rancher
 source ${SCRIPTS_DIR}/version-harvester ${TOP_DIR}/../harvester
 source ${SCRIPTS_DIR}/version-monitoring
 
-BASE_OS_IMAGE="rancher/harvester-os:20220407"
+BASE_OS_IMAGE="rancher/harvester-os:20220421"
 HARVESTER_OS_IMAGE=rancher/harvester-os:$VERSION
 
 cd ${PACKAGE_HARVESTER_OS_DIR}


### PR DESCRIPTION
Update the environment variables passed to the `harv-install` and `cos-installer-shutdown` script for `elemental` command. Do notice that elemental uses different names for several installation options, so we also need to adapt these new names in harv-install script.

~~We don't have to update the base-os version yet because `elemental` already exists in the current base-os: https://github.com/harvester/os2/releases/tag/20220407.~~
We do have to update the base OS version for the fix of https://github.com/rancher-sandbox/elemental/issues/164

# `HarvesterConfig.Install` fields and their corresponding environment variables
- ForceEFI: `ELEMENTAL_FORCE_EFI`
- Device: Positional arg or `ELEMENTAL_TARGET`
- ConfigURL: `ELEMENTAL_CLOUD_INIT`
- Silent: No env var. Must be specified by CLI arg `--quiet`
- ISOURL: `ELEMENTAL_ISO`
- PowerOff: `ELEMENTAL_POWEROFF`
- NoFormat: `ELEMENTAL_NO_FORMAT`
- Debug: No env var. Must be specified by CLI arg `--debug`
- TTY: `ELEMENTAL_TTY`
- ForceGPT: `ELEMENTAL_FORCE_GPT`

## Not in `HarvesterConfig.Install` but still required
- Custom partition layout file: `ELEMENTAL_PARTITION_LAYOUT`


# Todos
- [x] Test PXE installation
- [x] Air-gapped installation
- [x] Upgrade from older version of Harvester
- [x] Use `elemental` command to upgrade OS: https://github.com/harvester/harvester/pull/2166
    - Rebrand error: ![image](https://user-images.githubusercontent.com/5047724/163777088-038caed7-17de-4add-8b58-1ec498d7a8fb.png)
- [x] Fix `realpath: /run/netconfig/yp.conf: No such file or directory` 
    - `elemental` bug: https://github.com/rancher-sandbox/elemental/issues/164
    - Temporarily solved by add the symlink `/var/run -> /run` directly in `harv-install` script
    ![image](https://user-images.githubusercontent.com/5047724/163746275-167a36d1-21bd-4874-a528-b5dfc5a4a880.png)
- [ ] (Will submit other PR) Move the environment variables adaptation code from `harv-install` to Go
- [ ] (Will submit other PR) Develop some automated tests for base OS verification

# Related issues
- https://github.com/harvester/harvester/issues/2133

# Dependencies
- https://github.com/harvester/os2/pull/36