### PR TITLE
Disable avahi daemon

### DIFF
--- a/ci/run_vagrant_install_test.yml
+++ b/ci/run_vagrant_install_test.yml
@@ -139,6 +139,14 @@
       args:
         chdir: "{{ WORKSPACE }}/harvester-installer/ci/terraform"
 
+    - name: Testing services status
+      vars:
+        settings_file: "{{ WORKSPACE }}/ipxe-examples/vagrant-pxe-harvester/settings.yml"
+      shell: >
+        ./check_services_status.sh {{ settings_file}}
+      args:
+        chdir: "{{ WORKSPACE }}/harvester-installer/ci/terraform"
+
     - name: Testing basic operations with terraform
       register: terraform_test
       vars:

--- a/ci/terraform/check_services_status.sh
+++ b/ci/terraform/check_services_status.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -ex
+
+if [[ $# != 1 ]]
+then
+        echo "We need the settings.yaml from ipxe repo"
+        exit 1
+fi
+
+SETTINGS=$1
+
+DISABLED_SERVICES="avahi-daemon"
+NODE0_IP=$(yq e ".harvester_network_config.cluster[0].ip" ${SETTINGS})
+
+echo "Check services that should be disabled."
+
+SSHKEY=./tmp-ssh-key
+for service in ${DISABLED_SERVICES}; do
+  echo "Prepare to check ${service} service..."
+  if ! ssh -o "StrictHostKeyChecking no" -i tmp-ssh-key rancher@$NODE0_IP "sudo systemctl status ${service}" | grep -q inactive; then
+    echo "${service} should not enable, exit!"
+    exit 1
+  fi
+done

--- a/package/harvester-os/files/system/oem/10_services.yaml
+++ b/package/harvester-os/files/system/oem/10_services.yaml
@@ -1,0 +1,6 @@
+name: "Service related operations"
+stages:
+  initramfs:
+    - name: "disable avahi-daemon"
+      systemctl:
+        disable: [avahi-daemon]


### PR DESCRIPTION
**Problem:**
We need to disable avahi-daemon for the security scan.

**Solution:**
Disable avahi-daemon by default

**Related Issue:**
https://github.com/harvester/harvester/issues/3573

**Test plan:**
Check the avahi-daemon should not be enabled

