### PR TITLE
fix2361 increase grafana resource limit

### DIFF
--- a/pkg/config/templates/rancherd-13-monitoring.yaml
+++ b/pkg/config/templates/rancherd-13-monitoring.yaml
@@ -39,6 +39,13 @@ resources:
           type: pvc
           accessModes:
           - ReadWriteOnce
+        resources:
+          limits:
+            cpu: 200m
+            memory: 500Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
       prometheus:
         prometheusSpec:
           evaluationInterval: 1m


### PR DESCRIPTION
(1) Expose grafana pod resource setting managedchart rancher-monitoring 
(2) Increase grafana pod resource setting
current:
```
  resources:
    limits:
      memory: 200Mi --
      cpu: 200m
    requests:
      memory: 100Mi --
      cpu: 100m
```

after:
```
   resources: 
     limits:
       cpu: 200m
       memory: 500Mi --
     requests:
       cpu: 100m
       memory: 200Mi --

```


https://github.com/harvester/harvester/issues/2361