### PR TITLE
Add compatibility for password hashing algorithms rather than only SHA-512

### DIFF
--- a/pkg/console/dashboard_panels.go
+++ b/pkg/console/dashboard_panels.go
@@ -198,7 +198,7 @@ func toShell(g *gocui.Gui, v *gocui.View) error {
 			if err := validatorV.Show(); err != nil {
 				return err
 			}
-			validatorV.SetContent("Invalid credential")
+			validatorV.SetContent("Invalid credential or password hash algorithm not supported.")
 			return nil
 		},
 		gocui.KeyEsc: func(g *gocui.Gui, v *gocui.View) error {

--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -667,7 +667,7 @@ func addPasswordPanels(c *Console) error {
 			}
 			passwordV.Close()
 			passwordConfirmV.Close()
-			encrypted, err := util.GetEncrptedPasswd(userInputData.Password)
+			encrypted, err := util.GetEncryptedPasswd(userInputData.Password)
 			if err != nil {
 				return err
 			}

--- a/pkg/util/crypt.go
+++ b/pkg/util/crypt.go
@@ -3,7 +3,11 @@ package util
 import (
 	"strings"
 
+	"github.com/tredoe/osutil/user/crypt"
+	"github.com/tredoe/osutil/user/crypt/apr1_crypt"
 	"github.com/tredoe/osutil/user/crypt/common"
+	"github.com/tredoe/osutil/user/crypt/md5_crypt"
+	"github.com/tredoe/osutil/user/crypt/sha256_crypt"
 	"github.com/tredoe/osutil/user/crypt/sha512_crypt"
 )
 
@@ -13,11 +17,31 @@ func CompareByShadow(key, shadowLine string) bool {
 		return false
 	}
 	passwdHash := shadowSplits[1]
-	c := sha512_crypt.New()
+
+	passwdHashSplits := strings.Split(passwdHash, "$")
+	if len(passwdHashSplits) < 4 {
+		return false
+	}
+	var c crypt.Crypter
+
+	prefix := passwdHashSplits[1]
+	switch prefix {
+	case "1":
+		c = md5_crypt.New()
+	case "5":
+		c = sha256_crypt.New()
+	case "6":
+		c = sha512_crypt.New()
+	case "apr1":
+		c = apr1_crypt.New()
+	default:
+		return false
+	}
+
 	return c.Verify(passwdHash, []byte(key)) == nil
 }
 
