### PR TITLE
fix(upgrade): make upgrades from master to master possible

### DIFF
--- a/scripts/build-bundle
+++ b/scripts/build-bundle
@@ -171,13 +171,17 @@ save_image "common" $BUNDLE_DIR ${IMAGES_LISTS_DIR}/${image_list_file} ${IMAGES_
 
 # Tag harvester-upgrade:master-head to harvester-upgrade:<version> and save the image to an archive
 # This makes it possible to upgrade a cluster with a master ISO.
+# Also tag harvester-upgrade:master-head to harvester-upgrade:master-<commit>-head and save the image to an archive
+# This makes it possible to upgrade from master builds to master builds
 upgrade_image_repo=$(yq -e e '.upgrade.image.repository' $values_file)
 upgrade_image_tag=$(yq -e e '.upgrade.image.tag' $values_file)
 if [ "$upgrade_image_tag" != "$HARVESTER_VERSION" ]; then
   docker tag "${upgrade_image_repo}:${upgrade_image_tag}" "rancher/harvester-upgrade:${HARVESTER_VERSION}"
+  docker tag "${upgrade_image_repo}:${upgrade_image_tag}" "rancher/harvester-upgrade:${HARVESTER_APP_VERSION}-head"
   image_list_file="${IMAGES_LISTS_DIR}/harvester-extra-${VERSION}.txt"
   image_archive="${IMAGES_DIR}/harvester-extra-${VERSION}.tar"
   echo "docker.io/rancher/harvester-upgrade:${HARVESTER_VERSION}" > ${image_list_file}
+  echo "docker.io/rancher/harvester-upgrade:${HARVESTER_APP_VERSION}-head" >> ${image_list_file}
   docker image save -o $image_archive $(<$image_list_file)
   zstd --rm $image_archive -o "${image_archive}.zst"
   add_image_list_to_metadata "common" $BUNDLE_DIR $image_list_file "${image_archive}.zst"

--- a/scripts/version-harvester
+++ b/scripts/version-harvester
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 HARVESTER_VERSION=$(cd $1; source ./scripts/version &> /dev/null; echo $VERSION)
+HARVESTER_APP_VERSION=$(cd $1; source ./scripts/version &> /dev/null; echo $APP_VERSION)
 HARVESTER_CHART_VERSION=$(cd $1; source ./scripts/version &> /dev/null; echo $CHART_VERSION)
 HARVESTER_KUBEVIRT_VERSION=$(yq e '.kubevirt-operator.containers.operator.image.tag' $1/deploy/charts/harvester/values.yaml)
 HARVESTER_MIN_UPGRADABLE_VERSION=$(cd $1; source ./scripts/version &> /dev/null; echo $MIN_UPGRADABLE_VERSION)


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Sometimes we need to verify the bug fixes or feature deliveries in the upgrade area, it's essential to upgrade from the master-head to master-head with the exact same ISO image downloaded from `https://releases.rancher.com/harvester/master/harvester-master-amd64.iso`. But the `server-version` does not match with the image tag for `rancher/harvester-upgrade` image for such cases. The upgrade will then fail at the image-preloading phase as it cannot find the right image on the node nor on the Internet (if not air-gapped).

This is due to a different `VERSION` argument passed into the `harvester-upgrade` `docker build` command in `.drone.yaml`:

```
...
- name: docker-publish-upgrade-branch
  image: plugins/docker
  settings:
    build_args:
    - ARCH=amd64
    - VERSION=${DRONE_BRANCH}-${DRONE_COMMIT_SHA:0:8}-head
    context: package/upgrade
    custom_dns: 1.1.1.1
    dockerfile: package/upgrade/Dockerfile
    password:
      from_secret: docker_password
    repo: "rancher/harvester-upgrade"
    tag: ${DRONE_BRANCH}-head-amd64
    username:
      from_secret: docker_username
  when:
    ref:
      include:
      - "refs/heads/master"
      - "refs/heads/v*"
    event:
    - push
...
```

This step will be triggered every time when there's a new push to the `master` or `v*` branch. The image tag `${DRONE_BRANCH}-${DRONE_COMMIT_SHA:0:8}-head` only exists in an intermediate state and is never published. The one that gets published is the `${DRONE_BRANCH}-head-amd64`. However, the tag `${DRONE_BRANCH}-${DRONE_COMMIT_SHA:0:8}-head` tag is stored in the `server-version` CR and is then referenced as the `previousVersion` in the following upgrades.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Auto builds triggered by push events to branches like "master" or "v1.1" etc. will have `rancher/harvester-upgrade:<branch>-<commit>-head` image added into the bundle, therefore making the upgrade from master-head to master-head or v1.1-head to v1.1-head possible.

**Related Issue:**

harvester/harvester#3610

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

For reviewers:
1. Checkout to this branch
2. Build the ISO with the command `make`
3. Check the ISO image artifact with `isoinfo` command, it should contain the additional `harvester-upgrade` image with the `master-<commit>-head` tag

```
$ isoinfo -J -i dist/artifacts/harvester-master-amd64.iso -x /bundle/harvester/images-lists/harvester-extra-master.txt
docker.io/rancher/harvester-upgrade:544cb2b
docker.io/rancher/harvester-upgrade:master-544cb2b-head
```

For QAs:

1. Download the ISO image from `https://releases.rancher.com/harvester/master/harvester-master-amd64.iso`, please be sure that the image already has the fix included
2. Provision a Harvester cluster with the ISO image (single-node is fine)
3. Upgrade the cluster with the same ISO image
4. The upgrade should succeed