### PR TITLE
Set iommu=on for Intel or AMD

### DIFF
--- a/package/harvester-os/files/etc/cos/bootargs.cfg
+++ b/package/harvester-os/files/etc/cos/bootargs.cfg
@@ -2,9 +2,9 @@ set console_params="console=tty1"
 set kernel=/boot/vmlinuz
 set crash_kernel_params="crashkernel=219M,high crashkernel=72M,low"
 if [ -n "$recoverylabel" ]; then
-    set kernelcmd="$console_params root=live:LABEL=$recoverylabel rd.live.dir=/ rd.live.squashimg=$img panic=0 net.ifnames=1 rd.cos.oemtimeout=120"
+    set kernelcmd="$console_params root=live:LABEL=$recoverylabel rd.live.dir=/ rd.live.squashimg=$img panic=0 net.ifnames=1 rd.cos.oemtimeout=120 iommu"
 else
-    set kernelcmd="$console_params root=LABEL=$label cos-img/filename=$img panic=0 net.ifnames=1 rd.cos.oemtimeout=120 rd.cos.oemlabel=COS_OEM audit=1 audit_backlog_limit=8192"
+    set kernelcmd="$console_params root=LABEL=$label cos-img/filename=$img panic=0 net.ifnames=1 rd.cos.oemtimeout=120 rd.cos.oemlabel=COS_OEM audit=1 audit_backlog_limit=8192 iommu"
 fi
 
 set initramfs=/boot/initrd

--- a/package/harvester-os/files/usr/sbin/harv-install
+++ b/package/harvester-os/files/usr/sbin/harv-install
@@ -295,6 +295,13 @@ update_grub_settings()
         sed -i "s/console_params=\"console=tty1\"/console_params=\"console=${TTY} console=tty1\"/g" ${TARGET}/etc/cos/bootargs.cfg
     fi
 
+    # IOMMU system is used for PCI passthrough
+    if [[ "GenuineIntel" == $(awk < /proc/cpuinfo -F: '/vendor_id/ {print $2; exit}' |  tr -d '[:space:]') ]]; then
+        sed -i "s/iommu/intel_iommu=on/g" ${TARGET}/etc/cos/bootargs.cfg
+    else
+        sed -i "s/iommu/amd_iommu=on/g" ${TARGET}/etc/cos/bootargs.cfg
+    fi
+
     # calculate recommended crashkernel allocation size
     CRASH_KERNEL_PARAMS=$(get_crashkernel_params || true)
     if [ -n "$CRASH_KERNEL_PARAMS" ]; then


### PR DESCRIPTION
This sets the necessary kernel parameters for [PCI Passthrough](https://github.com/harvester/harvester/issues/992). 

# Testing
I built and installed this on my bare metal Dell T7500 server. I rebooted and verified that the `intel_iommu=on` boot args are in the grub config.
![IMG_9150](https://user-images.githubusercontent.com/261552/185710390-330e7b20-ffd0-4731-9f1f-652505806c7a.jpeg)

