### PR TITLE
Add checkPersistentStatePaths

### DIFF
--- a/pkg/console/validator_test.go
+++ b/pkg/console/validator_test.go
@@ -197,3 +197,83 @@ func TestCheckToken(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckPersistentStatePath(t *testing.T) {
+	testCases := []struct {
+		name                string
+		persistentStatePath string
+		expectErr           bool
+	}{
+		{
+			name:                "empty path",
+			persistentStatePath: "",
+			expectErr:           true,
+		},
+		{
+			name:                "not a abs path",
+			persistentStatePath: "var/lib/test",
+			expectErr:           true,
+		},
+		{
+			name:                "valid path",
+			persistentStatePath: "/var/lib/test",
+			expectErr:           false,
+		},
+		{
+			name:                "tmp path1",
+			persistentStatePath: "/tmp",
+			expectErr:           true,
+		},
+		{
+			name:                "tmp path2",
+			persistentStatePath: "/tmp/",
+			expectErr:           true,
+		},
+		{
+			name:                "tmp path3",
+			persistentStatePath: "/tmp/test",
+			expectErr:           true,
+		},
+		{
+			name:                "not tmp path1",
+			persistentStatePath: "/tmptest",
+			expectErr:           false,
+		},
+		{
+			name:                "not tmp path2",
+			persistentStatePath: "/tmptest/",
+			expectErr:           false,
+		},
+		{
+			name:                "not tmp path3",
+			persistentStatePath: "/tmptest/tmp",
+			expectErr:           false,
+		},
+		{
+			name:                "not tmp path4",
+			persistentStatePath: "/tmptest/tmp/",
+			expectErr:           false,
+		},
+		{
+			name:                "not tmp path5",
+			persistentStatePath: "/tmptest/tmp/foo",
+			expectErr:           false,
+		},
+		{
+			name:                "not tmp path6",
+			persistentStatePath: "/tmptest/tmp/foo/",
+			expectErr:           false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkPersistentStatePath(tc.persistentStatePath)
+			if tc.expectErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add a check to the user input path that was missing from the previous PR 

**Related Issue:**
https://github.com/harvester/harvester/issues/3688

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
**case 1**: The pathes used in the Harvester configuration os.persistentStatePaths is always the allowed path when installing
```yaml
os:
  persistentStatePaths:
    - /var/lib/rook
```
online url: https://bit.ly/420wRs3

The installation will be successful

**case 2**: Contain Nonabsolute path in the Harvester configuration os.persistentStatePaths when installing
```yaml
os:
  persistentStatePaths:
    - var/lib/rook
```
online url: https://bit.ly/3NcWjpP

An error `Invalid path. PersistentStatePath must be an absolute path` will be reported during installation

**case 3**: Contain disallowed path `/tmp` in the Harvester configuration os.persistentStatePaths when installing
```yaml
os:
  persistentStatePaths:
    - /var/lib/rook
    - /tmp
```

online url: https://bit.ly/3Aw09D7

An error `Invalid path. Parent dir of PersistentStatePath cannot be /tmp` will be reported during installation

**You can also test this PR by using [harvester-auto](https://github.com/futuretea/harvester-auto)**
build iso by `pr2iso 0 487`
test case 1 by: `pr2cNoBuild 0 487 https://bit.ly/420wRs3`
test case 2 by:`pr2cNoBuild 0 487 https://bit.ly/3NcWjpP`
test case 3 by: `pr2cNoBuild 0 487 https://bit.ly/3Aw09D7`
