### PR TITLE
Deactivate LVM and MD devices before installation

### DIFF
--- a/package/harvester-os/files/usr/sbin/harv-install
+++ b/package/harvester-os/files/usr/sbin/harv-install
@@ -369,6 +369,10 @@ if [ -L "$ELEMENTAL_TARGET" ]; then
   install_device=$(readlink -f "$ELEMENTAL_TARGET")
 fi
 
+# Tear down LVM and MD devices on the system, if the installing device is occuipied, the
+# partitioning operation could fail later. Be forgiven here.
+blkdeactivate --lvmoptions wholevg,retry --dmoptions force,retry --errors || true
+
 clear_disk_label
 
 # Run elemental installer but do not let it fetch ISO and do not shutdown


### PR DESCRIPTION
If the target device is occupied, the partitioning could fail.

Related Issue: https://github.com/harvester/harvester/issues/2230

**How to test**
- Install Centos or Ubuntu on a disk and choose LVM scheme. Note you can also manually create some LVs on a disk first, the key is to have LVs on the target disk. Here is an example:
  ```
  # assume /dev/vda
  rancher:~ # pvcreate /dev/vda
    Physical volume "/dev/vda" successfully created.
  rancher:~ # vgcreate test_vg /dev/vda
    Volume group "test_vg" successfully created
  rancher:~ # lvcreate -n test_lv -l 100%FREE test_vg
    Logical volume "test_lv" created.
  ```
- Reboot the system with Harvester ISO
- Check the LV is activated:
  ```
  rancher:~ # ls /dev/test_vg/test_lv -l
  lrwxrwxrwx 1 root root 7 May 24 09:53 /dev/test_vg/test_lv -> ../dm-0
  ```
- Install Harvester and the installation should succeed.