### PR TITLE
Use modprobe to load modules at initramfs stage instead of using cloud-init.

### DIFF
--- a/pkg/config/cos.go
+++ b/pkg/config/cos.go
@@ -137,7 +137,6 @@ func ConvertToCOS(config *HarvesterConfig) (*yipSchema.YipConfig, error) {
 	}
 
 	initramfs.Hostname = cfg.OS.Hostname
-	initramfs.Modules = cfg.OS.Modules
 	initramfs.Sysctl = cfg.OS.Sysctls
 	if len(cfg.OS.NTPServers) > 0 {
 		initramfs.TimeSyncd["NTP"] = strings.Join(cfg.OS.NTPServers, " ")
@@ -157,6 +156,11 @@ func ConvertToCOS(config *HarvesterConfig) (*yipSchema.YipConfig, error) {
 	}
 
 	initramfs.Environment = cfg.OS.Environment
+
+	// Use modprobe to load modules as a temporary solution
+	for _, module := range cfg.OS.Modules {
+		initramfs.Commands = append(initramfs.Commands, "modprobe "+module)
+	}
 
 	_, err = UpdateManagementInterfaceConfig(&initramfs, cfg.ManagementInterface, false)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Yanhong Yang <yanhong.yang@suse.com>

**Related issue:**
[#3366](https://github.com/harvester/harvester/issues/3366)

**Test steps:**
1. Prepare a iPXE installation environment, in `config.yaml` add these modules:
```
# ...
os:
  modules:
    - kvm
    - nvme
    - vhost_net
# ...
```
2. Install a Harvester instance using iPXE;
3. After boot up, enter the console and use command `lsmod | grep nvme` to check if nvme module loaded;
4. Use command `lsmod | grep vhost_net` to check if vhost_net module loaded;