### PR TITLE
[v1.1 backport] OS: bump OS to 20230207

### DIFF
--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -17,7 +17,7 @@ source ${SCRIPTS_DIR}/version-harvester ${TOP_DIR}/../harvester
 source ${SCRIPTS_DIR}/version-monitoring
 source ${SCRIPTS_DIR}/version-logging
 
-BASE_OS_IMAGE="rancher/harvester-os:20221228"
+BASE_OS_IMAGE="rancher/harvester-os:20230207"
 HARVESTER_OS_IMAGE=rancher/harvester-os:$VERSION
 
 cd ${PACKAGE_HARVESTER_OS_DIR}


### PR DESCRIPTION
    - change the baseOS to SLE Micro for Rancher 5.3
    - add sysvinit-tools back
    - add wicked back and remove the NetworkManager
    - add k9s (v0.26.7)

Signed-off-by: Vicente Cheng <vicente.cheng@suse.com>
(cherry picked from commit d8930db4be133cf516ee931629dde6a7679b09b2)

related to: https://github.com/harvester/harvester/issues/3280