### PR TITLE
[Backport v1.0.3] VIP must be different from management NIC's IP

### DIFF
--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -1675,6 +1675,12 @@ func addVIPPanel(c *Console) error {
 			vipTextV.SetContent(fmt.Sprintf("Invalid VIP: %s", vip))
 			return nil
 		}
+
+		if vip != "" && vip == mgmtNetwork.IP {
+			vipTextV.SetContent("VIP must not be the same as management NIC's IP")
+			return nil
+		}
+
 		c.config.Vip = vip
 		c.config.VipHwAddr = ""
 


### PR DESCRIPTION
related backport issue: https://github.com/harvester/harvester/issues/2377
parent pr: https://github.com/harvester/harvester-installer/pull/283

### Test plan
#### ***The backport PR should use the same test plan as parent pr.***

0. Build the installer and run it.
1. Select `Static` as your IPv4 Method
2. Type a IP for management NIC
    <img src="https://user-images.githubusercontent.com/14314532/170925842-7976fc30-31f8-4771-84fc-cbf2b3c39ffc.png" width="70%">
3. Select `Static` as your VIP mode
4. Type the same IP as NIC management IP
    <img src="https://user-images.githubusercontent.com/14314532/170925829-de50236d-a444-46bb-af84-a9a145744fe8.png" width="70%">
5. Expect to see the error message **"VIP must not be the same as management NIC's IP"**.
