### PR TITLE
build: bump base os to 20230413

### DIFF
--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -17,7 +17,7 @@ source ${SCRIPTS_DIR}/version-harvester ${TOP_DIR}/../harvester
 source ${SCRIPTS_DIR}/version-monitoring
 source ${SCRIPTS_DIR}/version-logging
 
-BASE_OS_IMAGE="rancher/harvester-os:20230406"
+BASE_OS_IMAGE="rancher/harvester-os:20230413"
 HARVESTER_OS_IMAGE=rancher/harvester-os:$VERSION
 
 cd ${PACKAGE_HARVESTER_OS_DIR}


### PR DESCRIPTION
**Problem:**
Some packages of harvester base os need to update

**Solution:**
bump harvester base os to the latest

**Related Issue:**

**Test plan:**

**Additional appendix:**
The whole updated packages are below.
```
-----RPM-----

Packages found only in docker.io/rancher/harvester-os:20230406: None

Packages found only in docker.io/rancher/harvester-os:20230413: None

Version differences:
PACKAGE                  IMAGE1 (docker.io/rancher/harvester-os:20230406)        IMAGE2 (docker.io/rancher/harvester-os:20230413)
-haveged                 1.9.14-150400.1.5, 72.2K                                1.9.14-150400.3.3.1, 72.2K
-libhavege2              1.9.14-150400.1.5, 132.5K                               1.9.14-150400.3.3.1, 132.5K
-libsystemd0             249.15-150400.8.22.1, 926.9K                            249.16-150400.8.25.7, 926.9K
-libudev1                249.15-150400.8.22.1, 240.4K                            249.16-150400.8.25.7, 240.4K
-libvmtools0             12.1.0-150300.21.2, 1.6M                                12.1.0-150300.23.5, 1.6M
-open-vm-tools           12.1.0-150300.21.2, 1.5M                                12.1.0-150300.23.5, 1.5M
-systemd                 249.15-150400.8.22.1, 10.9M                             249.16-150400.8.25.7, 10.6M
-systemd-sysvinit        249.15-150400.8.22.1, 4.6K                              249.16-150400.8.25.7, 4.6K
-timezone                2022g-150000.75.18.1, 1.2M                              2023c-150000.75.23.1, 1.2M
-udev                    249.15-150400.8.22.1, 8.3M                              249.16-150400.8.25.7, 8.7M
```