### PR TITLE
Added a diff to monitoring managed chart

### DIFF
--- a/pkg/config/templates/rancherd-13-monitoring.yaml
+++ b/pkg/config/templates/rancherd-13-monitoring.yaml
@@ -10,6 +10,18 @@ bootstrapResources:
     version: {{ .MonitoringChartVersion }}
     defaultNamespace: cattle-monitoring-system
     repoName: harvester-charts
+    diff:
+      comparePatches:
+        - apiVersion: admissionregistration.k8s.io/v1
+          kind: ValidatingWebhookConfiguration
+          name: rancher-monitoring-admission
+          operations:
+            - { "op": "remove", "path": "/webhooks" }
+        - apiVersion: admissionregistration.k8s.io/v1
+          kind: MutatingWebhookConfiguration
+          name: rancher-monitoring-admission
+          operations:
+            - { "op": "remove", "path": "/webhooks" }
     targets:
     - clusterName: local
       clusterSelector:


### PR DESCRIPTION
The PR adds a diff to the managed chart for monitoring and allows fleet to ignore changes to CA certificate injected at runtime.

This is related to issue: https://github.com/harvester/harvester/issues/2152

Post this change the fleet bundle associated with monitoring managed chart is reconciled correctly.