### PR TITLE
bump up image for harvester-vm-import-controller

### DIFF
--- a/pkg/config/templates/rancherd-22-vm-import-controller.yaml
+++ b/pkg/config/templates/rancherd-22-vm-import-controller.yaml
@@ -12,4 +12,5 @@ resources:
       valuesContent: |
         image:
           tag: v0.1.1
+        fullnameOverride: harvester-vm-import-controller
 

--- a/pkg/config/templates/rancherd-22-vm-import-controller.yaml
+++ b/pkg/config/templates/rancherd-22-vm-import-controller.yaml
@@ -11,5 +11,5 @@ resources:
       enabled: false
       valuesContent: |
         image:
-          tag: v0.1.0
+          tag: v0.1.1
 

--- a/scripts/build-bundle
+++ b/scripts/build-bundle
@@ -22,7 +22,7 @@ IMAGES_DIR="${BUNDLE_DIR}/harvester/images"
 IMAGES_LISTS_DIR="${BUNDLE_DIR}/harvester/images-lists"
 RANCHERD_IMAGES_DIR="${BUNDLE_DIR}/rancherd/images"
 VM_IMPORT_CONTROLLER_CHART_VERSION="0.1.1"
-VM_IMPORT_CONTROLLER_IMAGE="rancher/harvester-vm-import-controller:v0.1.0"
+VM_IMPORT_CONTROLLER_IMAGE="rancher/harvester-vm-import-controller:v0.1.1"
 mkdir -p ${CHARTS_DIR}
 mkdir -p ${IMAGES_DIR}
 mkdir -p ${IMAGES_LISTS_DIR}


### PR DESCRIPTION
The PR introduces a new version of the harvester-vm-import-controller, which addresses a number of issues fixed by PR: https://github.com/harvester/vm-import-controller/pull/5