### PR TITLE
Update for the latest Rancherd (v0.0.1-alpha13)

### DIFF
--- a/package/harvester-os/templates/91-harvester-bootstrap-repo.yaml
+++ b/package/harvester-os/templates/91-harvester-bootstrap-repo.yaml
@@ -1,4 +1,4 @@
-bootstrapResources:
+resources:
 - apiVersion: apps/v1
   kind: Deployment
   metadata:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -161,6 +161,7 @@ type HarvesterConfig struct {
 	OS                     `json:"os,omitempty"`
 	Install                `json:"install,omitempty"`
 	RuntimeVersion         string                    `json:"runtimeVersion,omitempty"`
+	RancherVersion         string                    `json:"rancherVersion,omitempty"`
 	HarvesterChartVersion  string                    `json:"harvesterChartVersion,omitempty"`
 	MonitoringChartVersion string                    `json:"monitoringChartVersion,omitempty"`
 	SystemSettings         map[string]string         `json:"systemSettings,omitempty"`

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -138,8 +138,8 @@ func TestHarvesterSystemSettingsRendering(t *testing.T) {
 		assert.Nil(t, err)
 
 		// Take the first one
-		loadedConf["bootstrapResources"][0].assertNameEqual(t, testCase.settingName)
-		loadedConf["bootstrapResources"][0].assertValueEqual(t, testCase.settingValue)
+		loadedConf["resources"][0].assertNameEqual(t, testCase.settingName)
+		loadedConf["resources"][0].assertValueEqual(t, testCase.settingValue)
 	}
 }
 
