### PR TITLE
vlan: fix static address config

### DIFF
--- a/pkg/config/templates/wicked-ifcfg-bridge
+++ b/pkg/config/templates/wicked-ifcfg-bridge
@@ -7,8 +7,8 @@ BRIDGE_PORTS='{{ .Bond }}'
 PRE_UP_SCRIPT="wicked:setup_bridge.sh"
 POST_UP_SCRIPT="wicked:setup_bridge.sh"
 
-{{ if eq .Method "static" -}}
-IPADDR={{ .IP }}
+{{ if eq .Bridge.Method "static" -}}
+IPADDR={{ .Bridge.IP }}
 NETMASK={{ .Bridge.SubnetMask }}
 {{- end }}
 


### PR DESCRIPTION
Static IP address isn't generated in wicked config.
https://github.com/harvester/harvester/issues/2796

Signed-off-by: Date Huang <date.huang@suse.com>