### PR TITLE
Introduce Logic To Remove Duplicate DNS Entries

### DIFF
--- a/pkg/console/util.go
+++ b/pkg/console/util.go
@@ -197,8 +197,21 @@ func enableNTPServers(ntpServerList []string) error {
 	return nil
 }
 
+func _removeDuplicateDNSEntry(dnsServerList []string) []string {
+	allKeys := make(map[string]bool)
+	var list []string
+	for _, item := range dnsServerList {
+		if _, value := allKeys[item]; !value {
+			allKeys[item] = true
+			list = append(list, item)
+		}
+	}
+	return list
+}
+
 func updateDNSServersAndReloadNetConfig(dnsServerList []string) error {
-	dnsServers := strings.Join(dnsServerList, " ")
+	duplicatesRemovedDNSList := _removeDuplicateDNSEntry(dnsServerList)
+	dnsServers := strings.Join(duplicatesRemovedDNSList, " ")
 	output, err := exec.Command("sed", "-i", fmt.Sprintf(`s/^NETCONFIG_DNS_STATIC_SERVERS.*/NETCONFIG_DNS_STATIC_SERVERS="%s"/`, dnsServers), "/etc/sysconfig/network/config").CombinedOutput()
 	if err != nil {
 		logrus.Error(err, string(output))

--- a/pkg/console/util_test.go
+++ b/pkg/console/util_test.go
@@ -181,6 +181,15 @@ func TestValidateNTPServers(t *testing.T) {
 	close(quit)
 }
 
+func TestDuplicateDNSEntriesGetRemoved(t *testing.T) {
+	dnsTestListWithDuplicates := []string{"1.1.1.1", "1.1.1.1", "8.8.8.8", "8.8.8.8", "8.8.4.4"}
+	resultWithDuplicates := _removeDuplicateDNSEntry(dnsTestListWithDuplicates)
+	assert.Equal(t, 3, len(resultWithDuplicates))
+	dnsTestListNoDuplicates := []string{"1.1.1.1", "8.8.8.8", "8.8.4.4"}
+	resultNoDuplicates := _removeDuplicateDNSEntry(dnsTestListNoDuplicates)
+	assert.Equal(t, 3, len(resultNoDuplicates))
+}
+
 func startMockNTPServers(quit chan interface{}) ([]string, error) {
 	ntpServers := []string{}
 	for i := 0; i < 2; i++ {


### PR DESCRIPTION
* util private function introduced to remove duplicate DNS entries that
  may get passed in during installation
* additional test case for helper function added

Resolves: feat/remove-duplicate-dns-entries