### PR TITLE
Allow server_url without port and https prefix.

### DIFF
--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -1687,6 +1687,14 @@ func addInstallPanel(c *Console) error {
 			if c.config.TTY == "" {
 				c.config.TTY = getFirstConsoleTTY()
 			}
+			if c.config.ServerURL != "" {
+				formatted, err := getFormattedServerURL(c.config.ServerURL)
+				if err != nil {
+					printToPanel(c.Gui, fmt.Sprintf("server url invalid: %s", err), installPanel)
+					return
+				}
+				c.config.ServerURL = formatted
+			}
 
 			// lookup MAC Address to populate device names where needed
 			// lookup device name to populate MAC Address

--- a/pkg/console/util_test.go
+++ b/pkg/console/util_test.go
@@ -80,16 +80,34 @@ func TestGetFormattedServerURL(t *testing.T) {
 			err:    nil,
 		},
 		{
-			Name:   "invalid ip",
-			input:  "1.2.3.4/",
-			output: "",
-			err:    errors.New("1.2.3.4/ is not a valid ip/domain"),
+			Name:   "ip without port and scheme",
+			input:  "1.1.1.1",
+			output: "https://1.1.1.1:443",
+			err:    nil,
 		},
 		{
-			Name:   "invalid domain",
-			input:  "example.org/",
+			Name:   "domain without port and scheme",
+			input:  "abc.org",
+			output: "https://abc.org:443",
+			err:    nil,
+		},
+		{
+			Name:   "custom port",
+			input:  "1.2.3.4:555",
 			output: "",
-			err:    errors.New("example.org/ is not a valid ip/domain"),
+			err:    errors.New("currently non-443 port are not allowed"),
+		},
+		{
+			Name:   "ip with path",
+			input:  "1.2.3.4/",
+			output: "",
+			err:    errors.New("path is not allowed in management address: /"),
+		},
+		{
+			Name:   "domain with path",
+			input:  "abc.org/test/abc",
+			output: "",
+			err:    errors.New("path is not allowed in management address: /test/abc"),
 		},
 	}
 	for _, testCase := range testCases {


### PR DESCRIPTION
**Related issue**
[#2737](https://github.com/harvester/harvester/issues/2737)

**Test steps**
1. Build an ISO with this branch;
2. Use the artifacts built with this branch to construct a PXE server, configure a `join` configuration and use a server URL without port, like `https://172.16.0.240`;
3. Use the PXE server to boot up a node and start automatic installation;
4. Complete the installation and see if node successfully joined cluster;
5. Get into console, run `yq '.serverurl' < /oem/harvester.config` to see if server URL is correctly configured.

Signed-off-by: Yanhong Yang <yanhong.yang@suse.com>