### PR TITLE
[Backport v1.1] ntp: rancher, rke2-server rke2-agent need to wait for time sync

### DIFF
--- a/package/harvester-os/files/etc/systemd/system/rancherd.service.d/override.conf
+++ b/package/harvester-os/files/etc/systemd/system/rancherd.service.d/override.conf
@@ -1,0 +1,3 @@
+[Unit]
+After=time-sync.target
+Wants=time-sync.target

--- a/package/harvester-os/files/etc/systemd/system/rke2-agent.service.d/override.conf
+++ b/package/harvester-os/files/etc/systemd/system/rke2-agent.service.d/override.conf
@@ -1,2 +1,6 @@
+[Unit]
+After=time-sync.target
+Wants=time-sync.target
+
 [Service]
 ExecStartPre=/usr/sbin/harv-update-rke2-server-url agent

--- a/package/harvester-os/files/etc/systemd/system/rke2-server.service.d/override.conf
+++ b/package/harvester-os/files/etc/systemd/system/rke2-server.service.d/override.conf
@@ -1,2 +1,6 @@
+[Unit]
+After=time-sync.target
+Wants=time-sync.target
+
 [Service]
 ExecStartPre=/usr/sbin/harv-update-rke2-server-url server

--- a/package/harvester-os/files/etc/systemd/system/systemd-time-wait-sync.service.d/override.conf
+++ b/package/harvester-os/files/etc/systemd/system/systemd-time-wait-sync.service.d/override.conf
@@ -1,0 +1,2 @@
+[Service]
+TimeoutStartSec=180

--- a/package/harvester-os/files/system/oem/06_ntp.yaml
+++ b/package/harvester-os/files/system/oem/06_ntp.yaml
@@ -1,7 +1,0 @@
-name: "Enable Systemd Time Wait Sync"
-stages:
-  initramfs:
-    - name: "enable systemd-time-wait-sync.service"
-      if: 'grep -q root=LABEL=COS_ACTIVE /proc/cmdline && [ -n "$(blkid -L COS_ACTIVE)" ]'
-      commands:
-        - systemctl enable systemd-time-wait-sync.service

--- a/package/harvester-os/files/system/oem/06_ntp.yaml
+++ b/package/harvester-os/files/system/oem/06_ntp.yaml
@@ -1,0 +1,7 @@
+name: "Enable Systemd Time Wait Sync"
+stages:
+  initramfs:
+    - name: "enable systemd-time-wait-sync.service"
+      if: 'grep -q root=LABEL=COS_ACTIVE /proc/cmdline && [ -n "$(blkid -L COS_ACTIVE)" ]'
+      commands:
+        - systemctl enable systemd-time-wait-sync.service

--- a/pkg/config/cos.go
+++ b/pkg/config/cos.go
@@ -22,6 +22,7 @@ const (
 	manifestsDirectory   = "/var/lib/rancher/rke2/server/manifests/"
 	harvesterConfig      = "harvester-config.yaml"
 	ntpdService          = "systemd-timesyncd"
+	timeWaitSyncService  = "systemd-time-wait-sync"
 	rancherdBootstrapDir = "/etc/rancher/rancherd/config.yaml.d/"
 
 	networkConfigDirectory = "/etc/sysconfig/network/"
@@ -86,6 +87,7 @@ func ConvertToCOS(config *HarvesterConfig) (*yipSchema.YipConfig, error) {
 	if len(cfg.OS.NTPServers) > 0 {
 		initramfs.TimeSyncd["NTP"] = strings.Join(cfg.OS.NTPServers, " ")
 		initramfs.Systemctl.Enable = append(initramfs.Systemctl.Enable, ntpdService)
+		initramfs.Systemctl.Enable = append(initramfs.Systemctl.Enable, timeWaitSyncService)
 	}
 	if len(cfg.OS.DNSNameservers) > 0 {
 		initramfs.Commands = append(initramfs.Commands, getAddStaticDNSServersCmd(cfg.OS.DNSNameservers))


### PR DESCRIPTION
backport PR https://github.com/harvester/harvester-installer/pull/373

use time-sync.target
wait for 3 min to sync time
if time sync took more 3 min, skip it and start rancherd, rke2-server and rke2-agent directly.