### PR TITLE
Introduce two images for upgrade o11y enhancement

### DIFF
--- a/scripts/build-bundle
+++ b/scripts/build-bundle
@@ -171,13 +171,34 @@ save_image "common" $BUNDLE_DIR ${IMAGES_LISTS_DIR}/${image_list_file} ${IMAGES_
 
 # Tag harvester-upgrade:master-head to harvester-upgrade:<version> and save the image to an archive
 # This makes it possible to upgrade a cluster with a master ISO.
+image_list_file="${IMAGES_LISTS_DIR}/harvester-extra-${VERSION}.txt"
+image_archive="${IMAGES_DIR}/harvester-extra-${VERSION}.tar"
+has_extra="false"
 upgrade_image_repo=$(yq -e e '.upgrade.image.repository' $values_file)
 upgrade_image_tag=$(yq -e e '.upgrade.image.tag' $values_file)
 if [ "$upgrade_image_tag" != "$HARVESTER_VERSION" ]; then
+  has_extra="true"
   docker tag "${upgrade_image_repo}:${upgrade_image_tag}" "rancher/harvester-upgrade:${HARVESTER_VERSION}"
-  image_list_file="${IMAGES_LISTS_DIR}/harvester-extra-${VERSION}.txt"
-  image_archive="${IMAGES_DIR}/harvester-extra-${VERSION}.tar"
   echo "docker.io/rancher/harvester-upgrade:${HARVESTER_VERSION}" > ${image_list_file}
+fi
+
+upgradelog_downloader_image_repo=$(yq -e e '.upgradelog-downloader.image.repository' $values_file)
+upgradelog_downloader_image_tag=$(yq -e e '.upgradelog-downloader.image.tag' $values_file)
+if [ "$upgradelog_downloader_image_tag" != "$HARVESTER_VERSION" ]; then
+  has_extra="true"
+  docker tag "${upgradelog_downloader_image_repo}:${upgrade_image_tag}" "rancher/harvester-upgradelog-downloader:${HARVESTER_VERSION}"
+  echo "docker.io/rancher/harvester-upgradelog-downloader:${HARVESTER_VERSION}" >> ${image_list_file}
+fi
+
+upgradelog_packager_image_repo=$(yq -e e '.upgradelog-packager.image.repository' $values_file)
+upgradelog_packager_image_tag=$(yq -e e '.upgradelog-packager.image.tag' $values_file)
+if [ "$upgradelog_packager_image_tag" != "$HARVESTER_VERSION" ]; then
+  has_extra="true"
+  docker tag "${upgradelog_packager_image_repo}:${upgrade_image_tag}" "rancher/harvester-upgradelog-packager:${HARVESTER_VERSION}"
+  echo "docker.io/rancher/harvester-upgradelog-packager:${HARVESTER_VERSION}" >> ${image_list_file}
+fi
+
+if [ "$has_extra" == "true" ]; then
   docker image save -o $image_archive $(<$image_list_file)
   zstd --rm $image_archive -o "${image_archive}.zst"
   add_image_list_to_metadata "common" $BUNDLE_DIR $image_list_file "${image_archive}.zst"

--- a/scripts/patch-harvester
+++ b/scripts/patch-harvester
@@ -32,8 +32,12 @@ echo "Replace the Harvester image tag to ${IMAGE_PUSH_TAG}"
 yq e -i '.containers.apiserver.image.tag = "'"${IMAGE_PUSH_TAG}"'"' ./deploy/charts/harvester/values.yaml
 yq e -i '.webhook.image.tag = "'"${IMAGE_PUSH_TAG}"'"' ./deploy/charts/harvester/values.yaml
 yq e -i '.upgrade.image.tag = "'"${IMAGE_PUSH_TAG}"'"' ./deploy/charts/harvester/values.yaml
+yq e -i '.upgradelog-downloader.image.tag = "'"${IMAGE_PUSH_TAG}"'"' ./deploy/charts/harvester/values.yaml
+yq e -i '.upgradelog-packager.image.tag = "'"${IMAGE_PUSH_TAG}"'"' ./deploy/charts/harvester/values.yaml
 
 echo "Replace the Harvester image repo to ${REPO}"
 replace_harvester_image_repo '.containers.apiserver.image.repository'
 replace_harvester_image_repo '.webhook.image.repository'
 replace_harvester_image_repo '.upgrade.image.repository'
+replace_harvester_image_repo '.upgradelog-downloader.image.repository'
+replace_harvester_image_repo '.upgradelog-packager.image.repository'


### PR DESCRIPTION
Signed-off-by: Zespre Chang <zespre.chang@suse.com>

This change will make the ISO image build process to include two new container images:

- Upgrade log downloader
- Upgrade log packager

Related issue: harvester/harvester#1926
Related PR: harvester/harvester#3379