### PR TITLE
installer: add parameter to disable installer

### DIFF
--- a/package/harvester-os/files/system/oem/91_installer.yaml
+++ b/package/harvester-os/files/system/oem/91_installer.yaml
@@ -3,6 +3,7 @@ stages:
   boot:
     - commands:
       - setup-installer.sh
+      if: '! grep -q "harvester.installer.disable=true" /proc/cmdline'
   initramfs:
     - environment_file: "/etc/rancher/installer/env"
       environment:


### PR DESCRIPTION
**Problem:**
Add the parameter to disable the installer

**Solution:**
add `harvester.installer.disable` to control the installer setup

**Related Issue:**
https://github.com/harvester/harvester/issues/2663

**Test plan:**
Test the following three cases:
1. Do not change /proc/cmdline -> should go into installer
2. Add `harvester.installer.disable=false` to /proc/cmdline -> should go into installer
3. Add `harvester.installer.disable=true` to /proc/cmdline -> should not go into installer 

How to modify `/proc/cmdline`, you can refer the following steps:
1. when you enter the grub, press `esc` to stop on this console
![esc_to_stop](https://user-images.githubusercontent.com/1615081/220509312-311ffefa-090b-438c-98b9-0092eb2eaf05.png)
2. then press `e` to modify `/proc/cmdline`, the following picture is original
![original](https://user-images.githubusercontent.com/1615081/220509383-8be3c3a6-c237-45da-b07a-9d9b0928b6dd.png)
3. modify the `/proc/cmdline` like the above test cases
![after](https://user-images.githubusercontent.com/1615081/220509929-5d105fd4-2178-40dc-9266-9d29fa8656e7.png)
4. finally, press `ctrl + x` to bootup, then you could verify the above test cases