### PR TITLE
Bump the rke2 to official v1.22.12 release

### DIFF
--- a/scripts/version-rke2
+++ b/scripts/version-rke2
@@ -1,1 +1,1 @@
-RKE2_VERSION="v1.22.12-rc3+rke2r1"
+RKE2_VERSION="v1.22.12+rke2r1"


### PR DESCRIPTION
port https://github.com/harvester/harvester-installer/pull/313 to master, let's keep both branches consistent at this moment.