### PR TITLE
Support os.persistentStatePaths in Harvester configuration

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -148,6 +148,8 @@ type OS struct {
 	Password       string            `json:"password,omitempty"`
 	Environment    map[string]string `json:"environment,omitempty"`
 	Labels         map[string]string `json:"labels,omitempty"`
+
+	PersistentStatePaths []string `json:"persistentStatePaths,omitempty"`
 }
 
 type HarvesterConfig struct {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -276,6 +276,23 @@ func TestHarvesterRootfsRendering(t *testing.T) {
 				assert.NotContains(t, rootfs.Environment["PERSISTENT_STATE_PATHS"], "/var/lib/harvester/defaultdisk")
 			},
 		},
+		{
+			name: "Test additional persistent state paths",
+			harvConfig: HarvesterConfig{
+				OS: OS{
+					PersistentStatePaths: []string{
+						"/path1",
+						"/path2",
+					},
+				},
+			},
+			assertion: func(t *testing.T, rootfs *Rootfs) {
+				assert.Contains(t, rootfs.Environment["VOLUMES"], "LABEL=HARV_LH_DEFAULT:/var/lib/harvester/defaultdisk")
+				assert.NotContains(t, rootfs.Environment["PERSISTENT_STATE_PATHS"], "/var/lib/harvester/defaultdisk")
+				assert.Contains(t, rootfs.Environment["PERSISTENT_STATE_PATHS"], "/path1")
+				assert.Contains(t, rootfs.Environment["PERSISTENT_STATE_PATHS"], "/path2")
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/config/templates/cos-rootfs.yaml
+++ b/pkg/config/templates/cos-rootfs.yaml
@@ -25,6 +25,11 @@ environment:
     /var/lib/third-party
     /var/crash
     /var/lib/longhorn
+    {{- if .OS.PersistentStatePaths }}
+    {{- range $path := .OS.PersistentStatePaths }}
+    {{ $path }}
+    {{- end }}
+    {{- end }}
     {{- if not .ShouldMountDataPartition }}
     /var/lib/harvester/defaultdisk
     {{- end }}


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Currently, Harvester OS does not support custom paths for persistent storage or read-write paths. This means that any changes made to files not in default persistentStatePaths will be lost upon reboot.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
To address this issue, this pull request adds a  new options to the Harvester OS configuration in Harvester config. 

 The `os.persistentStatePaths` option allows users to configure custom paths where modifications made to files will persist across reboots. This means that any changes made to files in these paths will not be lost upon reboot.

an config example for install rook-ceph in Harvester
```yaml
os:
  persistentStatePaths:
    - /var/lib/rook
  modules:
    - rbd
    - nbd
``` 

Without this PR, users can achieve the same effect by modifying `/oem/90_custom.yaml` and then rebootting. This PR allows users to define the desired os layout at installation time.

**Related Issue:**
https://github.com/harvester/harvester/issues/3688

**Note**
Please ensure that any custom paths added using these options are valid and secure, and that any modifications made to the OS are done with caution and understanding of the potential risks.

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
Refer to https://github.com/harvester/harvester/pull/3566
