### PR TITLE
suppress tar warning about time stamp and update rancher-logging hack…

### DIFF
--- a/pkg/config/templates/patch/rancher-logging/100.1.3+up3.17.7/configmap.yaml
+++ b/pkg/config/templates/patch/rancher-logging/100.1.3+up3.17.7/configmap.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.additionalLoggingSources.rke2.enabled }}
 # patch to 100.1.3+up3.17.7/templates/loggings/rke2/configmap.yaml
 # when harvester-installer makes ISO, the original file is replaced
+# harvester-patch to configmap fluent-bit.conf
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/pkg/config/templates/patch/rancher-logging/100.1.3+up3.17.7/daemonset.yaml
+++ b/pkg/config/templates/patch/rancher-logging/100.1.3+up3.17.7/daemonset.yaml
@@ -39,7 +39,7 @@ spec:
             - mountPath: /etc/machine-id
               name: machine-id
               readOnly: true
-            - mountPath: "/var/log/audit/audit.log" #harvester-patch
+            - mountPath: "/var/log/audit/audit.log" # harvester-patch
               name: rke2-audit
               readOnly: true
       {{- with .Values.tolerations }}

--- a/scripts/hack/patch-rancher-logging
+++ b/scripts/hack/patch-rancher-logging
@@ -13,7 +13,7 @@ patch_rancher_logging_chart()
   fi
 
   cd ${chart_dir}
-  tar zxf rancher-logging-${logging_version}.tgz
+  tar zxf rancher-logging-${logging_version}.tgz --warning=no-timestamp
 
   echo "patch rancher logging rke2 configmap.yaml, daemonset.yaml"
   cp -f ${pkg_logging_path}/${logging_version}/configmap.yaml ./rancher-logging/templates/loggings/rke2/configmap.yaml


### PR DESCRIPTION
suppress tar warning about time stamp and update rancher-logging hack file comment

Signed-off-by: Jian Wang <w13915984028@gmail.com>

issue: https://github.com/harvester/harvester/issues/2933

after commit, the build log:
(1) no warning like `tar: rancher-logging/Chart.yaml: time stamp 2022-10-13 18:49:58 is 0.271526857 s in the future`
(2) grep `harvester-patch` has all output of the patched file, for better trouble-shooting

```
...
Successfully packaged chart and saved it to: /go/src/github.com/harvester/harvester-installer/package/harvester-repo/charts/harvester-crd-0.0.0-master-61a6124.tgz

patch rancher logging rke2 configmap.yaml, daemonset.yaml
# harvester-patch to configmap fluent-bit.conf
            - mountPath: "/var/log/audit/audit.log" # harvester-patch
        - name: rke2-audit  # harvester-patch
Successfully packaged chart and saved it to: /go/src/github.com/harvester/harvester-installer/package/harvester-repo/charts/rancher-logging-100.1.3+up3.17.7.tgz
finish patch ranch-logging chart

docker image pull --quiet docker.io/rancher/system-agent-installer-rancher:v2.6.9-rc3

docker.io/rancher/system-agent-installer-rancher:v2.6.9-rc3
...
```