### PR TITLE
VIP panel: wrap info panel

### DIFF
--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -1595,6 +1595,8 @@ func addUpgradePanel(c *Console) error {
 }
 
 func addVIPPanel(c *Console) error {
+	setLocation := createVerticalLocator(c)
+
 	askVipMethodV, err := widgets.NewDropDown(c.Gui, askVipMethodPanel, askVipMethodLabel, getNetworkMethodOptions)
 	if err != nil {
 		return err
@@ -1697,19 +1699,20 @@ func addVIPPanel(c *Console) error {
 
 	askVipMethodV.PreShow = func() error {
 		c.Gui.Cursor = true
+		vipTextV.SetContent("")
 		return c.setContentByName(titlePanel, vipTitle)
 	}
 
-	maxX, maxY := c.Gui.Size()
-	askVipMethodV.SetLocation(maxX/8, maxY/8, maxX/8*7, maxY/8+2)
+	setLocation(askVipMethodV, 3)
 	c.AddElement(askVipMethodPanel, askVipMethodV)
 
-	vipV.SetLocation(maxX/8, maxY/8+3, maxX/8*7, maxY/8+5)
+	setLocation(vipV, 3)
 	c.AddElement(vipPanel, vipV)
 
 	vipTextV.FgColor = gocui.ColorRed
 	vipTextV.Focus = false
-	vipTextV.SetLocation(maxX/8, maxY/8+6, maxX/8*7, maxY/8+8)
+	vipTextV.Wrap = true
+	setLocation(vipTextV, 0)
 	c.AddElement(vipTextPanel, vipTextV)
 
 	return nil


### PR DESCRIPTION
The response message from DHCP servers could be more than one line.
Allow the panel to wrap text.

Related issue: https://github.com/harvester/harvester/issues/2224


**Test plans**
- Disable DHCPD and select `Automatic (DHCP)` method in the VIP panel. The error message should wrap.
<img width="1030" alt="Screen Shot 2022-05-27 at 4 00 46 PM" src="https://user-images.githubusercontent.com/1691518/170661505-5aa9c407-4b9e-4414-91dd-0efd9dd75926.png">

- Select the `Static` method and enter a very long text, the error message should wrap too.
<img width="1002" alt="Screen Shot 2022-05-27 at 4 23 15 PM" src="https://user-images.githubusercontent.com/1691518/170661533-8fb996c1-a17f-473b-b85b-0a411a3312a1.png">

- This PR also cleans the left-over error messages when jumping back to the DNS panel and jumping to the VIP panel again
  -  In the VIP panel, enter some error text in Static mode. An error message should display.
  -  Jump back to the DNS panel.
  -  Jump to the VIP panel. The error message should be clear.
