### PR TITLE
added some missing harvester settings

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -64,10 +64,7 @@ func GetSystemSettingsAllowList() []string {
 		"overcommit-config",
 		"vip-pools",
 		"auto-disk-provision-paths",
-		"csi-driver-config",
 		"containerd-registry",
-		"storage-network",
-		"harvester-csi-ccm-versions",
 	}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -64,6 +64,10 @@ func GetSystemSettingsAllowList() []string {
 		"overcommit-config",
 		"vip-pools",
 		"auto-disk-provision-paths",
+		"csi-driver-config",
+		"containerd-registry",
+		"storage-network",
+		"harvester-csi-ccm-versions",
 	}
 }
 


### PR DESCRIPTION
This PR contains some missing harvester settings in the GetSystemSettingsAllowList since Harvester v1.1.0. We need the containerd-registry setting during installation otherwise pulling the rancher-agent will fail when registering the Harvester cluster in Rancher in an air gapped environment.