### PR TITLE
feat2517 Harvester-installer support alertmanager

### DIFF
--- a/pkg/config/templates/rancherd-13-monitoring.yaml
+++ b/pkg/config/templates/rancherd-13-monitoring.yaml
@@ -30,7 +30,33 @@ resources:
           operator: DoesNotExist
     values:
       alertmanager:
-        enabled: false
+        enabled: true
+        config:
+          global:
+            resolve_timeout: 5m
+        service:
+          port: 9093
+        alertmanagerSpec:
+          {{- if .Vip }}
+          externalUrl: "https://{{ .Vip }}/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-alertmanager:9093/proxy/"
+          {{- end }}
+          retention: 120h
+          storage:
+            volumeClaimTemplate:
+              spec:
+                storageClassName: longhorn
+                accessModes:
+                - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: 5Gi
+          resources:
+            limits:
+              memory: 600Mi
+              cpu: 1000m
+            requests:
+              memory: 100Mi
+              cpu: 100m
       grafana:
         persistence:
           enabled: true
@@ -40,6 +66,8 @@ resources:
           accessModes:
           - ReadWriteOnce
       prometheus:
+        service:
+          port: 9090
         prometheusSpec:
           evaluationInterval: 1m
           resources:
@@ -62,6 +90,9 @@ resources:
                     storage: 50Gi
                 storageClassName: longhorn
                 volumeMode: Filesystem
+          {{- if .Vip }}
+          externalUrl: "https://{{ .Vip }}/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-prometheus:9090/proxy/"
+          {{- end }}
       prometheus-node-exporter:
         resources:
           limits:

--- a/scripts/images/allow.yaml
+++ b/scripts/images/allow.yaml
@@ -16,6 +16,7 @@ rancher:
   - docker.io/rancher/mirrored-prometheus-operator-prometheus-config-reloader
   - docker.io/rancher/mirrored-prometheus-operator-prometheus-operator
   - docker.io/rancher/mirrored-prometheus-prometheus
+  - docker.io/rancher/mirrored-prometheus-alertmanager
   - docker.io/rancher/mirrored-kiwigrid-k8s-sidecar
   - docker.io/rancher/mirrored-library-busybox
   - docker.io/rancher/mirrored-grafana-grafana

--- a/scripts/images/rancher-images.txt
+++ b/scripts/images/rancher-images.txt
@@ -14,6 +14,7 @@ docker.io/rancher/mirrored-prometheus-node-exporter:v1.2.2
 docker.io/rancher/mirrored-prometheus-operator-prometheus-config-reloader:v0.50.0
 docker.io/rancher/mirrored-prometheus-operator-prometheus-operator:v0.50.0
 docker.io/rancher/mirrored-prometheus-prometheus:v2.28.1
+docker.io/rancher/mirrored-prometheus-alertmanager:v0.22.2
 docker.io/rancher/rancher-webhook:v0.2.5
 docker.io/rancher/rancher:v2.6.4-harvester3
 docker.io/rancher/shell:v0.1.16


### PR DESCRIPTION
  Enable alertmanager in managedchart
  Export essential parameters
  Use PVC to store alert data
  Export externalUrl for return access

Signed-off-by: Jian Wang <w13915984028@gmail.com>

**Problem:**

Harvester support alertmanager.

**Solution:**

Default enable. (It's very helpful to know all the alerts right from system startsup). User can disable in Harvester dashboard setting `monitoring`.  cc:  @DaiYuzeng @guangbochen @bk201 
Alertmanager has one POD in the cluster, it takes around `50Mi` of memory.

```
harv1:~ # kubectl top pod -A
..
NAMESPACE                   NAME                                                     CPU(cores)   MEMORY(bytes)   

cattle-monitoring-system    alertmanager-rancher-monitoring-alertmanager-0           1m           50Mi            
cattle-monitoring-system    prometheus-rancher-monitoring-prometheus-0               78m          530Mi           
harvester-system            harvester-756cd66d6d-dcv2g                               23m          375Mi           
harvester-system            harvester-load-balancer-59bf75f489-sm5kv                 2m           29Mi 
```

PVC: 5GB to storge data.

Add longhorn related prometheus config, that will generate statistics and alarms
Fix kubevirtoperatordown issue

**Related Issue:**
https://github.com/harvester/harvester/issues/2517
https://github.com/harvester/harvester/issues/2518
https://github.com/harvester/harvester/issues/2619
https://github.com/harvester/harvester/issues/2621

HEP (will be committed in another PR):
https://github.com/w13915984028/harvester/blob/fix2517/enhancements/20220720-alertmanager.md

**Test plan:**

Per HEP

The commit in Harvester:
https://github.com/harvester/harvester/pull/2678