### PR TITLE
[WIP] bump rke2 to v1.22.12-rc3+rke2r1

### DIFF
--- a/package/harvester-os/files/usr/sbin/harv-install
+++ b/package/harvester-os/files/usr/sbin/harv-install
@@ -151,8 +151,11 @@ preload_rke2_images()
     fi
 
     RKE2_IMAGES_DIR="/var/lib/rancher/rke2/agent/images"
+    RKE2_IMAGES_LISTS_DIR="/tmp/images-lists"
     mkdir -p $TARGET/$RKE2_IMAGES_DIR
+    mkdir -p $TARGET/$RKE2_IMAGES_LISTS_DIR
     mount --bind ${ISOMNT}/bundle/harvester/images $TARGET/$RKE2_IMAGES_DIR
+    mount --bind ${ISOMNT}/bundle/harvester/images-lists $TARGET/$RKE2_IMAGES_LISTS_DIR
 
     cd $TARGET
     mount --bind /dev dev
@@ -192,7 +195,7 @@ preload_rke2_images()
       done
 
       # make sure all preloading images are ready
-      for i in /var/lib/rancher/rke2/agent/images/*.txt; do
+      for i in /tmp/images-lists/*.txt; do
         stdbuf -oL ctr-check-images.sh $i
       done
 
@@ -212,6 +215,7 @@ EOF
     umount proc
     cd - &> /dev/null
     umount ${TARGET}/${RKE2_IMAGES_DIR}
+    umount ${TARGET}/${RKE2_IMAGES_LISTS_DIR}
 }
 
 preload_rancherd_images()

--- a/scripts/build-bundle
+++ b/scripts/build-bundle
@@ -18,10 +18,12 @@ source ${SCRIPTS_DIR}/lib/image
 BUNDLE_DIR="${PACKAGE_HARVESTER_OS_DIR}/iso/bundle"
 CHARTS_DIR="${PACKAGE_HARVESTER_REPO_DIR}/charts"
 IMAGES_DIR="${BUNDLE_DIR}/harvester/images"
+IMAGES_LISTS_DIR="${BUNDLE_DIR}/harvester/images-lists"
 RANCHERD_IMAGES_DIR="${BUNDLE_DIR}/rancherd/images"
 
 mkdir -p ${CHARTS_DIR}
 mkdir -p ${IMAGES_DIR}
+mkdir -p ${IMAGES_LISTS_DIR}
 mkdir -p ${RANCHERD_IMAGES_DIR}
 
 # Prepare Harvester chart
@@ -70,26 +72,21 @@ sed -i "s,\$RKE2_VERSION,${RKE2_VERSION_NORMALIZED}," ${image_list_file}
 save_image "agent" $BUNDLE_DIR ${image_list_file} ${RANCHERD_IMAGES_DIR}
 
 # Rancher images
-image_list_file=${IMAGES_DIR}/rancher-images-${RANCHER_VERSION}.txt
+image_list_file=${IMAGES_LISTS_DIR}/rancher-images-${RANCHER_VERSION}.txt
 cp ${SCRIPTS_DIR}/images/rancher-images.txt $image_list_file
 save_image "common" $BUNDLE_DIR $image_list_file ${IMAGES_DIR}
 
 # RKE2 images
 RKE2_IMAGES_URL="${RKE2_IMAGE_REPO}${RKE2_VERSION}"
-image_list_file="${IMAGES_DIR}/rke2-images.linux-amd64-${RKE2_VERSION_NORMALIZED}.txt"
+image_list_file="${IMAGES_LISTS_DIR}/rke2-images.linux-amd64-${RKE2_VERSION_NORMALIZED}.txt"
 image_archive="${IMAGES_DIR}/rke2-images.linux-amd64-${RKE2_VERSION_NORMALIZED}.tar.zst"
 get_url "${RKE2_IMAGES_URL}/rke2-images.linux-amd64.txt" $image_list_file
 get_url "${RKE2_IMAGES_URL}/rke2-images.linux-amd64.tar.zst" $image_archive
 add_image_list_to_metadata "rke2" $BUNDLE_DIR $image_list_file $image_archive
 
 # exclude SR-IOV images
-image_list_file="${IMAGES_DIR}/rke2-images-multus.linux-amd64-${RKE2_VERSION_NORMALIZED}.txt"
-# save_image_list "rke2-images-multus" "${RKE2_IMAGES_URL}/rke2-images-multus.linux-amd64.txt" ${IMAGES_DIR}/rke2-images-multus.linux-amd64.txt
-# Workaround for https://github.com/rancher/rke2/issues/2229
-cat > $image_list_file <<EOF
-docker.io/rancher/hardened-cni-plugins:v0.9.1-build20211119
-docker.io/rancher/hardened-multus-cni:v3.7.1-build20211119
-EOF
+image_list_file="${IMAGES_LISTS_DIR}/rke2-images-multus.linux-amd64-${RKE2_VERSION_NORMALIZED}.txt"
+save_image_list "rke2-images-multus" "${RKE2_IMAGES_URL}/rke2-images-multus.linux-amd64.txt" $image_list_file
 
 save_image "rke2" $BUNDLE_DIR $image_list_file ${IMAGES_DIR}
 
@@ -128,8 +125,8 @@ awk -F '/' '{if(NF>=3){print $0} else if(NF==2){print "docker.io/"$0}else if(NF=
 sort -u "${image_list_file}.tmp" | \
 grep -Ev "local-path-provisioner|library-traefik|klipper-lb|multus" >"${image_list_file}"
 
-cp ${image_list_file} ${IMAGES_DIR}
-save_image "common" $BUNDLE_DIR ${IMAGES_DIR}/${image_list_file} ${IMAGES_DIR}
+cp ${image_list_file} ${IMAGES_LISTS_DIR}
+save_image "common" $BUNDLE_DIR ${IMAGES_LISTS_DIR}/${image_list_file} ${IMAGES_DIR}
 
 # Tag harvester-upgrade:master-head to harvester-upgrade:<version> and save the image to an archive
 # This makes it possible to upgrade a cluster with a master ISO.
@@ -137,7 +134,7 @@ upgrade_image_repo=$(yq -e e '.upgrade.image.repository' $values_file)
 upgrade_image_tag=$(yq -e e '.upgrade.image.tag' $values_file)
 if [ "$upgrade_image_tag" != "$HARVESTER_VERSION" ]; then
   docker tag "${upgrade_image_repo}:${upgrade_image_tag}" "${upgrade_image_repo}:${HARVESTER_VERSION}"
-  image_list_file="${IMAGES_DIR}/harvester-extra-${VERSION}.txt"
+  image_list_file="${IMAGES_LISTS_DIR}/harvester-extra-${VERSION}.txt"
   image_archive="${IMAGES_DIR}/harvester-extra-${VERSION}.tar"
   echo "${upgrade_image_repo}:${HARVESTER_VERSION}" | awk -F '/' '{if(NF>=3){print $0} else if(NF==2){print "docker.io/"$0}}' > ${image_list_file}
   docker image save -o $image_archive $(<$image_list_file)

--- a/scripts/images/rancher-images.txt
+++ b/scripts/images/rancher-images.txt
@@ -3,6 +3,7 @@ docker.io/rancher/fleet:v0.3.9
 docker.io/rancher/gitjob:v0.1.26
 docker.io/rancher/kubectl:v1.20.2
 docker.io/rancher/mirrored-grafana-grafana:7.5.11
+docker.io/rancher/mirrored-ingress-nginx-kube-webhook-certgen:v1.0
 docker.io/rancher/mirrored-ingress-nginx-kube-webhook-certgen:v1.1.1
 docker.io/rancher/mirrored-kiwigrid-k8s-sidecar:1.12.3
 docker.io/rancher/mirrored-kube-state-metrics-kube-state-metrics:v2.2.0

--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -14,7 +14,7 @@ source ${SCRIPTS_DIR}/version-rancher
 source ${SCRIPTS_DIR}/version-harvester ${TOP_DIR}/../harvester
 source ${SCRIPTS_DIR}/version-monitoring
 
-BASE_OS_IMAGE="rancher/harvester-os:20220705"
+BASE_OS_IMAGE="rancher/harvester-os:20220711"
 HARVESTER_OS_IMAGE=rancher/harvester-os:$VERSION
 
 cd ${PACKAGE_HARVESTER_OS_DIR}

--- a/scripts/package-harvester-repo
+++ b/scripts/package-harvester-repo
@@ -6,8 +6,10 @@ PACKAGE_HARVESTER_OS_DIR="${TOP_DIR}/package/harvester-os"
 PACKAGE_HARVESTER_REPO_DIR="${TOP_DIR}/package/harvester-repo"
 BUNDLE_DIR="${PACKAGE_HARVESTER_OS_DIR}/iso/bundle"
 IMAGES_DIR="${BUNDLE_DIR}/harvester/images"
+IMAGES_LISTS_DIR="${BUNDLE_DIR}/harvester/images-lists"
 
 mkdir -p ${IMAGES_DIR}
+mkdir -p ${IMAGES_LISTS_DIR}
 source ${SCRIPTS_DIR}/version
 source ${SCRIPTS_DIR}/lib/image
 
@@ -16,7 +18,7 @@ cd ${PACKAGE_HARVESTER_REPO_DIR}
 CLUSTER_REPO_IMAGE=rancher/harvester-cluster-repo:${VERSION}
 docker build -t ${CLUSTER_REPO_IMAGE} .
 
-repo_image_list_file="${IMAGES_DIR}/harvester-repo-images-${VERSION}.txt"
+repo_image_list_file="${IMAGES_LISTS_DIR}/harvester-repo-images-${VERSION}.txt"
 repo_image_archive="${IMAGES_DIR}/harvester-repo-images-${VERSION}.tar"
 
 # Save the image

--- a/scripts/version-rke2
+++ b/scripts/version-rke2
@@ -1,1 +1,1 @@
-RKE2_VERSION="v1.21.11+rke2r1"
+RKE2_VERSION="v1.22.12-rc3+rke2r1"


### PR DESCRIPTION
ref: https://github.com/harvester/harvester/issues/2336

**Test Steps**:
* Create a cluster.
* Check whether `kube-system/rke2-coredns-rke2-coredns-autoscaler` resources are
```
limits:
  cpu: 100m
  memory: 64Mi
requests:
  cpu: 25m
  memory: 16Mi
```