### PR TITLE
Bump the rke2 to official v1.22.12 release

### DIFF
--- a/scripts/version-rke2
+++ b/scripts/version-rke2
@@ -1,1 +1,1 @@
-RKE2_VERSION="v1.22.12-rc3+rke2r1"
+RKE2_VERSION="v1.22.12+rke2r1"


### PR DESCRIPTION
**Description:**
Bump the rke2 to the official [v1.22.12 release](https://github.com/rancher/rke2/releases/tag/v1.22.12%2Brke2r1) and it is identical to the previous [rc3 release](https://github.com/rancher/rke2/releases/tag/v1.22.12-rc3%2Brke2r1).