### PR TITLE
CI: Use main branch for ipxe-examples

### DIFF
--- a/ci/run_vagrant_install_test.yml
+++ b/ci/run_vagrant_install_test.yml
@@ -53,6 +53,7 @@
     - name: Clone ipxe-examples repo
       git:
         repo: https://github.com/harvester/ipxe-examples.git
+        version: main
         dest: "{{ WORKSPACE }}/ipxe-examples"
 
     - name: Check to see if "/usr/share/qemu/OVMF.fd" exist


### PR DESCRIPTION
We've made the v1.0 branch as the default branch in ipxe-example, and it doesn't work with the installer's master branch.
Use the `main` branch instead.