### PR TITLE
Resolve the device path before generating partition layout

### DIFF
--- a/pkg/config/cos.go
+++ b/pkg/config/cos.go
@@ -537,6 +537,11 @@ func CreateRootPartitioningLayout(devPath string) (*yipSchema.YipConfig, error) 
 		return nil, err
 	}
 
+	resolvedDevPath, err := filepath.EvalSymlinks(devPath)
+	if err != nil {
+		return nil, err
+	}
+
 	yipConfig := yipSchema.YipConfig{
 		Name: "Root partitioning layout",
 		Stages: map[string][]yipSchema.Stage{
@@ -545,7 +550,7 @@ func CreateRootPartitioningLayout(devPath string) (*yipSchema.YipConfig, error) 
 					Name: "Root partitioning layout",
 					Layout: yipSchema.Layout{
 						Device: &yipSchema.Device{
-							Path: devPath,
+							Path: resolvedDevPath,
 						},
 						Parts: []yipSchema.Partition{
 							{


### PR DESCRIPTION
Without resolving it first, elemental installation would fail.

## Test plan
1. Install Harvester with any node using PXE boot installation with setting `install.device` to /dev/disk/by-path instead of `/dev/vda`
2. Make sure installation succeeded

## Related issues
- https://github.com/harvester/harvester/issues/2256