### PR TITLE
Bump RKE2 to v1.24.9+rke2r1

### DIFF
--- a/scripts/version-rke2
+++ b/scripts/version-rke2
@@ -1,1 +1,1 @@
-RKE2_VERSION="v1.24.7+rke2r1"
+RKE2_VERSION="v1.24.9+rke2r1"


### PR DESCRIPTION
Related issue: https://github.com/harvester/harvester/issues/3321

Test bump. We need to use the 2023 Jan or Feb release.
