### PR TITLE
ISO: add a GRUB menuentry to boot VGA with 1024x768 resolution

### DIFF
--- a/package/harvester-os/iso/boot/grub2/grub.cfg
+++ b/package/harvester-os/iso/boot/grub2/grub.cfg
@@ -27,6 +27,14 @@ menuentry "Harvester Installer ${harvester_version}" --class os --unrestricted {
     $initrd ($root)/boot/rootfs.xz
 }
 
+menuentry "Harvester Installer ${harvester_version} (VGA 1024x768)" --class os --unrestricted {
+    set gfxpayload=1024x768x24,1024x768
+    echo Loading kernel...
+    $linux ($root)/boot/kernel.xz cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0 rd.cos.disable net.ifnames=1
+    echo Loading initrd...
+    $initrd ($root)/boot/rootfs.xz
+}
+
 if [ "${grub_platform}" = "efi" ]; then
     hiddenentry "Text mode" --hotkey "t" {
         set textmode=true


### PR DESCRIPTION
Related issue: https://github.com/harvester/harvester/issues/2937

Users can try to boot this entry if he or she sees resolution issues.


<img width="710" alt="Screen Shot 2022-11-09 at 12 08 37 PM" src="https://user-images.githubusercontent.com/1691518/200744328-f26c9b3c-67e5-48bf-81bb-c9e983b108a5.png">

`vga=792` is deprecated, switch to `gfxpayload` variable.