### PR TITLE
CI: bump dapper version to v0.5.8

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -13,7 +13,7 @@ trigger:
 
 steps:
 - name: build
-  image: rancher/dapper:v0.4.1
+  image: rancher/dapper:v0.5.8
   commands:
   - dapper ci
   volumes:


### PR DESCRIPTION
Attempt to fix CI error: 

```
/usr/local/bin/docker: Error response from daemon: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "./scripts/entry": stat ./scripts/entry: no such file or directory: unknown.
time="2023-02-03T00:50:51Z" level=error msg="error waiting for container: context canceled"
```

The source is not copied to the home we set:
```
#6 [2/2] COPY . /source/
```

- https://drone-pr.rancher.io/harvester/harvester-installer/1181/1/2