### PR TITLE
Add /var/lib/third-party to PERSISTENT_STATE_PATHS

### DIFF
--- a/pkg/config/templates/cos-rootfs.yaml
+++ b/pkg/config/templates/cos-rootfs.yaml
@@ -22,6 +22,7 @@ environment:
     /var/lib/kubelet
     /var/lib/wicked
     /var/lib/cni
+    /var/lib/third-party
     /var/crash
     /var/lib/longhorn
     {{- if not .ShouldMountDataPartition }}


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

The default rook ceph cluster data path on the host is '/var/lib/rook'. However, this path is non-persistent on Harvester OS, which will cause the osd of rook ceph to crash after the node restarts.
We need a directory to store data for a third-party component like rook

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Add /var/lib/third-party to PERSISTENT_STATE_PATHS

**Related Issue:**
https://github.com/harvester/harvester/issues/2405

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
Refer to https://github.com/harvester/harvester/pull/3566
