### PR TITLE
addition of iommu arguments to kernel boot args

### DIFF
--- a/package/harvester-os/files/etc/cos/bootargs.cfg
+++ b/package/harvester-os/files/etc/cos/bootargs.cfg
@@ -2,7 +2,7 @@ set console_params="console=tty1"
 set kernel=/boot/vmlinuz
 set crash_kernel_params="crashkernel=219M,high crashkernel=72M,low"
 if [ -n "$recoverylabel" ]; then
-    set kernelcmd="$console_params root=live:LABEL=$recoverylabel rd.live.dir=/ rd.live.squashimg=$img panic=0 net.ifnames=1 rd.cos.oemtimeout=120 intel_iommu=on amd_iommu=on iommu=pt"
+    set kernelcmd="$console_params root=live:LABEL=$recoverylabel rd.live.dir=/ rd.live.squashimg=$img panic=0 net.ifnames=1 rd.cos.oemtimeout=120"
 else
     set kernelcmd="$console_params root=LABEL=$label cos-img/filename=$img panic=0 net.ifnames=1 rd.cos.oemtimeout=120 rd.cos.oemlabel=COS_OEM audit=1 audit_backlog_limit=8192 intel_iommu=on amd_iommu=on iommu=pt"
 fi

--- a/package/harvester-os/files/etc/cos/bootargs.cfg
+++ b/package/harvester-os/files/etc/cos/bootargs.cfg
@@ -2,9 +2,9 @@ set console_params="console=tty1"
 set kernel=/boot/vmlinuz
 set crash_kernel_params="crashkernel=219M,high crashkernel=72M,low"
 if [ -n "$recoverylabel" ]; then
-    set kernelcmd="$console_params root=live:LABEL=$recoverylabel rd.live.dir=/ rd.live.squashimg=$img panic=0 net.ifnames=1 rd.cos.oemtimeout=120 iommu"
+    set kernelcmd="$console_params root=live:LABEL=$recoverylabel rd.live.dir=/ rd.live.squashimg=$img panic=0 net.ifnames=1 rd.cos.oemtimeout=120 intel_iommu=on amd_iommu=on iommu=pt"
 else
-    set kernelcmd="$console_params root=LABEL=$label cos-img/filename=$img panic=0 net.ifnames=1 rd.cos.oemtimeout=120 rd.cos.oemlabel=COS_OEM audit=1 audit_backlog_limit=8192 iommu"
+    set kernelcmd="$console_params root=LABEL=$label cos-img/filename=$img panic=0 net.ifnames=1 rd.cos.oemtimeout=120 rd.cos.oemlabel=COS_OEM audit=1 audit_backlog_limit=8192 intel_iommu=on amd_iommu=on iommu=pt"
 fi
 
 set initramfs=/boot/initrd

--- a/package/harvester-os/files/usr/sbin/harv-install
+++ b/package/harvester-os/files/usr/sbin/harv-install
@@ -295,13 +295,6 @@ update_grub_settings()
         sed -i "s/console_params=\"console=tty1\"/console_params=\"console=${TTY} console=tty1\"/g" ${TARGET}/etc/cos/bootargs.cfg
     fi
 
-    # IOMMU system is used for PCI passthrough
-    if [[ "GenuineIntel" == $(awk < /proc/cpuinfo -F: '/vendor_id/ {print $2; exit}' |  tr -d '[:space:]') ]]; then
-        sed -i "s/iommu/intel_iommu=on iommu=pt/g" ${TARGET}/etc/cos/bootargs.cfg
-    else
-        sed -i "s/iommu/amd_iommu=on iommu=pt/g" ${TARGET}/etc/cos/bootargs.cfg
-    fi
-
     # calculate recommended crashkernel allocation size
     CRASH_KERNEL_PARAMS=$(get_crashkernel_params || true)
     if [ -n "$CRASH_KERNEL_PARAMS" ]; then


### PR DESCRIPTION
PR superseedes: https://github.com/harvester/harvester-installer/pull/380

It fixes issue: https://github.com/harvester/harvester/issues/2973 by moving the iommu argument definition out of harv-installer and into bootargs.cfg.

This will ensure args are applied during both install and upgrade. 