### PR TITLE
Use correct harvester/harvester branch

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -11,7 +11,7 @@ cd ${TOP_DIR}
 harvester_path=../harvester
 if [ ! -d ${harvester_path} ];then
     echo "No existed harvester source. Pulling..."
-    git clone --branch master --single-branch --depth 1 https://github.com/harvester/harvester.git ../harvester
+    git clone --branch v1.0 --single-branch --depth 1 https://github.com/harvester/harvester.git ../harvester
 fi
 
 source ${SCRIPTS_DIR}/version-harvester $harvester_path

--- a/scripts/build-bundle
+++ b/scripts/build-bundle
@@ -27,7 +27,7 @@ mkdir -p ${RANCHERD_IMAGES_DIR}
 harvester_path=../harvester
 if [ ! -d ${harvester_path} ];then
     echo "No existed harvester source. Pulling into /tmp/harvester"
-    git clone --branch master --single-branch --depth 1 https://github.com/harvester/harvester.git /tmp/harvester
+    git clone --branch v1.0 --single-branch --depth 1 https://github.com/harvester/harvester.git /tmp/harvester
     harvester_path=/tmp/harvester
 fi
 


### PR DESCRIPTION
Make sure we use the correct backend code when building from the `v1.0` branch.