### PR TITLE
Drone: specify branches to trigger pipelines

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6,6 +6,11 @@ platform:
   os: linux
   arch: amd64
 
+trigger:
+  branch:
+  - master
+  - v*
+
 steps:
 - name: build
   image: rancher/dapper:v0.4.1


### PR DESCRIPTION
Only trigger pipelines on these branches:
- master
- v*

This avoids running publish pipeline on mergify backport PR branches (e.g. `mergify/bp/v1.1/pr-385` of PR https://github.com/harvester/harvester-installer/pull/391. [Error](https://drone-publish.rancher.io/harvester/harvester-installer/1074))