### PR TITLE
Bump OS to 20230209

### DIFF
--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -17,7 +17,7 @@ source ${SCRIPTS_DIR}/version-harvester ${TOP_DIR}/../harvester
 source ${SCRIPTS_DIR}/version-monitoring
 source ${SCRIPTS_DIR}/version-logging
 
-BASE_OS_IMAGE="rancher/harvester-os:20230207"
+BASE_OS_IMAGE="rancher/harvester-os:20230209"
 HARVESTER_OS_IMAGE=rancher/harvester-os:$VERSION
 
 cd ${PACKAGE_HARVESTER_OS_DIR}


### PR DESCRIPTION
Base OS changes:

```
-----RPM-----

Packages found only in docker.io/rancher/harvester-os:20230207: None

Packages found only in docker.io/rancher/harvester-os:20230209: None

Version differences:
PACKAGE               IMAGE1 (docker.io/rancher/harvester-os:20230207)        IMAGE2 (docker.io/rancher/harvester-os:20230209)
-libopenssl1_1        1.1.1l-150400.7.19.1, 3.9M                              1.1.1l-150400.7.22.1, 3.9M
-openssl-1_1          1.1.1l-150400.7.19.1, 1.6M                              1.1.1l-150400.7.22.1, 1.6M
```