### PR TITLE
Fixed umount error during shutdown

### DIFF
--- a/package/harvester-os/files/etc/systemd/system/rke2-shutdown.service
+++ b/package/harvester-os/files/etc/systemd/system/rke2-shutdown.service
@@ -1,11 +1,11 @@
 [Unit]
-Description=Kill RKE2 Containers for clean unmount
+Description=Kill RKE2 Containers
 DefaultDependencies=no
 RefuseManualStart=yes
-Before=reboot.target halt.target shutdown.target poweroff.target umount.target final.target
+Before=reboot.target halt.target shutdown.target poweroff.target
 
 [Install]
-RequiredBy=reboot.target halt.target shutdown.target poweroff.target umount.target final.target
+RequiredBy=reboot.target halt.target shutdown.target poweroff.target
 
 [Service]
 Type=oneshot

--- a/package/harvester-os/files/etc/systemd/system/rke2-shutdown.service
+++ b/package/harvester-os/files/etc/systemd/system/rke2-shutdown.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Kill RKE2 Containers for clean unmount
+DefaultDependencies=no
+RefuseManualStart=yes
+Before=reboot.target halt.target shutdown.target poweroff.target umount.target final.target
+
+[Install]
+RequiredBy=reboot.target halt.target shutdown.target poweroff.target umount.target final.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/sbin/rke2-kill-containers.sh

--- a/package/harvester-os/files/system/oem/91_rke2-shutdown.yaml
+++ b/package/harvester-os/files/system/oem/91_rke2-shutdown.yaml
@@ -1,0 +1,7 @@
+name: "Enable RKE2 shutdown service"
+stages:
+  initramfs:
+    - name: "enable rke2-shutdown.service"
+      if: 'grep -q root=LABEL=COS_ACTIVE /proc/cmdline && [ -n "$(blkid -L COS_ACTIVE)" ]'
+      commands:
+        - systemctl enable rke2-shutdown.service

--- a/package/harvester-os/files/usr/sbin/rke2-kill-containers.sh
+++ b/package/harvester-os/files/usr/sbin/rke2-kill-containers.sh
@@ -3,11 +3,6 @@ function list_units() {
   systemctl list-units --type=scope --no-legend | grep -Eo "(cri-containerd-.+\.scope)"
 }
 
-function get_unit_status() {
-  local unit_name="$1"
-  systemctl status "${unit_name}"
-}
-
 systemctl stop rke2-server.service || true
 systemctl stop rke2-agent.service || true
 

--- a/package/harvester-os/files/usr/sbin/rke2-kill-containers.sh
+++ b/package/harvester-os/files/usr/sbin/rke2-kill-containers.sh
@@ -13,7 +13,7 @@ if [ ${#unit_list[@]} -lt $max_concurrency ]; then
     max_concurrency=${#unit_list[@]}
 fi
 
-printf '%s\0' "${unit_list[@]}" | xargs -0 -n1 -P "$max_concurrency" sh -c 'sudo systemctl stop --kill-who=all "$@" && echo "Finished $@"' _ | { grep -v '^Finished' || true; } | { grep -v 'xargs:' || true; } &
+printf '%s\0' "${unit_list[@]}" | xargs -0 -n1 -P "$max_concurrency" sh -c 'sudo systemctl stop "$@" && echo "Finished $@"' _ | { grep -v '^Finished' || true; } | { grep -v 'xargs:' || true; } &
 wait
 
 echo "Finished stopping all units."

--- a/package/harvester-os/files/usr/sbin/rke2-kill-containers.sh
+++ b/package/harvester-os/files/usr/sbin/rke2-kill-containers.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -x
+function list_units() {
+  systemctl list-units --type=scope --no-legend | grep -Eo "(cri-containerd-.+\.scope)"
+}
+
+function get_unit_status() {
+  local unit_name="$1"
+  systemctl status "${unit_name}"
+}
+
+systemctl stop rke2-server.service || true
+systemctl stop rke2-agent.service || true
+
+unit_list=($(list_units))
+
+max_concurrency=$(($(nproc) + 1))
+if [ ${#unit_list[@]} -lt $max_concurrency ]; then
+    max_concurrency=${#unit_list[@]}
+fi
+
+printf '%s\0' "${unit_list[@]}" | xargs -0 -n1 -P "$max_concurrency" sh -c 'sudo systemctl stop --kill-who=all "$@" && echo "Finished $@"' _ | { grep -v '^Finished' || true; } | { grep -v 'xargs:' || true; } &
+wait
+
+echo "Finished stopping all units."
+exit 0


### PR DESCRIPTION
**Problem:**
https://github.com/harvester/harvester/issues/1876

**Solution:**
Create a rke2-shutdown.service to run rke2-kill-containers.sh to stop all the running pods (containers) before the system shutdown or reboots. 

The script executes the systemd stop(--kill-who=all) container unit in parallel. Systemd sends a SIGTERM signal to the process first, and if there is no response within the timeout, it will send a SIGKILL signal to the process. 

Through testing, there has been a significant improvement in ext4 errors during container unmounting, but some ext4 errors still occur, which are not fundamentally related to the container program. The following is the ext4 log recorded during the reboot:
```
Apr 19 09:40:40 localhost dracut-initqueue[871]: The superblock could not be read or does not describe a valid ext2/ext3/ext4
Apr 19 09:40:40 localhost dracut-initqueue[871]: filesystem.  If the device is valid and it really contains an ext2/ext3/ext4
Apr 19 09:40:41 localhost kernel: EXT4-fs (loop0): mounting ext2 file system using the ext4 subsystem
Apr 19 09:52:49 node1 kernel: EXT4-fs warning (device sda): ext4_end_bio:348: I/O error 7 writing to inode 2621451 starting block 1740004)
Apr 19 09:52:49 node1 kernel: EXT4-fs warning (device sda): ext4_end_bio:348: I/O error 7 writing to inode 2621451 starting block 1740008)
Apr 19 09:52:49 node1 kernel: EXT4-fs error (device sda) in ext4_reserve_inode_write:5834: Journal has aborted
Apr 19 09:52:49 node1 kernel: EXT4-fs error (device sda): ext4_convert_unwritten_extents:4825: inode #2621451: comm kworker/u24:3: mark_inode_dirty error
Apr 19 09:52:49 node1 kernel: EXT4-fs error (device sda) in ext4_convert_unwritten_io_end_vec:4864: Journal has aborted
Apr 19 09:52:49 node1 kernel: EXT4-fs error (device sdb) in ext4_orphan_add:3211: Journal has aborted
Apr 19 09:52:49 node1 kernel: EXT4-fs error (device sdb) in ext4_create:2822: Journal has aborted
Apr 19 09:52:49 node1 kernel: EXT4-fs error (device sdb): ext4_journal_check_start:83: comm alertmanager: Detected aborted journal
Apr 19 09:52:55 node1 kernel: EXT4-fs error (device sdc): ext4_put_super:1187: comm umount: Couldn't clean up the journal
```

**Related Issue:**
https://github.com/harvester/harvester/issues/1876
https://github.com/rancher/rke2/issues/2411#issue-1117223202

**Test plan:**
1. Build a new image and install
2. Shutdown/Reboot the harvester node
3. check console logs