-func GetEncrptedPasswd(key string) (string, error) {
+func GetEncryptedPasswd(key string) (string, error) {
 	c := sha512_crypt.New()
 	salt := common.Salt{}
 	saltBytes := salt.Generate(16)

--- a/pkg/util/crypt_test.go
+++ b/pkg/util/crypt_test.go
@@ -31,6 +31,30 @@ func TestCompareByShadow(t *testing.T) {
 			shadow:   "rancher:$6",
 			output:   false,
 		},
+		{
+			Name:     "match md5",
+			password: "123456",
+			shadow:   "rancher:$1$u9auViW8$PZ3di3aAQHHUtKS3jvgP3/:18578:0:99999:7:::",
+			output:   true,
+		},
+		{
+			Name:     "mismatch md5",
+			password: "1234",
+			shadow:   "rancher:$1$u9auViW8$PZ3di3aAQHHUtKS3jvgP3/:18578:0:99999:7:::",
+			output:   false,
+		},
+		{
+			Name:     "match sha256",
+			password: "123abc",
+			shadow:   "rancher:$5$6LAKtLP0k6eSLylm$iPmjvy9x2KFJdqNTMotoQ84OZunCFrKcctw.1l0Ho27:18578:0:99999:7:::",
+			output:   true,
+		},
+		{
+			Name:     "mismatch sha256",
+			password: "abc123",
+			shadow:   "rancher:$5$6LAKtLP0k6eSLylm$iPmjvy9x2KFJdqNTMotoQ84OZunCFrKcctw.1l0Ho27:18578:0:99999:7:::",
+			output:   false,
+		},
 	}
 	for _, tCase := range testCases {
 		actual := CompareByShadow(tCase.password, tCase.shadow)
@@ -39,7 +63,7 @@ func TestCompareByShadow(t *testing.T) {
 }
 
 func TestF(t *testing.T) {
-	s, e := GetEncrptedPasswd("1")
+	s, e := GetEncryptedPasswd("1")
 	t.Log(s)
 	t.Log(e)
 }

--- a/vendor/github.com/tredoe/osutil/user/crypt/apr1_crypt/apr1_crypt.go
+++ b/vendor/github.com/tredoe/osutil/user/crypt/apr1_crypt/apr1_crypt.go
@@ -1,0 +1,62 @@
+// Copyright 2012, Jeramey Crawford <jeramey@antihe.ro>
+// Copyright 2013, Jonas mg
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file.
+
+// Package apr1_crypt implements the standard Unix MD5-crypt algorithm created
+// by Poul-Henning Kamp for FreeBSD, and modified by the Apache project.
+//
+// The only change from MD5-crypt is the use of the magic constant "$apr1$"
+// instead of "$1$". The algorithms are otherwise identical.
+package apr1_crypt
+
+import (
+	"github.com/tredoe/osutil/user/crypt"
+	"github.com/tredoe/osutil/user/crypt/common"
+	"github.com/tredoe/osutil/user/crypt/md5_crypt"
+)
+
+func init() {
+	crypt.RegisterCrypt(crypt.APR1, New, MagicPrefix)
+}
+
+const (
+	MagicPrefix   = "$apr1$"
+	SaltLenMin    = 1
+	SaltLenMax    = 8
+	RoundsDefault = 1000
+)
+
+var md5Crypt = md5_crypt.New()
+
+func init() {
+	md5Crypt.SetSalt(GetSalt())
+}
+
+type crypter struct{ Salt common.Salt }
+
+// New returns a new crypt.Crypter computing the variant "apr1" of MD5-crypt
+func New() crypt.Crypter { return &crypter{common.Salt{}} }
+
+func (c *crypter) Generate(key, salt []byte) (string, error) {
+	return md5Crypt.Generate(key, salt)
+}
+
+func (c *crypter) Verify(hashedKey string, key []byte) error {
+	return md5Crypt.Verify(hashedKey, key)
+}
+
+func (c *crypter) Cost(hashedKey string) (int, error) { return RoundsDefault, nil }
+
+func (c *crypter) SetSalt(salt common.Salt) {}
+
+func GetSalt() common.Salt {
+	return common.Salt{
+		MagicPrefix:   []byte(MagicPrefix),
+		SaltLenMin:    SaltLenMin,
+		SaltLenMax:    SaltLenMax,
+		RoundsDefault: RoundsDefault,
+	}
+}

--- a/vendor/github.com/tredoe/osutil/user/crypt/md5_crypt/md5_crypt.go
+++ b/vendor/github.com/tredoe/osutil/user/crypt/md5_crypt/md5_crypt.go
@@ -1,0 +1,166 @@
+// Copyright 2012, Jeramey Crawford <jeramey@antihe.ro>
+// Copyright 2013, Jonas mg
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file.
+
+// Package md5_crypt implements the standard Unix MD5-crypt algorithm created by
+// Poul-Henning Kamp for FreeBSD.
+package md5_crypt
+
+import (
+	"bytes"
+	"crypto/md5"
+
+	"github.com/tredoe/osutil/user/crypt"
+	"github.com/tredoe/osutil/user/crypt/common"
+)
+
+func init() {
+	crypt.RegisterCrypt(crypt.MD5, New, MagicPrefix)
+}
+
+// NOTE: Cisco IOS only allows salts of length 4.
+
+const (
+	MagicPrefix   = "$1$"
+	SaltLenMin    = 1 // Real minimum is 0, but that isn't useful.
+	SaltLenMax    = 8
+	RoundsDefault = 1000
+)
+
+type crypter struct{ Salt common.Salt }
+
+// New returns a new crypt.Crypter computing the MD5-crypt password hashing.
+func New() crypt.Crypter {
+	return &crypter{GetSalt()}
+}
+
+func (c *crypter) Generate(key, salt []byte) (string, error) {
+	if len(salt) == 0 {
+		salt = c.Salt.Generate(SaltLenMax)
+	}
+	if !bytes.HasPrefix(salt, c.Salt.MagicPrefix) {
+		return "", common.ErrSaltPrefix
+	}
+
+	saltToks := bytes.Split(salt, []byte{'$'})
+
+	if len(saltToks) < 3 {
+		return "", common.ErrSaltFormat
+	} else {
+		salt = saltToks[2]
+	}
+	if len(salt) > 8 {
+		salt = salt[0:8]
+	}
+
+	// Compute alternate MD5 sum with input KEY, SALT, and KEY.
+	Alternate := md5.New()
+	Alternate.Write(key)
+	Alternate.Write(salt)
+	Alternate.Write(key)
+	AlternateSum := Alternate.Sum(nil) // 16 bytes
+
+	A := md5.New()
+	A.Write(key)
+	A.Write(c.Salt.MagicPrefix)
+	A.Write(salt)
+	// Add for any character in the key one byte of the alternate sum.
+	i := len(key)
+	for ; i > 16; i -= 16 {
+		A.Write(AlternateSum)
+	}
+	A.Write(AlternateSum[0:i])
+
+	// The original implementation now does something weird:
+	//   For every 1 bit in the key, the first 0 is added to the buffer
+	//   For every 0 bit, the first character of the key
+	// This does not seem to be what was intended but we have to follow this to
+	// be compatible.
+	for i = len(key); i > 0; i >>= 1 {
+		if (i & 1) == 0 {
+			A.Write(key[0:1])
+		} else {
+			A.Write([]byte{0})
+		}
+	}
+	Csum := A.Sum(nil)
+
+	// In fear of password crackers here comes a quite long loop which just
+	// processes the output of the previous round again.
+	// We cannot ignore this here.
+	for i = 0; i < RoundsDefault; i++ {
+		C := md5.New()
+
+		// Add key or last result.
+		if (i & 1) != 0 {
+			C.Write(key)
+		} else {
+			C.Write(Csum)
+		}
+		// Add salt for numbers not divisible by 3.
+		if (i % 3) != 0 {
+			C.Write(salt)
+		}
+		// Add key for numbers not divisible by 7.
+		if (i % 7) != 0 {
+			C.Write(key)
+		}
+		// Add key or last result.
+		if (i & 1) == 0 {
+			C.Write(key)
+		} else {
+			C.Write(Csum)
+		}
+
+		Csum = C.Sum(nil)
+	}
+
+	out := make([]byte, 0, 23+len(c.Salt.MagicPrefix)+len(salt))
+	out = append(out, c.Salt.MagicPrefix...)
+	out = append(out, salt...)
+	out = append(out, '$')
+	out = append(out, common.Base64_24Bit([]byte{
+		Csum[12], Csum[6], Csum[0],
+		Csum[13], Csum[7], Csum[1],
+		Csum[14], Csum[8], Csum[2],
+		Csum[15], Csum[9], Csum[3],
+		Csum[5], Csum[10], Csum[4],
+		Csum[11],
+	})...)
+
+	// Clean sensitive data.
+	A.Reset()
+	Alternate.Reset()
+	for i = 0; i < len(AlternateSum); i++ {
+		AlternateSum[i] = 0
+	}
+
+	return string(out), nil
+}
+
+func (c *crypter) Verify(hashedKey string, key []byte) error {
+	newHash, err := c.Generate(key, []byte(hashedKey))
+	if err != nil {
+		return err
+	}
+	if newHash != hashedKey {
+		return crypt.ErrKeyMismatch
+	}
+	return nil
+}
+
+func (c *crypter) Cost(hashedKey string) (int, error) { return RoundsDefault, nil }
+
+func (c *crypter) SetSalt(salt common.Salt) { c.Salt = salt }
+
+func GetSalt() common.Salt {
+	return common.Salt{
+		MagicPrefix:   []byte(MagicPrefix),
+		SaltLenMin:    SaltLenMin,
+		SaltLenMax:    SaltLenMax,
+		RoundsDefault: RoundsDefault,
+	}
+}

--- a/vendor/github.com/tredoe/osutil/user/crypt/sha256_crypt/sha256_crypt.go
+++ b/vendor/github.com/tredoe/osutil/user/crypt/sha256_crypt/sha256_crypt.go
@@ -1,0 +1,243 @@
+// Copyright 2012, Jeramey Crawford <jeramey@antihe.ro>
+// Copyright 2013, Jonas mg
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file.
+
+// Package sha256_crypt implements Ulrich Drepper's SHA256-crypt password
+// hashing algorithm.
+//
+// The specification for this algorithm can be found here:
+// http://www.akkadia.org/drepper/SHA-crypt.txt
+package sha256_crypt
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"strconv"
+
+	"github.com/tredoe/osutil/user/crypt"
+	"github.com/tredoe/osutil/user/crypt/common"
+)
+
+func init() {
+	crypt.RegisterCrypt(crypt.SHA256, New, MagicPrefix)
+}
+
+const (
+	MagicPrefix   = "$5$"
+	SaltLenMin    = 1
+	SaltLenMax    = 16
+	RoundsMin     = 1000
+	RoundsMax     = 999999999
+	RoundsDefault = 5000
+)
+
+var _rounds = []byte("rounds=")
+
+type crypter struct{ Salt common.Salt }
+
+// New returns a new crypt.Crypter computing the SHA256-crypt password hashing.
+func New() crypt.Crypter {
+	return &crypter{GetSalt()}
+}
+
+func (c *crypter) Generate(key, salt []byte) (string, error) {
+	var rounds int
+	var isRoundsDef bool
+
+	if len(salt) == 0 {
+		salt = c.Salt.GenerateWRounds(SaltLenMax, RoundsDefault)
+	}
+	if !bytes.HasPrefix(salt, c.Salt.MagicPrefix) {
+		return "", common.ErrSaltPrefix
+	}
+
+	saltToks := bytes.Split(salt, []byte{'$'})
+	if len(saltToks) < 3 {
+		return "", common.ErrSaltFormat
+	}
+
+	if bytes.HasPrefix(saltToks[2], _rounds) {
+		isRoundsDef = true
+		pr, err := strconv.ParseInt(string(saltToks[2][7:]), 10, 32)
+		if err != nil {
+			return "", common.ErrSaltRounds
+		}
+		rounds = int(pr)
+		if rounds < RoundsMin {
+			rounds = RoundsMin
+		} else if rounds > RoundsMax {
+			rounds = RoundsMax
+		}
+		salt = saltToks[3]
+	} else {
+		rounds = RoundsDefault
+		salt = saltToks[2]
+	}
+
+	if len(salt) > 16 {
+		salt = salt[0:16]
+	}
+
+	// Compute alternate SHA256 sum with input KEY, SALT, and KEY.
+	Alternate := sha256.New()
+	Alternate.Write(key)
+	Alternate.Write(salt)
+	Alternate.Write(key)
+	AlternateSum := Alternate.Sum(nil) // 32 bytes
+
+	A := sha256.New()
+	A.Write(key)
+	A.Write(salt)
+	// Add for any character in the key one byte of the alternate sum.
+	i := len(key)
+	for ; i > 32; i -= 32 {
+		A.Write(AlternateSum)
+	}
+	A.Write(AlternateSum[0:i])
+
+	// Take the binary representation of the length of the key and for every add
+	// the alternate sum, for every 0 the key.
+	for i = len(key); i > 0; i >>= 1 {
+		if (i & 1) != 0 {
+			A.Write(AlternateSum)
+		} else {
+			A.Write(key)
+		}
+	}
+	Asum := A.Sum(nil)
+
+	// Start computation of P byte sequence.
+	P := sha256.New()
+	// For every character in the password add the entire password.
+	for i = 0; i < len(key); i++ {
+		P.Write(key)
+	}
+	Psum := P.Sum(nil)
+	// Create byte sequence P.
+	Pseq := make([]byte, 0, len(key))
+	for i = len(key); i > 32; i -= 32 {
+		Pseq = append(Pseq, Psum...)
+	}
+	Pseq = append(Pseq, Psum[0:i]...)
+
+	// Start computation of S byte sequence.
+	S := sha256.New()
+	for i = 0; i < (16 + int(Asum[0])); i++ {
+		S.Write(salt)
+	}
+	Ssum := S.Sum(nil)
+	// Create byte sequence S.
+	Sseq := make([]byte, 0, len(salt))
+	for i = len(salt); i > 32; i -= 32 {
+		Sseq = append(Sseq, Ssum...)
+	}
+	Sseq = append(Sseq, Ssum[0:i]...)
+
+	Csum := Asum
+
+	// Repeatedly run the collected hash value through SHA256 to burn CPU cycles.
+	for i = 0; i < rounds; i++ {
+		C := sha256.New()
+
+		// Add key or last result.
+		if (i & 1) != 0 {
+			C.Write(Pseq)
+		} else {
+			C.Write(Csum)
+		}
+		// Add salt for numbers not divisible by 3.
+		if (i % 3) != 0 {
+			C.Write(Sseq)
+		}
+		// Add key for numbers not divisible by 7.
+		if (i % 7) != 0 {
+			C.Write(Pseq)
+		}
+		// Add key or last result.
+		if (i & 1) != 0 {
+			C.Write(Csum)
+		} else {
+			C.Write(Pseq)
+		}
+
+		Csum = C.Sum(nil)
+	}
+
+	out := make([]byte, 0, 80)
+	out = append(out, c.Salt.MagicPrefix...)
+	if isRoundsDef {
+		out = append(out, []byte("rounds="+strconv.Itoa(rounds)+"$")...)
+	}
+	out = append(out, salt...)
+	out = append(out, '$')
+	out = append(out, common.Base64_24Bit([]byte{
+		Csum[20], Csum[10], Csum[0],
+		Csum[11], Csum[1], Csum[21],
+		Csum[2], Csum[22], Csum[12],
+		Csum[23], Csum[13], Csum[3],
+		Csum[14], Csum[4], Csum[24],
+		Csum[5], Csum[25], Csum[15],
+		Csum[26], Csum[16], Csum[6],
+		Csum[17], Csum[7], Csum[27],
+		Csum[8], Csum[28], Csum[18],
+		Csum[29], Csum[19], Csum[9],
+		Csum[30], Csum[31],
+	})...)
+
+	// Clean sensitive data.
+	A.Reset()
+	Alternate.Reset()
+	P.Reset()
+	for i = 0; i < len(Asum); i++ {
+		Asum[i] = 0
+	}
+	for i = 0; i < len(AlternateSum); i++ {
+		AlternateSum[i] = 0
+	}
+	for i = 0; i < len(Pseq); i++ {
+		Pseq[i] = 0
+	}
+
+	return string(out), nil
+}
+
+func (c *crypter) Verify(hashedKey string, key []byte) error {
+	newHash, err := c.Generate(key, []byte(hashedKey))
+	if err != nil {
+		return err
+	}
+	if newHash != hashedKey {
+		return crypt.ErrKeyMismatch
+	}
+	return nil
+}
+
+func (c *crypter) Cost(hashedKey string) (int, error) {
+	saltToks := bytes.Split([]byte(hashedKey), []byte{'$'})
+	if len(saltToks) < 3 {
+		return 0, common.ErrSaltFormat
+	}
+
+	if !bytes.HasPrefix(saltToks[2], _rounds) {
+		return RoundsDefault, nil
+	}
+	roundToks := bytes.Split(saltToks[2], []byte{'='})
+	cost, err := strconv.ParseInt(string(roundToks[1]), 10, 0)
+	return int(cost), err
+}
+
+func (c *crypter) SetSalt(salt common.Salt) { c.Salt = salt }
+
+func GetSalt() common.Salt {
+	return common.Salt{
+		MagicPrefix:   []byte(MagicPrefix),
+		SaltLenMin:    SaltLenMin,
+		SaltLenMax:    SaltLenMax,
+		RoundsDefault: RoundsDefault,
+		RoundsMin:     RoundsMin,
+		RoundsMax:     RoundsMax,
+	}
+}


### PR DESCRIPTION
**Related issue:**
[#3051](https://github.com/harvester/harvester/issues/3051)

**Test steps:**
1. Prepare an iPXE installation environment, set the password using `openssl passwd -1` for MD5 based password;
2. Install a Harvester instance using iPXE;
3. After boot up, try to use the password set in `config.yaml` to get into the console.