### PR TITLE
Avoid iptables rules affecting bridge forwarding

### DIFF
--- a/package/harvester-os/files/etc/sysctl.d/net.conf
+++ b/package/harvester-os/files/etc/sysctl.d/net.conf
@@ -2,3 +2,6 @@
 net.ipv6.conf.all.disable_ipv6 = 1
 net.ipv6.conf.default.disable_ipv6 = 1
 net.ipv6.conf.lo.disable_ipv6 = 1
+
+# avoid iptables rules affecting bridge forwarding
+net.bridge.bridge-nf-call-iptables = 0


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
In the Harvester cluster whose management network has a VLAN ID, the VM will be unable to access the host port or node port with the host IP where the VM is running. 

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Disable `net.bridge.bridge-nf-call-iptables` to avoid iptables rules affecting bridge forwarding.

**Related Issue:** https://github.com/harvester/harvester/issues/3414

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
- Spin up a Harvester whose management network has a VLAN ID
- Create a VM with VLAN network whose VLAN ID is same with the management network.
- Curl <nodeIP:443> in the VM.

