### PR TITLE
build: bump base os to 20230323

### DIFF
--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -17,7 +17,7 @@ source ${SCRIPTS_DIR}/version-harvester ${TOP_DIR}/../harvester
 source ${SCRIPTS_DIR}/version-monitoring
 source ${SCRIPTS_DIR}/version-logging
 
-BASE_OS_IMAGE="rancher/harvester-os:20230303"
+BASE_OS_IMAGE="rancher/harvester-os:20230323"
 HARVESTER_OS_IMAGE=rancher/harvester-os:$VERSION
 
 cd ${PACKAGE_HARVESTER_OS_DIR}


### PR DESCRIPTION
**Problem:**
base os needs to update

**Solution:**
bump to the latest base os `20230323`

**Related Issue:**

**Test plan:**

**Additional appendix:**
The whole updated packages are below.
```
Version differences:
PACKAGE                   IMAGE1 (docker.io/rancher/harvester-os:20230303)        IMAGE2 (docker.io/rancher/harvester-os:20230323)
-grub2                    2.06-150400.11.17.1, 25M                                2.06-150400.11.23.2, 25M
-grub2-i386-pc            2.06-150400.11.17.1, 2.4M                               2.06-150400.11.23.2, 2.3M
-grub2-x86_64-efi         2.06-150400.11.17.1, 6.6M                               2.06-150400.11.23.2, 6.5M
-k9s                      0.26.7-150400.6.3, 74.8M                                0.26.7-150400.6.5, 74.8M
-kbd                      2.4.0-150400.3.5, 4M                                    2.4.0-150400.5.3.1, 4M
-kbd-legacy               2.4.0-150400.3.5, 560K                                  2.4.0-150400.5.3.1, 560K
-kernel-default           5.14.21-150400.24.46.1, 192.4M                          5.14.21-150400.24.49.3, 192.4M
-kexec-tools              2.0.20-150400.14.5, 305.7K                              2.0.20-150400.16.3.1, 305.7K
-kpartx                   0.9.0+62+suse.3e048d4-150400.4.7.1, 68K                 0.9.0+62+suse.3e048d4-150400.4.10.1, 68K
-libX11-6                 1.6.5-150000.3.24.1, 1.3M                               1.6.5-150000.3.27.1, 1.3M
-libX11-data              1.6.5-150000.3.24.1, 1.2M                               1.6.5-150000.3.27.1, 1.2M
-libgcc_s1                12.2.1+git416-150000.1.5.1, 122.7K                      12.2.1+git416-150000.1.7.1, 122.7K
-libgcrypt20              1.9.4-150400.6.5.1, 1.3M                                1.9.4-150400.6.8.1, 1.3M
-libjitterentropy3        3.4.0-150000.1.6.1, 46.6K                               3.4.0-150000.1.9.1, 46.7K
-libmpath0                0.9.0+62+suse.3e048d4-150400.4.7.1, 810.8K              0.9.0+62+suse.3e048d4-150400.4.10.1, 810.8K
-libopenssl1_1            1.1.1l-150400.7.25.1, 3.9M                              1.1.1l-150400.7.28.1, 3.9M
-libpython3_6m1_0         3.6.15-150300.10.40.1, 2.7M                             3.6.15-150300.10.45.1, 2.7M
-libsolv-tools            0.7.22-150400.1.5, 5.1M                                 0.7.23-150400.3.3.1, 5.1M
-libstdc++6               12.2.1+git416-150000.1.5.1, 2.1M                        12.2.1+git416-150000.1.7.1, 2.1M
-libzypp                  17.31.2-150400.3.9.1, 9.7M                              17.31.8-150400.3.14.1, 10.5M
-multipath-tools          0.9.0+62+suse.3e048d4-150400.4.7.1, 250.7K              0.9.0+62+suse.3e048d4-150400.4.10.1, 250.7K
-openssl-1_1              1.1.1l-150400.7.25.1, 1.6M                              1.1.1l-150400.7.28.1, 1.6M
-python3                  3.6.15-150300.10.40.1, 141.3K                           3.6.15-150300.10.45.1, 141.3K
-python3-base             3.6.15-150300.10.40.1, 30.6M                            3.6.15-150300.10.45.1, 30.5M
-python3-curses           3.6.15-150300.10.40.1, 148.5K                           3.6.15-150300.10.45.1, 148.5K
-qemu-guest-agent         6.2.0-150400.37.8.2, 634K                               6.2.0-150400.37.11.1, 633.7K
-rpm-ndb                  4.14.3-150300.52.1, 3M                                  4.14.3-150300.55.1, 3M
-vim-data-common          9.0.1234-150000.5.34.1, 443.7K                          9.0.1386-150000.5.37.1, 445.2K
-vim-small                9.0.1234-150000.5.34.1, 1.5M                            9.0.1386-150000.5.37.1, 1.5M
-xen-libs                 4.16.3_02-150400.4.19.1, 1.7M                           4.16.3_06-150400.4.25.1, 1.7M
-zypper                   1.14.57-150400.3.9.1, 7.9M                              1.14.59-150400.3.12.2, 7.9M
```

