### PR TITLE
build: bump base os to 20230328

### DIFF
--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -17,7 +17,7 @@ source ${SCRIPTS_DIR}/version-harvester ${TOP_DIR}/../harvester
 source ${SCRIPTS_DIR}/version-monitoring
 source ${SCRIPTS_DIR}/version-logging
 
-BASE_OS_IMAGE="rancher/harvester-os:20230323"
+BASE_OS_IMAGE="rancher/harvester-os:20230328"
 HARVESTER_OS_IMAGE=rancher/harvester-os:$VERSION
 
 cd ${PACKAGE_HARVESTER_OS_DIR}


### PR DESCRIPTION
**Problem:**
Some packages of harvester base os need to update

**Solution:**
bump harvester base os to the latest

**Related Issue:**

**Test plan:**

**Additional appendix:**
The whole updated packages are below.
```
Version differences:
PACKAGE                    IMAGE1 (docker.io/rancher/harvester-os:20230323)        IMAGE2 (docker.io/rancher/harvester-os:20230328)
-curl                      7.79.1-150400.5.15.1, 729.5K                            7.79.1-150400.5.18.1, 729.5K
-libcurl4                  7.79.1-150400.5.15.1, 630.7K                            7.79.1-150400.5.18.1, 630.7K
-libndctl6                 71.1-150400.8.5, 253.9K                                 71.1-150400.10.3.1, 253.9K
-librados2                 16.2.9.536+g41a9f9a5573-150400.3.3.1, 12.5M             16.2.11.58+g38d6afd3b78-150400.3.6.1, 12.6M
-librbd1                   16.2.9.536+g41a9f9a5573-150400.3.3.1, 13.1M             16.2.11.58+g38d6afd3b78-150400.3.6.1, 13.1M
-libsgutils2-1_47-2        1.47+5.d13bc56-150400.3.3.1, 267.8K                     1.47+13.75d23ac-150400.3.6.1, 267.8K
-nfs-client                2.1.1-150100.10.27.1, 733.3K                            2.1.1-150100.10.32.1, 733.2K
-nfs-kernel-server         2.1.1-150100.10.27.1, 277.6K                            2.1.1-150100.10.32.1, 277.6K
-qemu-guest-agent          6.2.0-150400.37.11.1, 633.7K                            6.2.0-150400.37.14.2, 633.7K
-sg3_utils                 1.47+5.d13bc56-150400.3.3.1, 2.3M                       1.47+13.75d23ac-150400.3.6.1, 2.3M
```