### PR TITLE
fix2282 grafana does not need pvc by default

### DIFF
--- a/pkg/config/templates/rancherd-13-monitoring.yaml
+++ b/pkg/config/templates/rancherd-13-monitoring.yaml
@@ -32,13 +32,6 @@ resources:
       alertmanager:
         enabled: false
       grafana:
-        persistence:
-          enabled: true
-          size: "10"
-          storageClassName: longhorn
-          type: pvc
-          accessModes:
-          - ReadWriteOnce
       prometheus:
         prometheusSpec:
           evaluationInterval: 1m


### PR DESCRIPTION
Grafana is integrated by rancher-monitoring and used in Harvester.

(1)It has a volume /var/lib/grafana, which is used for config and plugin, and the content are as below:
```
/usr/share/grafana $ ls /var/lib/grafana/ -alt
total 1792
drwxrwsrwx    4 root     472           4096 Jun  8 12:30 .
-rw-r-----    1 grafana  472        1814528 Jun  8 12:30 grafana.db
drwx--S---    2 grafana  472           4096 May 25 07:19 png
drwxr-sr-x    2 grafana  472           4096 May 25 07:18 plugins
drwxr-xr-x    1 root     root          4096 Oct  5  2021 ..
/usr/share/grafana $ ls /var/lib/grafana/plugins/ -alt
total 8
drwxrwsrwx    4 root     472           4096 Jun  8 12:30 ..
drwxr-sr-x    2 grafana  472           4096 May 25 07:18 .
/usr/share/grafana $ ls /var/lib/grafana/png -alt
total 8
drwxrwsrwx    4 root     472           4096 Jun  8 12:30 ..
drwx--S---    2 grafana  472           4096 May 25 07:19 .
/usr/share/grafana $ 
```

Currently, this volume is backed by pvc.
The pvc size is 10 Mb, it's fairly small.
```
GF_PATHS_DATA=/var/lib/grafana/
GF_PATHS_PLUGINS=/var/lib/grafana/plugins

                "volumeMounts": [
.
                    {
                        "mountPath": "/var/lib/grafana",
                        "name": "storage"
                    },                
        "volumes": [
..
            {
                "name": "storage",
                "persistentVolumeClaim": {
                    "claimName": "rancher-monitoring-grafana"
                }
            },
```

(2) By default, the pvc is not needed.
https://github.com/grafana/helm-charts/blob/main/charts/grafana/values.yaml#L285

(3) Per investigation, this embedded grafana does not have customize config that needs pvc to store and fetch.

(4) After this commit, the pvc is removed.

```
        "volumes": [
.
            {
                "emptyDir": {},
                "name": "storage"
            },
```
Without pvc, the grafana POD can (re)start faster
```
harv1:~ # kubectl delete pods -n cattle-monitoring-system rancher-monitoring-grafana-57777cc795-brtzw
pod "rancher-monitoring-grafana-57777cc795-brtzw" deleted

harv1:~ # kubectl get pods -A
NAMESPACE                   NAME                                                     READY   STATUS        RESTARTS   AGE
..
cattle-monitoring-system    rancher-monitoring-grafana-57777cc795-bs6g2              2/3     Running       0          9s
```

With this PR, https://github.com/harvester/harvester/issues/2013 is also partialy improved, grafana POD does not rely on PVC.

issue:
https://github.com/harvester/harvester/issues/2282