### PR TITLE
Install mode

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -44,7 +44,6 @@ ENV DAPPER_ENV REPO TAG DRONE_TAG DRONE_BRANCH CROSS RKE2_IMAGE_REPO USE_LOCAL_I
 ENV DAPPER_SOURCE /go/src/github.com/harvester/harvester-installer/
 ENV DAPPER_OUTPUT ./bin ./dist
 ENV DAPPER_DOCKER_SOCKET true
-# append --device /dev/kvm to speed up qcow2 image generation
 ENV DAPPER_RUN_ARGS "-v /run/containerd/containerd.sock:/run/containerd/containerd.sock -v harvester-installer-go:/root/go -v harvester-installer-cache:/root/.cache --privileged"
 
 ENV HOME ${DAPPER_SOURCE}

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -18,11 +18,16 @@ ENV ARCH $DAPPER_HOST_ARCH
 
 # mtools and dosfstools are requirements for luet-makeiso >= 0.4.0 to build hybrid ISO.
 RUN zypper -n rm container-suseconnect && \
-    zypper -n install go1.18 git curl docker gzip tar wget zstd squashfs xorriso awk jq mtools dosfstools rsync
+    zypper -n install go1.18 git curl docker gzip tar wget zstd squashfs xorriso awk jq mtools dosfstools unzip rsync
 RUN curl -sfL https://github.com/mikefarah/yq/releases/download/v4.21.1/yq_linux_${ARCH} -o /usr/bin/yq && chmod +x /usr/bin/yq
 RUN if [ "${ARCH}" == "amd64" ]; then \
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.49.0; \
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.49.0; \
     fi
+
+RUN zypper addrepo http://download.opensuse.org/distribution/leap/15.4/repo/oss/ oss && \
+    zypper --gpg-auto-import-keys refresh && \
+    zypper in -y qemu-x86 qemu-tools
+
 # set up helm
 ENV HELM_VERSION v3.3.1
 ENV HELM_URL=https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz
@@ -35,11 +40,12 @@ COPY --from=luet /usr/bin/luet /usr/bin/luet
 COPY --from=elemental /usr/bin/elemental /usr/bin/elemental
 
 # You cloud defined your own rke2 url by setup `RKE2_IMAGE_REPO`
-ENV DAPPER_ENV REPO TAG DRONE_TAG DRONE_BRANCH CROSS RKE2_IMAGE_REPO USE_LOCAL_IMAGES
+ENV DAPPER_ENV REPO TAG DRONE_TAG DRONE_BRANCH CROSS RKE2_IMAGE_REPO USE_LOCAL_IMAGES BUILD_QCOW
 ENV DAPPER_SOURCE /go/src/github.com/harvester/harvester-installer/
 ENV DAPPER_OUTPUT ./bin ./dist
 ENV DAPPER_DOCKER_SOCKET true
-ENV DAPPER_RUN_ARGS "-v /run/containerd/containerd.sock:/run/containerd/containerd.sock -v harvester-installer-go:/root/go -v harvester-installer-cache:/root/.cache"
+# append --device /dev/kvm to speed up qcow2 image generation
+ENV DAPPER_RUN_ARGS "-v /run/containerd/containerd.sock:/run/containerd/containerd.sock -v harvester-installer-go:/root/go -v harvester-installer-cache:/root/.cache --privileged"
 
 ENV HOME ${DAPPER_SOURCE}
 WORKDIR ${DAPPER_SOURCE}

--- a/package/harvester-os/files/usr/sbin/harv-dummy-iface
+++ b/package/harvester-os/files/usr/sbin/harv-dummy-iface
@@ -1,0 +1,6 @@
+#!/bin/bash -ex
+
+ip link add type dummy
+ip addr add 192.168.1.100/255.255.255.0 dev dummy0
+ip link set dummy0 up
+ip route add default via 192.168.1.100

--- a/package/harvester-os/files/usr/sbin/harv-restart-services
+++ b/package/harvester-os/files/usr/sbin/harv-restart-services
@@ -1,0 +1,3 @@
+#!/bin/bash -ex
+systemctl restart --no-block rancherd
+systemctl restart getty@tty1.service

--- a/package/harvester-os/files/usr/sbin/stream-disk
+++ b/package/harvester-os/files/usr/sbin/stream-disk
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+set -e
+
+TARGET=/run/cos/target
+DATA_DISK_FSLABEL="HARV_LH_DEFAULT"
+DEFAULT_LH_PARTITION="6"
+
+update_boot_args()
+{
+      if [ -z "${HARVESTER_TTY}" ]; then
+          TTY=$(tty | sed 's!/dev/!!')
+      else
+          TTY=$HARVESTER_TTY
+      fi
+
+      if [ -e "/dev/${TTY%,*}" ] && [ "$TTY" != tty1 ] && [ "$TTY" != console ] && [ -n "$TTY" ]; then
+          sed -i "1s/.*/console_params=\"console=${TTY} console=tty1\"/g" ${TARGET}/etc/cos/bootargs.cfg
+      fi
+}
+
+echo "writing image to disk"
+curl --retry 5 --no-buffer -k ${HARVESTER_RAW_DISK_IMAGE_PATH} | dd of=${HARVESTER_DEVICE} bs=1M
+echo -e "w" | fdisk ${HARVESTER_DEVICE}
+
+# if config_url is set then stream this to userdata.yaml as installer will load it on next boot
+echo "checking and writing userdata"
+sleep 30
+if [ -n "${HARVESTER_STREAMDISK_CLOUDINIT_URL}" ]
+then
+  oem_partition=$(blkid -L COS_OEM)
+  mount -t ext4 ${oem_partition} /oem
+  curl -k -o /oem/userdata.yaml ${HARVESTER_STREAMDISK_CLOUDINIT_URL}
+  cp ${HARVESTER_CONFIG} /oem/harvester.config
+  umount /oem
+fi
+
+echo "patching console"
+persistent_partition=$(blkid -L COS_STATE)
+mkdir -p $TARGET
+mount -t ext4 ${persistent_partition} /mnt
+mount /mnt/cOS/active.img ${TARGET}
+
+update_boot_args
+
+# resize HARV_LH_DEFAULT
+echo "resizing default data disk"
+parted ${HARVESTER_DEVICE} resizepart ${DEFAULT_LH_PARTITION} 100%
+mkfs -t ext4 ${HARVESTER_DEVICE}${DEFAULT_LH_PARTITION}
+e2label ${HARVESTER_DEVICE}${DEFAULT_LH_PARTITION} ${DATA_DISK_FSLABEL}

