### PR TITLE
Bump RKE2 to v1.24.11+rke2r1

### DIFF
--- a/scripts/version-rke2
+++ b/scripts/version-rke2
@@ -1,1 +1,1 @@
-RKE2_VERSION="v1.24.11-rc1+rke2r1"
+RKE2_VERSION="v1.24.11+rke2r1"


### PR DESCRIPTION
Bump RKE2 to `v1.24.11+rke2r1`.
There is no change after v1.24.11-rc1+rke2r1, just to change to the formal release version.