### PR TITLE
fix: change update ca stage

### DIFF
--- a/package/harvester-os/files/system/oem/99_ca.yaml
+++ b/package/harvester-os/files/system/oem/99_ca.yaml
@@ -1,6 +1,6 @@
 name: "Update system CA certificates"
 stages:
-  initramfs:
+  boot:
   - name: "Run update-ca-certificates to apply addition-ca in /etc/pki/trust/anchors"
     commands:
     - update-ca-certificates -v

--- a/pkg/config/cos.go
+++ b/pkg/config/cos.go
@@ -74,6 +74,7 @@ func ConvertToCOS(config *HarvesterConfig) (*yipSchema.YipConfig, error) {
 		initramfs.Files = append(initramfs.Files, yipSchema.File{
 			Path:        ff.Path,
 			Content:     ff.Content,
+			Encoding:    ff.Encoding,
 			Permissions: uint32(perm),
 			OwnerString: ff.Owner,
 		})


### PR DESCRIPTION
ref: https://github.com/harvester/harvester/issues/2736

### Test plan

**Create first node**
* Use [vagrant-pxe-harvester](https://github.com/harvester/ipxe-examples/tree/main/vagrant-pxe-harvester) to setup 1-node cluster.
* Generate self-signed certificate. Remember to change `IP.1` value to your VIP.
```console
cat <<EOF > ssl.conf
[req]
prompt = no
default_md = sha256
default_bits = 2048
distinguished_name = dn
x509_extensions = v3_req

[dn]
C = TW
ST = Taiwan
L = Taipei
O = Test Inc.
OU = IT Department
emailAddress = admin@example.com
CN = localhost

[v3_req]
subjectAltName = @alt_names
basicConstraints = CA:TRUE

[alt_names]
IP.1 = 192.168.0.30
EOF

openssl req -x509 -new -nodes -sha256 -utf8 -days 3650 -newkey rsa:2048 -keyout server.key -out server.crt -config ssl.conf
```
* Upload `server.crt` to `Public Certificate` and `CA` in the `ssl-certificates` setting. Upload `server.key` to `Private Key` in the `ssl-certificates` setting.

**Update pxe server**
* Update [`harvester_cluster_nodes`](https://github.com/harvester/ipxe-examples/blob/4122862dd35e59ea034ac851262f47a914927ba8/vagrant-pxe-harvester/settings.yml#L25) to `2`.
* Use `vagrant ssh pxe_server` to login pxe server.
* Add following content to `/etc/dhcp/dhcpd.conf`. Remember to change you `fixed-address` to your second node IP.
```
host harvest_node_1 {
    hardware ethernet 02:00:00:35:86:92;
    fixed-address 192.168.0.31;
    server-name "harvester-node-1";
}
```
* Restart dhcp server `systemctl restart isc-dhcp-server.service`.
* Get base64 encoded tls.crt in `kubectl get sec -n cattle-system tls-ingress -o yaml`
* Add `write_files` to `/var/www/harvester/config-join-1.yaml` in pxe server.
```
os:
  # ...
  write_files:
  - encoding: b64
    content: <base64 encoded certificate>
    owner: root:root
    path: /etc/pki/trust/anchors/ssl-certificate
    permissions: '0644'
```

**Create second node**
* Under [vagrant-pxe-harvester](https://github.com/harvester/ipxe-examples/tree/main/vagrant-pxe-harvester) folder and run `vagrant up harvester-node-1`.
* After second installed, we can use `journalctl -u rancher-system-agent.service` to see error logs.
* Also, we can see that `certificate-authority-data` in `/var/lib/rancher/agent/rancher2_connection_info.json` is old value.

**Fix second node**
* In the first node, run a command `kubectl get sec -n cattle-system tls-ingress -o yaml`.
* Paste value `tls.crt` in the secret to `certificate-authority-data` in `/var/lib/rancher/agent/rancher2_connection_info.json`.
* Finally, run `systemctl restart rancher-system-agent.service` in the second node.