### PR TITLE
baseos: upgrade latest SLE Micro package

### DIFF
--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -14,7 +14,7 @@ source ${SCRIPTS_DIR}/version-rancher
 source ${SCRIPTS_DIR}/version-harvester ${TOP_DIR}/../harvester
 source ${SCRIPTS_DIR}/version-monitoring
 
-BASE_OS_IMAGE="rancher/harvester-os:20220829"
+BASE_OS_IMAGE="rancher/harvester-os:20220919"
 HARVESTER_OS_IMAGE=rancher/harvester-os:$VERSION
 
 cd ${PACKAGE_HARVESTER_OS_DIR}


### PR DESCRIPTION
Only zypper update.
baseos's Dockerfile isn't changed.

Signed-off-by: Date Huang <date.huang@suse.com>