### PR TITLE
console: install: bond: make a map to avoid execute set default bondMode

### DIFF
--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -1049,6 +1049,10 @@ func addNetworkPanel(c *Console) error {
 	askBondModeV.PreShow = func() error {
 		if mgmtNetwork.BondOptions == nil {
 			askBondModeV.Value = config.BondModeActiveBackup
+			mgmtNetwork.BondOptions = map[string]string{
+				"mode":   config.BondModeActiveBackup,
+				"miimon": "100",
+			}
 		}
 		return nil
 	}


### PR DESCRIPTION
### Root Cause:

`mgmtNetwork.BondOptions` will `nil` until `askBondModeVConfirm` is executed first time.
`PreShow` will be executed multiple times and set BondMode back to the default value in the first time.

### Fix

While setting default bond mode, let installer set BondOptions to non-null map to avoid.
https://github.com/harvester/harvester-installer/pull/320

### Workaround

Choose bond mode twice or more to set the correct value.

### Test Plan

1. select other bond mode than default one
2. continue install option until showing all config yaml before installation
3. check installation yaml has correct bond mode.

![image](https://user-images.githubusercontent.com/2821179/185289044-086c79d6-4f9a-4ccd-83e7-37b34708991e.png)


related: https://github.com/harvester/harvester/issues/2675

test plan: https://github.com/harvester/harvester/issues/2675


Signed-off-by: Date Huang <date.huang@suse.com>