### PR TITLE
Revert "Patch GRUB config: Add --no-floppy option"

### DIFF
--- a/package/harvester-os/files/usr/sbin/harv-install
+++ b/package/harvester-os/files/usr/sbin/harv-install
@@ -267,7 +267,7 @@ add_debug_grub_entry()
 {
     cat > "${STATEDIR}/grubmenu" << "EOF"
 menuentry "${display_name} (debug)" --id debug {
-  search --no-floppy --set=root --label COS_STATE
+  search.fs_label COS_STATE root
   set img=/cOS/active.img
   set label=COS_ACTIVE
   loopback loop0 /$img
@@ -296,14 +296,6 @@ update_grub_settings()
     if [ -n "$CRASH_KERNEL_PARAMS" ]; then
         sed -i "s/^set crash_kernel_params=.*/crash_kernel_params=\"${CRASH_KERNEL_PARAMS}\"/" ${TARGET}/etc/cos/bootargs.cfg
     fi
-
-    # PATCH: Adding '--no-floppy' option to search command
-    GRUB_CFG="${STATEDIR}/grub2/grub.cfg"
-    sed -i "s/search /search --no-floppy /" "$GRUB_CFG"
-    sed -i "s/search.fs_label /search --no-floppy --label /" "$GRUB_CFG"
-    sed -i "s/search.file /search --no-floppy --file /" "$GRUB_CFG"
-    sed -i "s/search.fs_uuid /search --no-floppy --fs-uuid /" "$GRUB_CFG"
-    sed -i -E 's/^(\s*search\b)(.*)root$/\1 --set=root\2/' "$GRUB_CFG"
 
     add_debug_grub_entry
 }

--- a/package/harvester-os/iso/boot/grub2/grub.cfg
+++ b/package/harvester-os/iso/boot/grub2/grub.cfg
@@ -1,4 +1,4 @@
-search --no-floppy --file --set=root /boot/kernel.xz
+search --file --set=root /boot/kernel.xz
 set default=0
 set timeout=10
 set timeout_style=menu


### PR DESCRIPTION
Reverts harvester/harvester-installer#266

The root cause is related to specific hardware: https://github.com/harvester/harvester/issues/2115#issuecomment-1118208280