### PR TITLE
fix2282 adjust grafana POD PVC size to 2GiB

### DIFF
--- a/pkg/config/templates/rancherd-13-monitoring.yaml
+++ b/pkg/config/templates/rancherd-13-monitoring.yaml
@@ -34,7 +34,7 @@ resources:
       grafana:
         persistence:
           enabled: true
-          size: "10"
+          size: 2Gi
           storageClassName: longhorn
           type: pvc
           accessModes:


### PR DESCRIPTION
Signed-off-by: Jian Wang <w13915984028@gmail.com>

fix2282 adjust grafana POD PVC size to 2GiB

https://github.com/harvester/harvester/issues/2282

Upgrade patch:
https://github.com/harvester/harvester/pull/2711

Note:
The upgrade patch will make sure the claimed `PVC size` is 2Gi after upgrading. But the existing grafana PVC is not affected, it is still 10Mb (the smallest size LH gives)

How to patch existing PVC, needs more investigation.
(more scripts like disable grafana, delete PVC, re-enable grafana; or accordging to PVC reset steps as per LH's document; both of them are more than quick inheritage from current upgrading framework @bk201 @guangbochen
)