### PR TITLE
build: bump os to 20230303

### DIFF
--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -17,7 +17,7 @@ source ${SCRIPTS_DIR}/version-harvester ${TOP_DIR}/../harvester
 source ${SCRIPTS_DIR}/version-monitoring
 source ${SCRIPTS_DIR}/version-logging
 
-BASE_OS_IMAGE="rancher/harvester-os:20230302"
+BASE_OS_IMAGE="rancher/harvester-os:20230303"
 HARVESTER_OS_IMAGE=rancher/harvester-os:$VERSION
 
 cd ${PACKAGE_HARVESTER_OS_DIR}


### PR DESCRIPTION
**Problem:**
Can not install harvester by interactive installation because we remove the yip command

**Solution:**
add yip back

**Related Issue:**
https://github.com/harvester/harvester/issues/3584

**Test plan:**
Ensure the interactive installation is workable.