--- a/package/harvester-os/files/usr/sbin/stream-disk
+++ b/package/harvester-os/files/usr/sbin/stream-disk
@@ -20,8 +20,9 @@ update_boot_args()
 }
 
 echo "writing image to disk"
-curl --retry 5 --no-buffer -k ${HARVESTER_RAW_DISK_IMAGE_PATH} | dd of=${HARVESTER_DEVICE} bs=1M
+curl --retry 5 --no-buffer -k ${HARVESTER_RAW_DISK_IMAGE_PATH} | zstd -d -T4 | dd of=${HARVESTER_DEVICE} bs=1M iflag=fullblock oflag=direct
 echo -e "w" | fdisk ${HARVESTER_DEVICE}
+partprobe ${HARVESTER_DEVICE}
 
 # if config_url is set then stream this to userdata.yaml as installer will load it on next boot
 echo "checking and writing userdata"

--- a/package/harvester-os/iso/boot/grub2/grub.cfg
+++ b/package/harvester-os/iso/boot/grub2/grub.cfg
@@ -22,7 +22,7 @@ if [ -f ${font} ];then
 fi
 menuentry "Harvester Installer ${harvester_version}" --class os --unrestricted {
     echo Loading kernel...
-    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0 rd.cos.disable net.ifnames=1
+    $linux ($root)/boot/kernel.xz cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0 rd.cos.disable net.ifnames=1
     echo Loading initrd...
     $initrd ($root)/boot/initrd
 }
