### PR TITLE
build: bump os to 20230302

### DIFF
--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -17,7 +17,7 @@ source ${SCRIPTS_DIR}/version-harvester ${TOP_DIR}/../harvester
 source ${SCRIPTS_DIR}/version-monitoring
 source ${SCRIPTS_DIR}/version-logging
 
-BASE_OS_IMAGE="rancher/harvester-os:20230220"
+BASE_OS_IMAGE="rancher/harvester-os:20230302"
 HARVESTER_OS_IMAGE=rancher/harvester-os:$VERSION
 
 cd ${PACKAGE_HARVESTER_OS_DIR}


### PR DESCRIPTION
bump os to 20230302 for various packages updated

```
Version differences:
PACKAGE                  IMAGE1 (docker.io/rancher/harvester-os:20230220)        IMAGE2 (docker.io/rancher/harvester-os:20230302)
-kdump                   1.0.2+git18.g615d6ab-150400.3.8.1, 1M                   1.0.2+git20.g64239cc-150400.3.11.1, 1M
-libopenssl1_1           1.1.1l-150400.7.22.1, 3.9M                              1.1.1l-150400.7.25.1, 3.9M
-libpython3_6m1_0        3.6.15-150300.10.37.2, 2.7M                             3.6.15-150300.10.40.1, 2.7M
-libsystemd0             249.14-150400.8.19.1, 926.9K                            249.15-150400.8.22.1, 926.9K
-libudev1                249.14-150400.8.19.1, 240.4K                            249.15-150400.8.22.1, 240.4K
-libxslt1                1.1.34-150400.1.7, 344.4K                               1.1.34-150400.3.3.1, 344.3K
-openssl-1_1             1.1.1l-150400.7.22.1, 1.6M                              1.1.1l-150400.7.25.1, 1.6M
-python3                 3.6.15-150300.10.37.2, 141.3K                           3.6.15-150300.10.40.1, 141.3K
-python3-base            3.6.15-150300.10.37.2, 30.5M                            3.6.15-150300.10.40.1, 30.6M
-python3-curses          3.6.15-150300.10.37.2, 148.5K                           3.6.15-150300.10.40.1, 148.5K
-systemd                 249.14-150400.8.19.1, 11M                               249.15-150400.8.22.1, 10.9M
-systemd-sysvinit        249.14-150400.8.19.1, 4.6K                              249.15-150400.8.22.1, 4.6K
-tar                     1.34-150000.3.26.1, 551.1K                              1.34-150000.3.31.1, 551.1K
-ucode-intel             20220809-150200.18.1, 5.8M                              20230214-150200.21.1, 11.7M
-udev                    249.14-150400.8.19.1, 8.3M                              249.15-150400.8.22.1, 8.3M
```

