### PR TITLE
fix: ignore harvester patch diff of default sc

### DIFF
--- a/pkg/config/templates/rancherd-10-harvester.yaml
+++ b/pkg/config/templates/rancherd-10-harvester.yaml
@@ -78,6 +78,11 @@ resources:
     defaultNamespace: harvester-system
     diff:
       comparePatches:
+      - apiVersion: storage.k8s.io/v1
+        jsonPointers:
+        - /metadata/annotations
+        kind: StorageClass
+        name: harvester-longhorn
       - apiVersion: apiextensions.k8s.io/v1
         jsonPointers:
         - /status/acceptedNames


### PR DESCRIPTION
**Problem:**
The `mcc-harvester` bundle CR will contain an errApplied status after setting a different default storageClass.

**Solution:**
Ignore the patch diff since Harvester is allowing users to config different default storageClass.

**Related Issue:**
https://github.com/harvester/harvester/issues/3802

**Test plan:**
- spin up a new harvester cluster with the new ISO image.
- config a new storage class and set it as the default one.
- check the bundle status of the `mcc-harvester` later, it should not contain any errors like below:
```
ks get bundles -n fleet-local
NAME                                          BUNDLEDEPLOYMENTS-READY   STATUS
fleet-agent-local                             1/1
local-managed-system-agent                    1/1
mcc-harvester                                 0/1                       ErrApplied(1) [Cluster fleet-local/local: cannot patch "harvester-longhorn" with kind StorageClass: admission webhook "validator.harvesterhci.io" denied the request: default storage class %!s(MISSING) already exists, please reset it first]; storageclass.storage.k8s.io harvester-longhorn modified {"metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}
mcc-harvester-crd                             1/1
mcc-local-managed-system-upgrade-controller   1/1
mcc-rancher-logging                           1/1
mcc-rancher-logging-crd                       1/1
mcc-rancher-monitoring                        1/1
mcc-rancher-monitoring-crd                    1/1
```


