### PR TITLE
change to lookup interfaces using management_interface post v1.1.0

### DIFF
--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -68,6 +68,8 @@ func (c *Console) layoutInstall(g *gocui.Gui) error {
 				c.config.Merge(cfg)
 				initPanel = installPanel
 			}
+		} else {
+			logrus.Errorf("automatic install failed: %v\n", err)
 		}
 
 		// add SchemeVersion in non-automatic mode

--- a/pkg/util/cmdline.go
+++ b/pkg/util/cmdline.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/rancher/mapper/values"
@@ -47,6 +48,10 @@ func parseCmdLine(cmdline string, prefix string) (map[string]interface{}, error)
 	}
 
 	err = toNetworkInterfaces(data)
+	if err != nil {
+		return data, err
+	}
+	err = toSchemeVersion(data)
 	return data, err
 }
 
@@ -63,7 +68,7 @@ func ReadCmdline(prefix string) (map[string]interface{}, error) {
 
 // parse kernel arguments and process network interfaces as a struct
 func toNetworkInterfaces(data map[string]interface{}) error {
-	networkInterfaces, ok := values.GetValue(data, "install", "networks", "harvester-mgmt", "interfaces")
+	networkInterfaces, ok := values.GetValue(data, "install", "management_interface", "interfaces")
 	if !ok {
 		return nil
 	}
@@ -86,6 +91,20 @@ func toNetworkInterfaces(data map[string]interface{}) error {
 		outDetails = append(outDetails, n)
 	}
 
-	values.PutValue(data, outDetails, "install", "networks", "harvester-mgmt", "interfaces")
+	values.PutValue(data, outDetails, "install", "management_interface", "interfaces")
+	return nil
+}
+
+func toSchemeVersion(data map[string]interface{}) error {
+	schemeVersion, ok := values.GetValue(data, "scheme_version")
+	if !ok {
+		return nil
+	}
+
+	schemeVersionUint, err := strconv.ParseUint(schemeVersion.(string), 10, 32)
+	if err != nil {
+		return err
+	}
+	values.PutValue(data, schemeVersionUint, "scheme_version")
 	return nil
 }

--- a/pkg/util/cmdline_test.go
+++ b/pkg/util/cmdline_test.go
@@ -38,7 +38,7 @@ func Test_parseCmdLineWithoutPrefix(t *testing.T) {
 
 func Test_parseCmdLineWithNetworkInterface(t *testing.T) {
 
-	cmdline := `harvester.os.sshAuthorizedKeys=a  harvester.install.networks.harvester-mgmt.method=dhcp harvester.install.networks.harvester-mgmt.bond_options.mode=balance-tlb harvester.install.networks.harvester-mgmt.bond_options.miimon=100 harvester.os.sshAuthorizedKeys=b harvester.install.mode=create harvester.install.networks.harvester-mgmt.interfaces="hwAddr: ab:cd:ef:gh" harvester.install.networks.harvester-mgmt.interfaces="hwAddr:   de:fg:hi:jk"`
+	cmdline := `harvester.os.sshAuthorizedKeys=a  harvester.install.management_interface.method=dhcp harvester.install.management_interface.bond_options.mode=balance-tlb harvester.install.management_interface.bond_options.miimon=100 harvester.os.sshAuthorizedKeys=b harvester.install.mode=create harvester.install.management_interface.interfaces="hwAddr: ab:cd:ef:gh" harvester.install.management_interface.interfaces="hwAddr:   de:fg:hi:jk"`
 
 	m, err := parseCmdLine(cmdline, "harvester")
 	if err != nil {
@@ -54,10 +54,22 @@ func Test_parseCmdLineWithNetworkInterface(t *testing.T) {
 		},
 	}
 
-	have, ok := values.GetValue(m, "install", "networks", "harvester-mgmt", "interfaces")
+	have, ok := values.GetValue(m, "install", "management_interface", "interfaces")
 	if !ok {
 		t.Fatal(fmt.Errorf("no network interfaces found"))
 	}
 
 	assert.Equal(t, want, have)
+}
+
+func Test_parseCmdLineWithSchemeVersion(t *testing.T) {
+	cmdline := `harvester.os.sshAuthorizedKeys=a  harvester.install.management_interface.method=dhcp harvester.install.management_interface.bond_options.mode=balance-tlb harvester.install.management_interface.bond_options.miimon=100 harvester.os.sshAuthorizedKeys=b harvester.install.mode=create harvester.install.management_interface.interfaces="hwAddr: ab:cd:ef:gh" harvester.install.management_interface.interfaces="hwAddr:   de:fg:hi:jk" harvester.scheme_version=1`
+
+	m, err := parseCmdLine(cmdline, "harvester")
+	assert.NoError(t, err, "expected no error while parsing arguments")
+
+	val, ok := m["scheme_version"]
+	assert.True(t, ok, "expected to find key scheme_version")
+	var tmp uint64
+	assert.IsType(t, tmp, val, "expected to find scheme_version to be type uint")
 }


### PR DESCRIPTION
The PR fixes how management_interfaces and scheme_version are parsed via kernel_arguments in v1.1.x images.

related to: https://github.com/harvester/harvester/issues/2964