### PR TITLE
Bump OS 20221201

### DIFF
--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -17,7 +17,7 @@ source ${SCRIPTS_DIR}/version-harvester ${TOP_DIR}/../harvester
 source ${SCRIPTS_DIR}/version-monitoring
 source ${SCRIPTS_DIR}/version-logging
 
-BASE_OS_IMAGE="rancher/harvester-os:20221128"
+BASE_OS_IMAGE="rancher/harvester-os:20221201"
 HARVESTER_OS_IMAGE=rancher/harvester-os:$VERSION
 
 cd ${PACKAGE_HARVESTER_OS_DIR}


### PR DESCRIPTION


```
Version differences:
PACKAGE                        IMAGE1 (docker.io/rancher/harvester-os:20221128)        IMAGE2 (docker.io/rancher/harvester-os:20221201)
-device-mapper                 1.02.163-8.42.1, 263.8K                                 2.03.05_1.02.163-150200.8.49.1, 263.8K
-libdevmapper-event1_03        1.02.163-8.42.1, 26.5K                                  2.03.05_1.02.163-150200.8.49.1, 26.5K
-libdevmapper1_03              1.02.163-8.42.1, 349.8K                                 2.03.05_1.02.163-150200.8.49.1, 349.8K
-libgcc_s1                     11.3.0+git1637-150000.1.11.2, 98.7K                     12.2.1+git416-150000.1.5.1, 122.7K
-liblvm2cmd2_03                2.03.05-8.42.1, 2.2M                                    2.03.05-150200.8.49.1, 2.2M
-libpython3_6m1_0              3.6.15-150300.10.30.1, 2.7M                             3.6.15-150300.10.37.2, 2.7M
-libstdc++6                    11.3.0+git1637-150000.1.11.2, 2.1M                      12.2.1+git416-150000.1.5.1, 2.1M
-libtiff5                      4.0.9-150000.45.16.1, 498K                              4.0.9-150000.45.19.1, 502K
-lvm2                          2.03.05-8.42.1, 3.4M                                    2.03.05-150200.8.49.1, 3.4M
-python3                       3.6.15-150300.10.30.1, 141.3K                           3.6.15-150300.10.37.2, 141.3K
-python3-base                  3.6.15-150300.10.30.1, 30.6M                            3.6.15-150300.10.37.2, 30.5M
-python3-curses                3.6.15-150300.10.30.1, 148.6K                           3.6.15-150300.10.37.2, 148.5K
-supportutils                  3.1.20-150300.7.35.10.1, 287.9K                         3.1.21-150300.7.35.15.1, 294.3K
-vim-data-common               9.0.0313-150000.5.25.1, 437.7K                          9.0.0814-150000.5.28.1, 441.2K
-vim-small                     9.0.0313-150000.5.25.1, 1.5M                            9.0.0814-150000.5.28.1, 1.5M
```