### PR TITLE
OS/grub: add default `grubenv` to prevent search hang

### DIFF
--- a/package/harvester-os/files/usr/sbin/harv-install
+++ b/package/harvester-os/files/usr/sbin/harv-install
@@ -316,6 +316,17 @@ update_grub_settings()
     sed -i "s/search.fs_uuid /search --no-floppy --fs-uuid /" "$GRUB_CFG"
     sed -i -E 's/^(\s*search\b)(.*)root$/\1 --set=root\2/' "$GRUB_CFG"
 
+    # For some firmware (e.g., Dell BOSS adapter 3022), users may get
+    # stuck on the grub file search for about 30 minutes, this can be
+    # mitigated by adding the `grubenv` file.
+    #
+    # PATCH: add /oem/grubenv if it does not exist
+    oem_dir=${TARGET}/oem
+    GRUBENV_FILE="${oem_dir}/grubenv"
+    if ! [ -f ${GRUBENV_FILE} ]; then
+        grub2-editenv ${GRUBENV_FILE} create
+    fi
+
     add_debug_grub_entry
 }
 


### PR DESCRIPTION
related issue: https://github.com/harvester/harvester/issues/2115

#### Test Plan
1. Test the installation with the ISO that contains this commit.
2. Make sure the installation is complete and boots up normally.
3. Check the path `/oem/grubenv`. The file should exist.