### PR TITLE
Add iommu=pt for PCI passthrough

### DIFF
--- a/package/harvester-os/files/usr/sbin/harv-install
+++ b/package/harvester-os/files/usr/sbin/harv-install
@@ -297,9 +297,9 @@ update_grub_settings()
 
     # IOMMU system is used for PCI passthrough
     if [[ "GenuineIntel" == $(awk < /proc/cpuinfo -F: '/vendor_id/ {print $2; exit}' |  tr -d '[:space:]') ]]; then
-        sed -i "s/iommu/intel_iommu=on/g" ${TARGET}/etc/cos/bootargs.cfg
+        sed -i "s/iommu/intel_iommu=on iommu=pt/g" ${TARGET}/etc/cos/bootargs.cfg
     else
-        sed -i "s/iommu/amd_iommu=on/g" ${TARGET}/etc/cos/bootargs.cfg
+        sed -i "s/iommu/amd_iommu=on iommu=pt/g" ${TARGET}/etc/cos/bootargs.cfg
     fi
 
     # calculate recommended crashkernel allocation size


### PR DESCRIPTION
This adds a parameter to the grub bootloader which boosts performance of PCI devices enabled for passthrough by removing the need to do DMA translation.