### PR TITLE
Support os.afterInstallChrootCommands in Harvester configuration

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -136,9 +136,10 @@ type File struct {
 }
 
 type OS struct {
-	SSHAuthorizedKeys []string `json:"sshAuthorizedKeys,omitempty"`
-	WriteFiles        []File   `json:"writeFiles,omitempty"`
-	Hostname          string   `json:"hostname,omitempty"`
+	AfterInstallChrootCommands []string `json:"afterInstallChrootCommands,omitempty"`
+	SSHAuthorizedKeys          []string `json:"sshAuthorizedKeys,omitempty"`
+	WriteFiles                 []File   `json:"writeFiles,omitempty"`
+	Hostname                   string   `json:"hostname,omitempty"`
 
 	Modules        []string          `json:"modules,omitempty"`
 	Sysctls        map[string]string `json:"sysctls,omitempty"`

--- a/pkg/config/cos.go
+++ b/pkg/config/cos.go
@@ -183,7 +183,25 @@ func ConvertToCOS(config *HarvesterConfig) (*yipSchema.YipConfig, error) {
 		},
 	}
 
+	// Add after-install-chroot stage
+	if len(config.OS.AfterInstallChrootCommands) > 0 {
+		afterInstallChroot := yipSchema.Stage{}
+		if err := overwriteAfterInstallChrootStage(config, &afterInstallChroot); err != nil {
+			return nil, err
+		}
+		cosConfig.Stages["after-install-chroot"] = []yipSchema.Stage{afterInstallChroot}
+	}
+
 	return cosConfig, nil
+}
+
+func overwriteAfterInstallChrootStage(config *HarvesterConfig, stage *yipSchema.Stage) error {
+	content, err := render("cos-after-install-chroot.yaml", config)
+	if err != nil {
+		return err
+	}
+
+	return yaml.Unmarshal([]byte(content), stage)
 }
 
 func overwriteRootfsStage(config *HarvesterConfig, stage *yipSchema.Stage) error {

--- a/pkg/config/templates/cos-after-install-chroot.yaml
+++ b/pkg/config/templates/cos-after-install-chroot.yaml
@@ -1,0 +1,9 @@
+# yip stage to overwrite after-install-chroot layout
+if: '[ ! -f "/run/cos/recovery_mode" ]'
+name: "Run after-install-chroot commands"
+commands:
+    {{- if .OS.AfterInstallChrootCommands }}
+    {{- range $cmd := .OS.AfterInstallChrootCommands }}
+    - {{ printf "%q" $cmd }}
+    {{- end }}
+    {{- end }}


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Harvester OS does not support users adding additional software packages.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
To support this requirement, elemental-toolkit provides a stage called [after-install-chroot](https://rancher.github.io/elemental-toolkit/docs/customizing/stages/#after-install-chroot). Commands executed in this stage do not encounter file system write issues and the results of user commands are persistent and will not be lost due to a reboot. We can use this mechanism and expose it through Harvester Configuration.

**Related Issue:**
https://github.com/harvester/harvester/issues/3689

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
1.  build iso from this PR
2.  install node use the following Harvester configuration example:
```yaml
os:
  afterInstallChrootCommands:
    - mkdir /bin/justatestdir
    - cd /bin/justatestdir
    - touch /bin/justatestdir/a
```
3. ssh into node, check status
```bash
ls /bin/justatestdir/a
```
4. reboot
5. repeat step 3