@@ -30,7 +30,7 @@ menuentry "Harvester Installer ${harvester_version}" --class os --unrestricted {
 menuentry "Harvester Installer ${harvester_version} (VGA 1024x768)" --class os --unrestricted {
     set gfxpayload=1024x768x24,1024x768
     echo Loading kernel...
-    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0 rd.cos.disable net.ifnames=1
+    $linux ($root)/boot/kernel.xz cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0 rd.cos.disable net.ifnames=1
     echo Loading initrd...
     $initrd ($root)/boot/initrd
 }

--- a/package/harvester-os/iso/boot/grub2/grub.cfg
+++ b/package/harvester-os/iso/boot/grub2/grub.cfg
@@ -22,7 +22,7 @@ if [ -f ${font} ];then
 fi
 menuentry "Harvester Installer ${harvester_version}" --class os --unrestricted {
     echo Loading kernel...
-    $linux ($root)/boot/kernel.xz cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0 rd.cos.disable net.ifnames=1
+    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0 rd.cos.disable net.ifnames=1
     echo Loading initrd...
     $initrd ($root)/boot/initrd
 }
@@ -30,7 +30,7 @@ menuentry "Harvester Installer ${harvester_version}" --class os --unrestricted {
 menuentry "Harvester Installer ${harvester_version} (VGA 1024x768)" --class os --unrestricted {
     set gfxpayload=1024x768x24,1024x768
     echo Loading kernel...
-    $linux ($root)/boot/kernel.xz cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0 rd.cos.disable net.ifnames=1
+    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0 rd.cos.disable net.ifnames=1
     echo Loading initrd...
     $initrd ($root)/boot/initrd
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -379,6 +379,7 @@ func GenerateRancherdConfig(config *HarvesterConfig) (*yipSchema.YipConfig, erro
 	if len(config.OS.NTPServers) > 0 {
 		runtimeConfig.TimeSyncd["NTP"] = strings.Join(config.OS.NTPServers, " ")
 		runtimeConfig.Systemctl.Enable = append(runtimeConfig.Systemctl.Enable, ntpdService)
+		runtimeConfig.Systemctl.Enable = append(runtimeConfig.Systemctl.Enable, timeWaitSyncService)
 	}
 	if len(config.OS.DNSNameservers) > 0 {
 		runtimeConfig.Commands = append(runtimeConfig.Commands, getAddStaticDNSServersCmd(config.OS.DNSNameservers))

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -4,6 +4,7 @@ const (
 	ModeCreate  = "create"
 	ModeJoin    = "join"
 	ModeUpgrade = "upgrade"
+	ModeInstall = "install"
 
 	NetworkMethodDHCP   = "dhcp"
 	NetworkMethodStatic = "static"

--- a/pkg/config/read_test.go
+++ b/pkg/config/read_test.go
@@ -3,6 +3,8 @@ package config
 import (
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestToEnv(t *testing.T) {
@@ -35,4 +37,12 @@ func TestToEnv(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("got = %v, want %v", got, want)
 	}
+}
+
+func TestReadUserData(t *testing.T) {
+	config, err := readUserData("./testdata/userdata.yaml")
+	assert.NoError(t, err, "expected no error during loading of userdata")
+	assert.Equal(t, config.Token, "token", "expected token to be token")
+	assert.Equal(t, config.OS.Password, "p@ssword", "expected password to be p@ssword")
+	assert.Equal(t, config.Install.ManagementInterface.Method, "dhcp", "expected network mode to be dhcp")
 }

--- a/pkg/config/testdata/userdata.yaml
+++ b/pkg/config/testdata/userdata.yaml
@@ -1,0 +1,19 @@
+#cloud-config
+token: token
+os:
+  ssh_authorized_keys:
+    - ssh-rsa ...        # replace with your public key
+  password: p@ssword   # replace with a your password
+  ntp_servers:
+    - 0.suse.pool.ntp.org
+    - 1.suse.pool.ntp.org
+install:
+  mode: create
+  automatic: true
+  networks:
+  management_interface:
+    interfaces:
+      - name: ens0
+      - name: ens3
+    method: dhcp
+  vipMode: dhcp

--- a/pkg/console/dashboard_panels.go
+++ b/pkg/console/dashboard_panels.go
@@ -18,6 +18,7 @@ import (
 	"github.com/harvester/harvester-installer/pkg/util"
 	"github.com/harvester/harvester-installer/pkg/version"
 	"github.com/harvester/harvester-installer/pkg/widgets"
+	"gopkg.in/yaml.v2"
 )
 
 const (
@@ -27,10 +28,11 @@ const (
 	colorYellow
 	colorBlue
 
-	statusReady         = "Ready"
-	statusNotReady      = "NotReady"
-	statusSettingUpNode = "Setting up node"
-	statusSettingUpHarv = "Setting up Harvester"
+	statusReady            = "Ready"
+	statusNotReady         = "NotReady"
+	statusSettingUpNode    = "Setting up node"
+	statusSettingUpHarv    = "Setting up Harvester"
+	defaultHarvesterConfig = "/oem/harvester.config"
 
 	logo string = `
 ██╗░░██╗░█████╗░██████╗░██╗░░░██╗███████╗░██████╗████████╗███████╗██████╗░
@@ -550,4 +552,17 @@ func getNodeStatus() string {
 
 func wrapColor(s string, color int) string {
 	return fmt.Sprintf("\033[3%d;7m%s\033[0m", color, s)
+}
+
+func (c *Console) getHarvesterConfig() error {
+	content, err := ioutil.ReadFile(defaultHarvesterConfig)
+	if err != nil {
+		if os.IsNotExist(err) {
+			logrus.Info("no existing harvester config detected in /oem/harvester.config")
+			return nil
+		}
+		return fmt.Errorf("unable to read default harvester.config file %s: %v", defaultHarvesterConfig, err)
+	}
+
+	return yaml.Unmarshal(content, c.config)
 }

--- a/pkg/console/dashboard_panels.go
+++ b/pkg/console/dashboard_panels.go
@@ -28,11 +28,13 @@ const (
 	colorYellow
 	colorBlue
 
-	statusReady            = "Ready"
-	statusNotReady         = "NotReady"
-	statusSettingUpNode    = "Setting up node"
-	statusSettingUpHarv    = "Setting up Harvester"
+	statusReady         = "Ready"
+	statusNotReady      = "NotReady"
+	statusSettingUpNode = "Setting up node"
+	statusSettingUpHarv = "Setting up Harvester"
+
 	defaultHarvesterConfig = "/oem/harvester.config"
+	defaultCustomConfig    = "/oem/99_custom.yaml"
 
 	logo string = `
 ██╗░░██╗░█████╗░██████╗░██╗░░░██╗███████╗░██████╗████████╗███████╗██████╗░
@@ -558,7 +560,7 @@ func (c *Console) getHarvesterConfig() error {
 	content, err := ioutil.ReadFile(defaultHarvesterConfig)
 	if err != nil {
 		if os.IsNotExist(err) {
-			logrus.Info("no existing harvester config detected in /oem/harvester.config")
+			logrus.Infof("no existing harvester config detected in %s", defaultHarvesterConfig)
 			return nil
 		}
 		return fmt.Errorf("unable to read default harvester.config file %s: %v", defaultHarvesterConfig, err)

--- a/pkg/console/helper.go
+++ b/pkg/console/helper.go
@@ -1,0 +1,96 @@
+package console
+
+import (
+	"github.com/harvester/harvester-installer/pkg/util"
+	"github.com/harvester/harvester-installer/pkg/widgets"
+	"github.com/jroimartin/gocui"
+)
+
+type passwordWrapper struct {
+	c                *Console
+	passwordV        *widgets.Input
+	passwordConfirmV *widgets.Input
+}
+
+func (p *passwordWrapper) passwordVConfirmKeyBinding(g *gocui.Gui, v *gocui.View) error {
+	password1V, err := p.c.GetElement(passwordPanel)
+	if err != nil {
+		return err
+	}
+	userInputData.Password, err = password1V.GetData()
+	if err != nil {
+		return err
+	}
+	if userInputData.Password == "" {
+		return p.c.setContentByName(validatorPanel, "Password is required")
+	}
+	return showNext(p.c, passwordConfirmPanel)
+}
+
+func (p *passwordWrapper) passwordVEscapeKeyBinding(g *gocui.Gui, v *gocui.View) error {
+	p.passwordV.Close()
+	p.passwordConfirmV.Close()
+	if installModeOnly {
+		if canChoose, err := canChooseDataDisk(); err != nil {
+			return err
+		} else if canChoose {
+			return showDataDiskPage(p.c)
+		} else {
+			return showDiskPage(p.c)
+		}
+	}
+	if err := p.c.setContentByName(notePanel, ""); err != nil {
+		return err
+	}
+	return showNext(p.c, tokenPanel)
+}
+
+func (p *passwordWrapper) passwordConfirmVArrowUpKeyBinding(g *gocui.Gui, v *gocui.View) error {
+	var err error
+	userInputData.PasswordConfirm, err = p.passwordConfirmV.GetData()
+	if err != nil {
+		return err
+	}
+	return showNext(p.c, passwordPanel)
+}
+
+func (p *passwordWrapper) passwordConfirmVKeyEnter(g *gocui.Gui, v *gocui.View) error {
+	var err error
+	userInputData.PasswordConfirm, err = p.passwordConfirmV.GetData()
+	if err != nil {
+		return err
+	}
+	if userInputData.Password != userInputData.PasswordConfirm {
+		return p.c.setContentByName(validatorPanel, "Password mismatching")
+	}
+	p.passwordV.Close()
+	p.passwordConfirmV.Close()
+	encrypted, err := util.GetEncryptedPasswd(userInputData.Password)
+	if err != nil {
+		return err
+	}
+	p.c.config.Password = encrypted
+	//TODO: When booted in install mode.. show steps for application of config
+	if installModeOnly {
+		return showNext(p.c, confirmInstallPanel)
+	}
+	return showNext(p.c, ntpServersPanel)
+}
+
+func (p *passwordWrapper) passwordConfirmVKeyEscape(g *gocui.Gui, v *gocui.View) error {
+	p.passwordV.Close()
+	p.passwordConfirmV.Close()
+	if err := p.c.setContentByName(notePanel, ""); err != nil {
+		return err
+	}
+	if installModeOnly {
+		if canChoose, err := canChooseDataDisk(); err != nil {
+			return err
+		} else if canChoose {
+			return showDataDiskPage(p.c)
+		} else {
+			return showDiskPage(p.c)
+		}
+	}
+	return showNext(p.c, tokenPanel)
+}

--- a/pkg/console/helper.go
+++ b/pkg/console/helper.go
@@ -1,9 +1,10 @@
 package console
 
 import (
+	"github.com/jroimartin/gocui"
+
 	"github.com/harvester/harvester-installer/pkg/util"
 	"github.com/harvester/harvester-installer/pkg/widgets"
-	"github.com/jroimartin/gocui"
 )
 
 type passwordWrapper struct {

--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -53,6 +53,8 @@ var (
 	mgmtNetwork = config.Network{
 		DefaultRoute: true,
 	}
+	alreadyInstalled bool
+	installModeOnly  bool
 )
 
 func (c *Console) layoutInstall(g *gocui.Gui) error {
@@ -63,10 +65,30 @@ func (c *Console) layoutInstall(g *gocui.Gui) error {
 
 		c.config.OS.Modules = []string{"kvm", "vhost_net"}
 
+		// if already installed then lets check if cloud init allows us to provision
+		if alreadyInstalled {
+			err = mergeCloudInit(c.config)
+			if err != nil {
+				logrus.Errorf("error merging cloud-config")
+			}
+			logrus.Infof("already install value post config merge: %v", c.config.Automatic)
+			// if already installed and automatic installation is set to true
+			// configure node directly
+			if alreadyInstalled && c.config.Automatic {
+				initPanel = installPanel
+			}
+		}
+
 		if cfg, err := config.ReadConfig(); err == nil {
 			if cfg.Install.Automatic && isFirstConsoleTTY() {
 				logrus.Info("Start automatic installation...")
 				c.config.Merge(cfg)
+				// setup InstallMode to ensure that during automatic install
+				// we are only copying binaries and ignoring network / rancherd setup
+				// needed for generating pre-installed qcow2 image
+				if c.config.Install.Mode == config.ModeInstall && !alreadyInstalled {
+					installModeOnly = true
+				}
 				initPanel = installPanel
 			}
 		} else {
@@ -338,6 +360,11 @@ func addDiskPanel(c *Console) error {
 		} else if canChoose {
 			return showDataDiskPage(c)
 		} else {
+			//TODO: When Install modeonly.. we need to decide that this
+			// network page is not shown and skip straight to the password page
+			if installModeOnly {
+				return showNext(c, passwordConfirmPanel, passwordPanel)
+			}
 			return showHostnamePage(c)
 		}
 	}
@@ -696,6 +723,16 @@ func addAskCreatePanel(c *Console) error {
 				Text:  "Upgrade Harvester",
 			})
 		}
+
+		// layoutInstall is now called from layoutDashboard due to the addition
+		// of the new config.ModeInstall. config will be setup by layoutDashboard before passing control here
+		// this extra option should only show up if that is not the case
+		if !alreadyInstalled {
+			options = append(options, widgets.Option{
+				Value: config.ModeInstall,
+				Text:  "Install Harvester binaries only",
+			})
+		}
 		return options, nil
 	}
 	// new cluster or join existing cluster
@@ -706,6 +743,9 @@ func addAskCreatePanel(c *Console) error {
 	askCreateV.FirstPage = true
 	askCreateV.PreShow = func() error {
 		askCreateV.Value = c.config.Install.Mode
+		if alreadyInstalled {
+			return c.setContentByName(titlePanel, "Harvester already installed. Choose configuration mode")
+		}
 		return c.setContentByName(titlePanel, "Choose installation mode")
 	}
 	askCreateV.KeyBindings = map[gocui.Key]func(*gocui.Gui, *gocui.View) error{
@@ -714,7 +754,19 @@ func addAskCreatePanel(c *Console) error {
 			if err != nil {
 				return err
 			}
+
+			if alreadyInstalled {
+				// need to wipe the Mode value before we set panel
+				// needed to ensure that value lookup fails as install
+				// is not available in the option in this case
+				c.config.Install.Mode = ""
+			}
+
 			c.config.Install.Mode = selected
+			if selected == config.ModeInstall {
+				installModeOnly = true
+			}
+
 			askCreateV.Close()
 
 			if selected == config.ModeCreate {
@@ -722,6 +774,12 @@ func addAskCreatePanel(c *Console) error {
 				userInputData.ServerURL = ""
 			} else if selected == config.ModeUpgrade {
 				return showNext(c, confirmUpgradePanel)
+			}
+
+			// all packages are already install
+			// configure hostname and network
+			if alreadyInstalled {
+				return showHostnamePage(c)
 			}
 			return showDiskPage(c)
 		},
@@ -817,81 +875,38 @@ func addPasswordPanels(c *Console) error {
 		return err
 	}
 
-	passwordV.PreShow = func() error {
+	pw := &passwordWrapper{
+		c:                c,
+		passwordV:        passwordV,
+		passwordConfirmV: passwordConfirmV,
+	}
+
+	pw.passwordV.PreShow = func() error {
 		passwordV.Value = userInputData.Password
 		return nil
 	}
 
-	passwordVConfirm := func(g *gocui.Gui, v *gocui.View) error {
-		password1V, err := c.GetElement(passwordPanel)
-		if err != nil {
-			return err
-		}
-		userInputData.Password, err = password1V.GetData()
-		if err != nil {
-			return err
-		}
-		if userInputData.Password == "" {
-			return c.setContentByName(validatorPanel, "Password is required")
-		}
-		return showNext(c, passwordConfirmPanel)
+	pw.passwordV.KeyBindings = map[gocui.Key]func(*gocui.Gui, *gocui.View) error{
+		gocui.KeyEnter:     pw.passwordVConfirmKeyBinding,
+		gocui.KeyArrowDown: pw.passwordVConfirmKeyBinding,
+		gocui.KeyEsc:       pw.passwordVEscapeKeyBinding,
 	}
-	passwordV.KeyBindings = map[gocui.Key]func(*gocui.Gui, *gocui.View) error{
-		gocui.KeyEnter:     passwordVConfirm,
-		gocui.KeyArrowDown: passwordVConfirm,
-		gocui.KeyEsc: func(g *gocui.Gui, v *gocui.View) error {
-			passwordV.Close()
-			passwordConfirmV.Close()
-			if err := c.setContentByName(notePanel, ""); err != nil {
-				return err
-			}
-			return showNext(c, tokenPanel)
-		},
-	}
-	passwordV.SetLocation(maxX/8, maxY/8, maxX/8*7, maxY/8+2)
-	c.AddElement(passwordPanel, passwordV)
 
-	passwordConfirmV.PreShow = func() error {
+	pw.passwordV.SetLocation(maxX/8, maxY/8, maxX/8*7, maxY/8+2)
+	c.AddElement(passwordPanel, pw.passwordV)
+
+	pw.passwordConfirmV.PreShow = func() error {
 		c.Gui.Cursor = true
 		passwordConfirmV.Value = userInputData.PasswordConfirm
 		c.setContentByName(notePanel, "")
 		return c.setContentByName(titlePanel, "Configure the password to access the node")
 	}
-	passwordConfirmV.KeyBindings = map[gocui.Key]func(*gocui.Gui, *gocui.View) error{
-		gocui.KeyArrowUp: func(g *gocui.Gui, v *gocui.View) error {
-			userInputData.PasswordConfirm, err = passwordConfirmV.GetData()
-			if err != nil {
-				return err
-			}
-			return showNext(c, passwordPanel)
-		},
-		gocui.KeyEnter: func(g *gocui.Gui, v *gocui.View) error {
-			userInputData.PasswordConfirm, err = passwordConfirmV.GetData()
-			if err != nil {
-				return err
-			}
-			if userInputData.Password != userInputData.PasswordConfirm {
-				return c.setContentByName(validatorPanel, "Password mismatching")
-			}
-			passwordV.Close()
-			passwordConfirmV.Close()
-			encrypted, err := util.GetEncryptedPasswd(userInputData.Password)
-			if err != nil {
-				return err
-			}
-			c.config.Password = encrypted
-			return showNext(c, ntpServersPanel)
-		},
-		gocui.KeyEsc: func(g *gocui.Gui, v *gocui.View) error {
-			passwordV.Close()
-			passwordConfirmV.Close()
-			if err := c.setContentByName(notePanel, ""); err != nil {
-				return err
-			}
-			return showNext(c, tokenPanel)
-		},
+	pw.passwordConfirmV.KeyBindings = map[gocui.Key]func(*gocui.Gui, *gocui.View) error{
+		gocui.KeyArrowUp: pw.passwordConfirmVArrowUpKeyBinding,
+		gocui.KeyEnter:   pw.passwordConfirmVKeyEnter,
+		gocui.KeyEsc:     pw.passwordConfirmVKeyEscape,
 	}
-	passwordConfirmV.SetLocation(maxX/8, maxY/8+3, maxX/8*7, maxY/8+5)
+	pw.passwordConfirmV.SetLocation(maxX/8, maxY/8+3, maxX/8*7, maxY/8+5)
 	c.AddElement(passwordConfirmPanel, passwordConfirmV)
 
 	return nil
@@ -1071,6 +1086,10 @@ func addHostnamePanel(c *Console) error {
 
 	prev := func(g *gocui.Gui, v *gocui.View) error {
 		c.CloseElements(hostnamePanel, hostnameValidatorPanel)
+		if alreadyInstalled {
+			return showNext(c, askCreatePanel)
+		}
+
 		if canChoose, err := canChooseDataDisk(); err != nil {
 			return err
 		} else if canChoose {
@@ -1779,8 +1798,16 @@ func addConfirmInstallPanel(c *Console) error {
 		options += string(installBytes)
 		logrus.Debug("cfm cfg: ", fmt.Sprintf("%+v", c.config.Install))
 		if !c.config.Install.Silent {
-			confirmV.SetContent(options +
-				"\nYour disk will be formatted and Harvester will be installed with \nthe above configuration. Continue?\n")
+			if alreadyInstalled {
+				confirmV.SetContent(options +
+					"\nHarvester is already installed. It will be configured with \nthe above configuration.\n Continue?\n")
+			} else if installModeOnly {
+				confirmV.SetContent(options +
+					"\nHarvester will be copied to local disk.\n No configuration will be performed.\n Continue?\n")
+			} else {
+				confirmV.SetContent(options +
+					"\nYour disk will be formatted and Harvester will be installed with \nthe above configuration. Continue?\n")
+			}
 		}
 		c.Gui.Cursor = false
 		return c.setContentByName(titlePanel, "Confirm installation options")
@@ -1803,6 +1830,9 @@ func addConfirmInstallPanel(c *Console) error {
 		},
 		gocui.KeyEsc: func(g *gocui.Gui, v *gocui.View) error {
 			confirmV.Close()
+			if installModeOnly {
+				return showNext(c, passwordConfirmPanel, passwordPanel)
+			}
 			return showNext(c, cloudInitPanel)
 		},
 	}
@@ -1855,6 +1885,10 @@ func addInstallPanel(c *Console) error {
 	installV := widgets.NewPanel(c.Gui, installPanel)
 	installV.PreShow = func() error {
 		go func() {
+			// in alreadyInstalled mode and auto configuration, the network is not available
+			if alreadyInstalled && c.config.Automatic == true && c.config.ManagementInterface.Method == "dhcp" {
+				configureInstallModeDHCP(c)
+			}
 			logrus.Info("Local config: ", c.config)
 			if c.config.Install.ConfigURL != "" {
 				printToPanel(c.Gui, fmt.Sprintf("Fetching %s...", c.config.Install.ConfigURL), installPanel)
@@ -1938,7 +1972,11 @@ func addInstallPanel(c *Console) error {
 				printToPanel(c.Gui, fmt.Sprintf("invalid webhook: %s", err), installPanel)
 			}
 
-			doInstall(c.Gui, c.config, webhooks)
+			if alreadyInstalled {
+				configureInstalledNode(c.Gui, c.config, webhooks)
+			} else {
+				doInstall(c.Gui, c.config, webhooks)
+			}
 		}()
 		return c.setContentByName(footerPanel, "")
 	}
@@ -2322,6 +2360,65 @@ func addDNSServersPanel(c *Console) error {
 		return asyncTaskV.Close()
 	}
 	c.AddElement(dnsServersPanel, dnsServersV)
+
+	return nil
+}
+
+func configureInstallModeDHCP(c *Console) {
+	netDef := c.config.Install.ManagementInterface
+	// copy settings before application //
+	mgmtNetwork.Interfaces = netDef.Interfaces
+	if netDef.BondOptions == nil {
+		mgmtNetwork.BondOptions = map[string]string{
+			"mode":   config.BondModeBalanceTLB,
+			"miimon": "100",
+		}
+	} else {
+		mgmtNetwork.BondOptions = netDef.BondOptions
+	}
+	mgmtNetwork.Method = netDef.Method
+
+	_, err := applyNetworks(
+		mgmtNetwork,
+		c.config.Hostname,
+	)
+	if err != nil {
+		logrus.Error(err)
+		printToPanel(c.Gui, fmt.Sprintf("error applying network configuration: %s", err.Error()), installPanel)
+	}
+
+	_, err = getIPThroughDHCP(config.MgmtInterfaceName)
+	if err != nil {
+		printToPanel(c.Gui, fmt.Sprintf("error getting DHCP address: %s", err.Error()), installPanel)
+	}
+
+	// if need vip via dhcp
+	if c.config.Install.VipMode == config.NetworkMethodDHCP {
+		vip, err := getVipThroughDHCP(config.MgmtInterfaceName)
+		if err != nil {
+			printToPanel(c.Gui, fmt.Sprintf("fail to get vip: %s", err), installPanel)
+			return
+		}
+		c.config.Vip = vip.ipv4Addr
+		c.config.VipHwAddr = vip.hwAddr
+	}
+
+}
+
+func mergeCloudInit(c *config.HarvesterConfig) error {
+	cloudConfig, err := config.ReadUserDataConfig()
+	if err != nil {
+		return err
+	}
+	if cloudConfig.Install.Automatic {
+		c.Merge(cloudConfig)
+		if cloudConfig.OS.Hostname != "" {
+			c.OS.Hostname = cloudConfig.OS.Hostname
+		}
+		if cloudConfig.OS.Password != "" {
+			c.OS.Password = cloudConfig.OS.Password
+		}
+	}
 
 	return nil
 }

--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -763,6 +763,10 @@ func addAskCreatePanel(c *Console) error {
 			}
 
 			c.config.Install.Mode = selected
+			// explicitly set this false to ensure if user changes from
+			// install mode only to create /join then the variable is
+			// reset to ensure correct panel sequence is displayed
+			installModeOnly = false
 			if selected == config.ModeInstall {
 				installModeOnly = true
 			}

--- a/pkg/console/util.go
+++ b/pkg/console/util.go
@@ -871,7 +871,6 @@ func applyRancherdConfig(ctx context.Context, g *gocui.Gui, hvstConfig *config.H
 	if err != nil {
 		return err
 	}
-	//defer os.Remove(liveCosConfig)
 
 	// apply live stage to configure node
 	err = apply(ctx, g, liveCosConfig, "live")
@@ -924,13 +923,11 @@ func generateEnvAndConfig(g *gocui.Gui, hvstConfig *config.HarvesterConfig) ([]s
 	if err != nil {
 		return nil, nil, err
 	}
-	//defer os.Remove(cosConfigFile)
 
 	hvstConfigFile, err := saveTemp(hvstConfig, "harvester")
 	if err != nil {
 		return nil, nil, err
 	}
-	//defer os.Remove(hvstConfigFile)
 
 	userDataUrl := hvstConfig.Install.ConfigURL
 	hvstConfig.Install.ConfigURL = cosConfigFile

--- a/pkg/console/util.go
+++ b/pkg/console/util.go
@@ -773,17 +773,16 @@ func configureInstalledNode(g *gocui.Gui, hvstConfig *config.HarvesterConfig, we
 	defer os.Remove(cosConfigFile)
 	defer os.Remove(hvstConfigFile)
 
-	err = applyRancherdConfig(ctx, g, hvstConfig, cosConfig)
-	if err != nil {
+	if err := applyRancherdConfig(ctx, g, hvstConfig, cosConfig); err != nil {
 		printToPanel(g, fmt.Sprintf("error applying rancherd config :%v", err), installPanel)
 		return err
 	}
 
-	err = restartCoreServices()
-	if err != nil {
+	if err := restartCoreServices(); err != nil {
 		printToPanel(g, fmt.Sprintf("error restarting core services: %v", err), installPanel)
 	}
-	return err
+
+	return nil
 }
 
 func apply(ctx context.Context, g *gocui.Gui, configFile string, stage string) error {
@@ -860,8 +859,8 @@ func applyRancherdConfig(ctx context.Context, g *gocui.Gui, hvstConfig *config.H
 	copyFiles := yipSchema.Stage{
 		Name: "copy files",
 		Commands: []string{
-			fmt.Sprintf("cp %s /oem/99_custom.yaml", cosConfigFile),
-			fmt.Sprintf("cp %s /oem/harvester.config", hvstConfigFile),
+			fmt.Sprintf("cp %s %s", defaultCustomConfig, cosConfigFile),
+			fmt.Sprintf("cp %s %s", defaultHarvesterConfig, hvstConfigFile),
 		},
 	}
 
@@ -873,8 +872,7 @@ func applyRancherdConfig(ctx context.Context, g *gocui.Gui, hvstConfig *config.H
 	}
 
 	// apply live stage to configure node
-	err = apply(ctx, g, liveCosConfig, "live")
-	if err != nil {
+	if err := apply(ctx, g, liveCosConfig, "live"); err != nil {
 		return err
 	}
 

--- a/pkg/console/util.go
+++ b/pkg/console/util.go
@@ -859,8 +859,8 @@ func applyRancherdConfig(ctx context.Context, g *gocui.Gui, hvstConfig *config.H
 	copyFiles := yipSchema.Stage{
 		Name: "copy files",
 		Commands: []string{
-			fmt.Sprintf("cp %s %s", defaultCustomConfig, cosConfigFile),
-			fmt.Sprintf("cp %s %s", defaultHarvesterConfig, hvstConfigFile),
+			fmt.Sprintf("cp %s %s", cosConfigFile, defaultCustomConfig),
+			fmt.Sprintf("cp %s %s", hvstConfigFile, defaultHarvesterConfig),
 		},
 	}
 

--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -127,7 +127,15 @@ rm -rf "${extract_dir}"
 if [ "${BUILD_QCOW}" == "true" ]; then
   echo "generating harvester install mode qcow"
   qemu-img create -f raw -o size=250G ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-amd64.raw
-  qemu-system-x86_64 --enable-kvm -nographic -cpu host -smp cores=2,threads=2,sockets=1 -m 8192 -serial mon:stdio -serial file:harvester-installer.log  -nic none -drive file=${ARTIFACTS_DIR}/${PROJECT_PREFIX}-amd64.raw,if=virtio,cache=writeback,discard=ignore,format=raw -boot d -cdrom ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-amd64.iso -kernel ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-vmlinuz-amd64 -append "cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.ram=1 rd.live.squashimg=rootfs.squashfs console=ttyS1 rd.cos.disable net.ifnames=1 harvester.install.mode=install harvester.install.device=/dev/vda harvester.install.automatic=true harvester.install.powerOff=true harvester.os.password=rancher harvester.scheme_version=1 harvester.install.persistentPartitionSize=150Gi" -initrd ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-initrd-amd64 -boot once=d
+  qemu-system-x86_64 --enable-kvm -nographic -cpu host -smp cores=2,threads=2,sockets=1 -m 8192 -serial mon:stdio \
+  -serial file:harvester-installer.log  -nic none \
+  -drive file=${ARTIFACTS_DIR}/${PROJECT_PREFIX}-amd64.raw,if=virtio,cache=writeback,discard=ignore,format=raw \
+  -boot d -cdrom ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-amd64.iso -kernel ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-vmlinuz-amd64 \
+  -append "cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.ram=1 rd.live.squashimg=rootfs.squashfs \
+  console=ttyS1 rd.cos.disable net.ifnames=1 harvester.install.mode=install harvester.install.device=/dev/vda \
+  harvester.install.automatic=true harvester.install.powerOff=true harvester.os.password=rancher \
+  harvester.scheme_version=1 harvester.install.persistentPartitionSize=150Gi" \
+  -initrd ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-initrd-amd64 -boot once=d
   tail -100 harvester-installer.log
   echo "compressing raw image"
   zstd -T4 --rm ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-amd64.raw

--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -129,8 +129,8 @@ if [ "${BUILD_QCOW}" == "true" ]; then
   qemu-img create -f raw -o size=250G ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-amd64.raw
   qemu-system-x86_64 --enable-kvm -nographic -cpu host -smp cores=2,threads=2,sockets=1 -m 8192 -serial mon:stdio -serial file:harvester-installer.log  -nic none -drive file=${ARTIFACTS_DIR}/${PROJECT_PREFIX}-amd64.raw,if=virtio,cache=writeback,discard=ignore,format=raw -boot d -cdrom ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-amd64.iso -kernel ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-vmlinuz-amd64 -append "cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.ram=1 rd.live.squashimg=rootfs.squashfs console=ttyS1 rd.cos.disable net.ifnames=1 harvester.install.mode=install harvester.install.device=/dev/vda harvester.install.automatic=true harvester.install.powerOff=true harvester.os.password=rancher harvester.scheme_version=1 harvester.install.persistentPartitionSize=150Gi" -initrd ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-initrd-amd64 -boot once=d
   tail -100 harvester-installer.log
-  echo "converting qcow2 to raw image"
-  qemu-img convert -f raw -O qcow2 ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-amd64.raw ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-amd64.qcow2
+  echo "compressing raw image"
+  zstd -T4 --rm ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-amd64.raw
 fi
 
 # Write checksum

--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -126,8 +126,8 @@ rm -rf "${extract_dir}"
 
 if [ "${BUILD_QCOW}" == "true" ]; then
   echo "generating harvester install mode qcow"
-  qemu-img create -f raw -o preallocation=full -o size=60G ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-amd64.raw
-  qemu-system-x86_64 --enable-kvm -nographic -cpu host -smp cores=2,threads=2,sockets=1 -m 8192 -serial mon:stdio -serial file:harvester-installer.log  -nic none -drive file=${ARTIFACTS_DIR}/${PROJECT_PREFIX}-amd64.raw,if=virtio,cache=writeback,discard=ignore,format=raw -boot d -cdrom ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-amd64.iso -kernel ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-vmlinuz-amd64 -append "cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.ram=1 rd.live.squashimg=rootfs.squashfs console=ttyS1 rd.cos.disable net.ifnames=1 harvester.install.mode=install harvester.install.device=/dev/vda harvester.install.automatic=true harvester.install.powerOff=true harvester.os.password=rancher harvester.scheme_version=1" -initrd ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-initrd-amd64 -boot once=d
+  qemu-img create -f raw -o size=250G ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-amd64.raw
+  qemu-system-x86_64 --enable-kvm -nographic -cpu host -smp cores=2,threads=2,sockets=1 -m 8192 -serial mon:stdio -serial file:harvester-installer.log  -nic none -drive file=${ARTIFACTS_DIR}/${PROJECT_PREFIX}-amd64.raw,if=virtio,cache=writeback,discard=ignore,format=raw -boot d -cdrom ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-amd64.iso -kernel ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-vmlinuz-amd64 -append "cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.ram=1 rd.live.squashimg=rootfs.squashfs console=ttyS1 rd.cos.disable net.ifnames=1 harvester.install.mode=install harvester.install.device=/dev/vda harvester.install.automatic=true harvester.install.powerOff=true harvester.os.password=rancher harvester.scheme_version=1 harvester.install.persistentPartitionSize=150Gi" -initrd ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-initrd-amd64 -boot once=d
   tail -100 harvester-installer.log
 fi
 

--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -124,6 +124,13 @@ xorriso -volid "$(yq '.iso.label' manifest.yaml)" \
 # Cleanup
 rm -rf "${extract_dir}"
 
+if [ "${BUILD_QCOW}" == "true" ]; then
+  echo "generating harvester install mode qcow"
+  qemu-img create -f raw -o preallocation=full -o size=60G ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-amd64.raw
+  qemu-system-x86_64 --enable-kvm -nographic -cpu host -smp cores=2,threads=2,sockets=1 -m 8192 -serial mon:stdio -serial file:harvester-installer.log  -nic none -drive file=${ARTIFACTS_DIR}/${PROJECT_PREFIX}-amd64.raw,if=virtio,cache=writeback,discard=ignore,format=raw -boot d -cdrom ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-amd64.iso -kernel ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-vmlinuz-amd64 -append "cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.ram=1 rd.live.squashimg=rootfs.squashfs console=ttyS1 rd.cos.disable net.ifnames=1 harvester.install.mode=install harvester.install.device=/dev/vda harvester.install.automatic=true harvester.install.powerOff=true harvester.os.password=rancher harvester.scheme_version=1" -initrd ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-initrd-amd64 -boot once=d
+  tail -100 harvester-installer.log
+fi
+
 # Write checksum
 cd ${ARTIFACTS_DIR}
 CHECKSUM_FILE=${ISO_PREFIX}.sha512

--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -129,6 +129,8 @@ if [ "${BUILD_QCOW}" == "true" ]; then
   qemu-img create -f raw -o size=250G ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-amd64.raw
   qemu-system-x86_64 --enable-kvm -nographic -cpu host -smp cores=2,threads=2,sockets=1 -m 8192 -serial mon:stdio -serial file:harvester-installer.log  -nic none -drive file=${ARTIFACTS_DIR}/${PROJECT_PREFIX}-amd64.raw,if=virtio,cache=writeback,discard=ignore,format=raw -boot d -cdrom ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-amd64.iso -kernel ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-vmlinuz-amd64 -append "cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.ram=1 rd.live.squashimg=rootfs.squashfs console=ttyS1 rd.cos.disable net.ifnames=1 harvester.install.mode=install harvester.install.device=/dev/vda harvester.install.automatic=true harvester.install.powerOff=true harvester.os.password=rancher harvester.scheme_version=1 harvester.install.persistentPartitionSize=150Gi" -initrd ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-initrd-amd64 -boot once=d
   tail -100 harvester-installer.log
+  echo "converting qcow2 to raw image"
+  qemu-img convert -f raw -O qcow2 ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-amd64.raw ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-amd64.qcow2
 fi
 
 # Write checksum


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Support ability to install harvester to a machine without configuring the node.
**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
PR introduces a new install mode, which allows users to install the harvester binaries to disk, without configuring the k8s components.

This allows users to install harvester and ship devices to remote location for configuration on first boot.

In addition, the PR also introduces generation of a pre-installed qcow2 image which can be later used with the new install mode and automatic installation to stream disk to image, there by improving provisioning times in public cloud providers like equinix metal.

In automatic install mode, if a config_url is provided, then the same is also written to disk, and node will auto configure on the first boot, ensuring faster provisioning.

**Related Issue:**
https://github.com/harvester/harvester/issues/2198
**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