@@ -158,8 +158,8 @@ func TestHarvesterSystemSettingsRendering_MultipleSettings(t *testing.T) {
 	err = yaml.Unmarshal([]byte(content), &loadedConf)
 	assert.Nil(t, err)
 
-	assert.Equal(t, 2, len(loadedConf["bootstrapResources"]))
-	for _, setting := range loadedConf["bootstrapResources"] {
+	assert.Equal(t, 2, len(loadedConf["resources"]))
+	for _, setting := range loadedConf["resources"] {
 		switch setting.Value {
 		case "bar":
 			setting.assertNameEqual(t, "foo")
@@ -185,7 +185,7 @@ func TestHarvesterSystemSettingsRendering_AsEmptyArrayIfNoSetting(t *testing.T) 
 	err = yaml.Unmarshal([]byte(content), &loadedConf)
 	assert.Nil(t, err)
 
-	bootstrapResources, ok := loadedConf["bootstrapResources"]
+	bootstrapResources, ok := loadedConf["resources"]
 	assert.True(t, ok)
 	assert.NotNil(t, bootstrapResources)
 	assert.Equal(t, 0, len(bootstrapResources))
@@ -210,8 +210,8 @@ func TestHarvesterTokenRendering(t *testing.T) {
 	for _, testCase := range testCases {
 		// Renders the config into YAML manifest, then decode the YAML manifest and verify the content
 		conf := HarvesterConfig{
-			Token: testCase.token,
-			// RuntimeVersion: "DoesNotMatter",
+			Token:          testCase.token,
+			RancherVersion: "v0.0.0-fake", // Necessary to prevent rendering failed
 		}
 		content, err := render("rancherd-config.yaml", conf)
 		assert.Nil(t, err)

--- a/pkg/config/cos.go
+++ b/pkg/config/cos.go
@@ -33,6 +33,7 @@ const (
 var (
 	// Following variables are replaced by ldflags
 	RKE2Version            = ""
+	RancherVersion         = ""
 	HarvesterChartVersion  = ""
 	MonitoringChartVersion = ""
 
@@ -159,6 +160,9 @@ func overwriteRootfsStage(config *HarvesterConfig, stage *yipSchema.Stage) error
 func initRancherdStage(config *HarvesterConfig, stage *yipSchema.Stage) error {
 	if config.RuntimeVersion == "" {
 		config.RuntimeVersion = RKE2Version
+	}
+	if config.RancherVersion == "" {
+		config.RancherVersion = RancherVersion
 	}
 	if config.HarvesterChartVersion == "" {
 		config.HarvesterChartVersion = HarvesterChartVersion

--- a/pkg/config/templates/rancherd-10-harvester.yaml
+++ b/pkg/config/templates/rancherd-10-harvester.yaml
@@ -1,4 +1,4 @@
-bootstrapResources:
+resources:
 # create the cattle-monitoring-system namespace and SA upfront, so that kubevirt monitoring-operator integration can find it
 - apiVersion: v1
   kind: Namespace

--- a/pkg/config/templates/rancherd-11-monitoring-crd.yaml
+++ b/pkg/config/templates/rancherd-11-monitoring-crd.yaml
@@ -1,4 +1,4 @@
-bootstrapResources:
+resources:
 - apiVersion: management.cattle.io/v3
   kind: ManagedChart
   metadata:

--- a/pkg/config/templates/rancherd-12-monitoring-dashboard.yaml
+++ b/pkg/config/templates/rancherd-12-monitoring-dashboard.yaml
@@ -1,4 +1,4 @@
-bootstrapResources:
+resources:
 # need to pre-load those VM monitoring dashboards, required to create the `cattle-dashboards` namespace upfront
 # and keep those labels and annotations to avoid conflict from the operator
 - apiVersion: v1

--- a/pkg/config/templates/rancherd-13-monitoring.yaml
+++ b/pkg/config/templates/rancherd-13-monitoring.yaml
@@ -1,4 +1,4 @@
-bootstrapResources:
+resources:
 - apiVersion: management.cattle.io/v3
   kind: ManagedChart
   metadata:

--- a/pkg/config/templates/rancherd-20-harvester-settings.yaml
+++ b/pkg/config/templates/rancherd-20-harvester-settings.yaml
@@ -1,4 +1,4 @@
-bootstrapResources: {{ if not .SystemSettings -}} [] {{- else }}
+resources: {{ if not .SystemSettings -}} [] {{- else }}
 {{- range $name, $value := .SystemSettings }}
 - apiVersion: harvesterhci.io/v1beta1
   kind: Setting

--- a/pkg/config/templates/rancherd-21-harvester-clusternetworks.yaml
+++ b/pkg/config/templates/rancherd-21-harvester-clusternetworks.yaml
@@ -1,4 +1,4 @@
-bootstrapResources: {{ if not .ClusterNetworks -}} [] {{- else }}
+resources: {{ if not .ClusterNetworks -}} [] {{- else }}
 {{- range $name, $network := .ClusterNetworks }}
 - apiVersion: network.harvesterhci.io/v1beta1
   kind: ClusterNetwork

--- a/pkg/config/templates/rancherd-config.yaml
+++ b/pkg/config/templates/rancherd-config.yaml
@@ -6,5 +6,7 @@ role: cluster-init
 {{- end }}
 token: {{ printf "%q" .Token }}
 kubernetesVersion: {{ .RuntimeVersion }}
+rancherVersion: {{ .RancherVersion }}
+rancherInstallerImage: rancher/system-agent-installer-rancher:{{ .RancherVersion }}
 labels:
  - harvesterhci.io/managed=true

--- a/scripts/build
+++ b/scripts/build
@@ -18,15 +18,18 @@ source ${SCRIPTS_DIR}/version-harvester $harvester_path
 source ${SCRIPTS_DIR}/version-rke2
 source ${SCRIPTS_DIR}/version
 source ${SCRIPTS_DIR}/version-monitoring
+source ${SCRIPTS_DIR}/version-rancher
 
 echo "Installer version: ${VERSION}"
 echo "Harvester version: ${HARVESTER_VERSION}"
 echo "Harvester chart version: ${HARVESTER_CHART_VERSION}"
+echo "Rancher version: ${RANCHER_VERSION}"
 echo "Rancher monitoring version: ${MONITORING_VERSION}"
 
 mkdir -p bin
 
 LINKFLAGS="-X github.com/harvester/harvester-installer/pkg/config.RKE2Version=$RKE2_VERSION
+           -X github.com/harvester/harvester-installer/pkg/config.RancherVersion=$RANCHER_VERSION
            -X github.com/harvester/harvester-installer/pkg/version.Version=$VERSION
            -X github.com/harvester/harvester-installer/pkg/version.HarvesterVersion=$HARVESTER_VERSION
            -X github.com/harvester/harvester-installer/pkg/config.HarvesterChartVersion=$HARVESTER_CHART_VERSION

--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -14,7 +14,7 @@ source ${SCRIPTS_DIR}/version-rancher
 source ${SCRIPTS_DIR}/version-harvester ${TOP_DIR}/../harvester
 source ${SCRIPTS_DIR}/version-monitoring
 
-BASE_OS_IMAGE="rancher/harvester-os:20220421"
+BASE_OS_IMAGE="rancher/harvester-os:20220526"
 HARVESTER_OS_IMAGE=rancher/harvester-os:$VERSION
 
 cd ${PACKAGE_HARVESTER_OS_DIR}


### PR DESCRIPTION
- Bump harvester-os version
- Specify Rancher version in rancherd config
- Replace `bootstrapResources` with `resources` for Rancherd configs
- Fix testing

**Related issue**
https://github.com/harvester/harvester/issues/1933

## Dependencies
- https://github.com/harvester/os2/pull/38