### PR TITLE
Bump OS to 20221005

### DIFF
--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -15,7 +15,7 @@ source ${SCRIPTS_DIR}/version-harvester ${TOP_DIR}/../harvester
 source ${SCRIPTS_DIR}/version-monitoring
 source ${SCRIPTS_DIR}/version-logging
 
-BASE_OS_IMAGE="rancher/harvester-os:20220928"
+BASE_OS_IMAGE="rancher/harvester-os:20221005"
 HARVESTER_OS_IMAGE=rancher/harvester-os:$VERSION
 
 cd ${PACKAGE_HARVESTER_OS_DIR}


### PR DESCRIPTION
Include rancherd update: https://github.com/rancher/rancherd/pull/25.

Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>