### PR TITLE
fix(install_panels): add a field for MTU config

### DIFF
--- a/pkg/console/constant.go
+++ b/pkg/console/constant.go
@@ -24,6 +24,7 @@ const (
 	hostNamePanel          = "hostname"
 	addressPanel           = "address"
 	gatewayPanel           = "gateway"
+	mtuPanel               = "mtu"
 	dnsServersPanel        = "dnsServers"
 	networkValidatorPanel  = "networkValidator"
 	diskValidatorPanel     = "diskValidator"
@@ -49,6 +50,7 @@ const (
 	hostNameLabel         = "HostName"
 	addressLabel          = "IPv4 Address"
 	gatewayLabel          = "Gateway"
+	mtuLabel              = "MTU (optional)"
 	dnsServersLabel       = "DNS Servers"
 	ntpServersLabel       = "NTP Servers"
 

--- a/pkg/console/validator.go
+++ b/pkg/console/validator.go
@@ -151,6 +151,19 @@ func checkIP(addr string) error {
 	return nil
 }
 
+func checkMTU(mtu int) error {
+	// Treat 0 as default value
+	if mtu == 0 {
+		return nil
+	} else {
+		// RFC 791
+		if mtu < 576 || mtu > 9000 {
+			return fmt.Errorf("%d is not a valid MTU value", mtu)
+		}
+		return nil
+	}
+}
+
 func checkHwAddr(hwAddr string) error {
 	if _, err := net.ParseMAC(hwAddr); err != nil {
 		return fmt.Errorf("%s is an invalid hardware address, error: %w", hwAddr, err)
@@ -211,6 +224,9 @@ func checkNetworks(network config.Network, dnsServers []string) error {
 			return err
 		}
 		if err := checkIP(network.Gateway); err != nil {
+			return err
+		}
+		if err := checkMTU(network.MTU); err != nil {
 			return err
 		}
 	default:


### PR DESCRIPTION
**Problem:**

Users are not able to configure `harvester-mgmt` bond with the desired MTU value via ISO installation. This could be a problem while the target machine being provisioned resides on a network whose path MTU is below 1500 bytes.

**Solution:**

Along with the ISO installation, users can configure the bond's MTU on the network configuration page when choosing the "Static" option for "IPv4 Method".

Configure MTU value:
<img width="1278" alt="Screen Shot 2022-09-24 at 00 20 48" src="https://user-images.githubusercontent.com/1827717/192014657-13a2fbb8-bd97-4e89-b748-fe452b597c16.png">

Confirm that the MTU is shown on the page:
<img width="1277" alt="Screen Shot 2022-09-24 at 01 12 47" src="https://user-images.githubusercontent.com/1827717/192017124-19ec1f91-5ba0-4125-b593-46e12f9b3de1.png">

Press <Alt+F2> and execute `ip addr` after applied the network config to see if the MTU is being set:
<img width="997" alt="Screen Shot 2022-09-24 at 00 21 59" src="https://user-images.githubusercontent.com/1827717/192017236-1e5dba0d-57b9-4dbe-afcd-706647e4dea4.png">

**Related Issue:**

harvester/harvester#2437

**Test plan:**

1. Spin up a node with Harvester ISO installation
2. Go through installation steps
3. On the network configuration page, select "Static" in the network method field then the MTU field will show up
4. Configure IP address, gateway, and MTU with a value (should be in the range of 576 ~ 9000)
5. Go through the remaining installation steps
6. On the confirm page, check if the MTU value shown on the page
7. Proceed with the installation
8. After the installation succeeded, get into the node and check the MTU value on the uplink interface, management bridge and bond interface
<img width="996" alt="Screen Shot 2022-09-24 at 00 55 20" src="https://user-images.githubusercontent.com/1827717/192015759-f2e7b2a6-cc0c-4856-bca8-ac978cd2d3f4.png">
