### PR TITLE
feat(upgrade): inject minUpgradableVersion into OS image

### DIFF
--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -29,6 +29,7 @@ kubernetes: ${RKE2_VERSION}
 rancher: ${RANCHER_VERSION}
 monitoringChart: ${MONITORING_VERSION}
 kubevirt: ${HARVESTER_KUBEVIRT_VERSION}
+minUpgradableVersion: ${HARVESTER_MIN_UPGRADABLE_VERSION}
 EOF
 
 # Collect dependencies' versions

--- a/scripts/version-harvester
+++ b/scripts/version-harvester
@@ -3,3 +3,4 @@
 HARVESTER_VERSION=$(cd $1; source ./scripts/version &> /dev/null; echo $VERSION)
 HARVESTER_CHART_VERSION=$(cd $1; source ./scripts/version &> /dev/null; echo $CHART_VERSION)
 HARVESTER_KUBEVIRT_VERSION=$(yq e '.kubevirt-operator.containers.operator.image.tag' $1/deploy/charts/harvester/values.yaml)
+HARVESTER_MIN_UPGRADABLE_VERSION=$(cd $1; source ./scripts/version &> /dev/null; echo $MIN_UPGRADABLE_VERSION)


### PR DESCRIPTION
A version string specifying the minimum version required to be able to upgrade is injected into `harvester-release.yaml` for further usage.

Related issue: harvester/harvester#2431
Related PR: harvester/harvester#2730

Signed-off-by: Zespre Chang <zespre.chang@suse.com>