### PR TITLE
Bump OS to 20221128

### DIFF
--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -17,7 +17,7 @@ source ${SCRIPTS_DIR}/version-harvester ${TOP_DIR}/../harvester
 source ${SCRIPTS_DIR}/version-monitoring
 source ${SCRIPTS_DIR}/version-logging
 
-BASE_OS_IMAGE="rancher/harvester-os:20221123"
+BASE_OS_IMAGE="rancher/harvester-os:20221128"
 HARVESTER_OS_IMAGE=rancher/harvester-os:$VERSION
 
 cd ${PACKAGE_HARVESTER_OS_DIR}


### PR DESCRIPTION
Related issue: https://github.com/harvester/harvester/issues/3159

Update packages:
```
-----RPM-----

Packages found only in docker.io/rancher/harvester-os:20221123: None

Packages found only in docker.io/rancher/harvester-os:20221128-cdaa061: None

Version differences:
PACKAGE                  IMAGE1 (docker.io/rancher/harvester-os:20221123)        IMAGE2 (docker.io/rancher/harvester-os:20221128-cdaa061)
-grub2                   2.04-150300.22.20.2, 24.3M                              2.04-150300.22.25.1, 24.3M
-grub2-i386-pc           2.04-150300.22.20.2, 2.2M                               2.04-150300.22.25.1, 2.2M
-grub2-x86_64-efi        2.04-150300.22.20.2, 6.2M                               2.04-150300.22.25.1, 6.2M
-nginx                   1.19.8-3.6.1, 2.2M                                      1.19.8-150300.3.9.1, 2
```