### PR TITLE
CI: Enable software-emulation for nested VMs

### DIFF
--- a/ci/run_vagrant_install_test.yml
+++ b/ci/run_vagrant_install_test.yml
@@ -120,6 +120,19 @@
       debug:
         msg: "{{ setup_harvester_result.stdout_lines }}"
 
+    - name: Enable software-emulation in KubeVirt
+      register: kubevirt_result
+      vars:
+        settings_file: "{{ WORKSPACE }}/ipxe-examples/vagrant-pxe-harvester/settings.yml"
+      shell: >
+        ./enable_soft_emulation.sh {{ settings_file }}
+      args:
+        chdir: "{{ WORKSPACE }}/harvester-installer/ci/terraform"
+
+    - name: Print Enable software-emulation in KubeVirt output
+      debug:
+        msg: "{{ kubevirt_result.stdout_lines }}"
+
     - name: Clear the previous temp file
       shell: >
         ./cleanup_test_files.sh

--- a/ci/terraform/enable_soft_emulation.sh
+++ b/ci/terraform/enable_soft_emulation.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -ex
+
+if [[ $# != 1 ]]
+then
+        echo "We need the settings.yaml from ipxe repo"
+        exit 1
+fi
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/" &> /dev/null && pwd )"
+IN_SCRIPT_DIR=$SCRIPT_DIR/in-scripts
+
+SETTINGS=$1
+SSHKEY="$SCRIPT_DIR/tmp-ssh-key"
+NODE0_IP=$(yq e ".harvester_network_config.cluster[0].ip" ${SETTINGS})
+
+ssh-keygen -R ${NODE0_IP} || true
+
+scp -o "StrictHostKeyChecking no" -i ${SSHKEY} $IN_SCRIPT_DIR/patch-kubevirt.sh rancher@$NODE0_IP:/tmp/
+ssh -o "StrictHostKeyChecking no" -i ${SSHKEY} rancher@$NODE0_IP sudo -i /tmp/patch-kubevirt.sh

--- a/ci/terraform/in-scripts/patch-kubevirt.sh
+++ b/ci/terraform/in-scripts/patch-kubevirt.sh
@@ -1,0 +1,34 @@
+#!/bin/bash -ex
+
+wait_kubevirt() {
+  # Wait for kubevirt to be deployed
+  namespace=$1
+  name=$2
+
+  echo "Waiting for KubeVirt to be deployed..."
+  while [ true ]; do
+    kubevirt=$(kubectl get kubevirts.kubevirt.io $name -n $namespace -o yaml)
+
+    current_phase=$(echo "$kubevirt" | yq e '.status.phase' -)
+    if [ "$current_phase" = "Deployed" ]; then
+      echo "KubeVirt is deployed"
+      break
+    fi
+
+    echo "KubeVirt current phase: $current_phase"
+    sleep 5
+  done
+}
+
+MANIFEST=$(mktemp --suffix=.yml)
+trap "rm -f $MANIFEST" EXIT
+
+cat >$MANIFEST<<EOF
+spec:
+  configuration:
+    developerConfiguration:
+      useEmulation: true
+EOF
+
+kubectl patch kubevirts.kubevirt.io/kubevirt -n harvester-system --patch-file $MANIFEST --type merge
+wait_kubevirt harvester-system kubevirt

--- a/ci/terraform/test_terraform_vm.sh
+++ b/ci/terraform/test_terraform_vm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 if [[ $# != 1 ]]
 then
@@ -12,16 +12,20 @@ SETTINGS=$1
 
 NODE0_IP=$(yq e ".harvester_network_config.cluster[0].ip" ${SETTINGS})
 
-# sometimes VM network is not ready immediately, try three times and sleep 20 seconds on each try
-for i in {1..3}
-do
-    sleep 20
+retries=0
+while [ true ]; do
     SSHKEY=./tmp-ssh-key
-    ssh -i ${SSHKEY} rancher@$NODE0_IP "ping -c 5 $TEST_VM_IP"
-    cmd_ret=$?
-    if [ $cmd_ret == 0 ]; then
-        break
-    elif [ $i == 3 ]; then
-        exit 1
+    if ssh -i ${SSHKEY} rancher@$NODE0_IP "ping -c 5 $TEST_VM_IP"; then
+      echo "VM is alive."
+      break
     fi
+
+  if [ $retries -eq 60 ]; then
+    echo "Pinging VM timed out. Exit!"
+    exit 1
+  fi
+
+  echo "Fail to ping VM, will retry in 5 seconds..."
+  sleep 5
+  retries=$((retries+1))
 done


### PR DESCRIPTION
Enable soft-emulation, the new kernel seems not to play well with the Equinix EPYC instance.
- Set the configuration in KubeVirt CR. Do this in VM to avoid downloading kubectl.
```
spec:
  configuration:
    developerConfiguration:
      useEmulation: true
```
- Update pinging code to a checking loop (timeout 5 minutes).

Related issue: https://github.com/harvester/harvester/issues/3447