### PR TITLE
Fix harvester ready check

### DIFF
--- a/pkg/config/cos_test.go
+++ b/pkg/config/cos_test.go
@@ -3,8 +3,9 @@ package config
 import (
 	"testing"
 
-	"github.com/harvester/harvester-installer/pkg/util"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/harvester/harvester-installer/pkg/util"
 )
 
 func TestCalcCosPersistentPartSize(t *testing.T) {

--- a/pkg/util/cmdline_test.go
+++ b/pkg/util/cmdline_test.go
@@ -2,9 +2,10 @@ package util
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/rancher/mapper/values"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func Test_parseCmdLineWithPrefix(t *testing.T) {


### PR DESCRIPTION
current logic:
if one pod has labels "app.kubernetes.io/name=harvester" is ready, then harvester is ready.


problem:
if no harvester pod is ready, only harvester-webhook (has labels "app.kubernetes.io/name=harvester") is ready. console still show `Ready`

solution:
change logic to "harvester pod ready and harvester-webhook pod ready"

**Related issues**
https://github.com/harvester/harvester/issues/2778


**Test Plan**
1. scale down harvester
+ remove annotation "management.cattle.io/scale-available" in deployment harvester 
+ set deploy harvester replicas to 0 (need first)
```bash
kubectl -n harvester-system edit deploy harvester
```
2. check the `Status` in `Harvester Cluster`

