### PR TITLE
fix 3979 3839 add prometheus and alertmanager to diff list

### DIFF
--- a/pkg/config/templates/rancherd-13-monitoring.yaml
+++ b/pkg/config/templates/rancherd-13-monitoring.yaml
@@ -22,6 +22,18 @@ resources:
           name: rancher-monitoring-admission
           operations:
             - { "op": "remove", "path": "/webhooks" }
+        - apiVersion: monitoring.coreos.com/v1
+          jsonPointers:
+          - /spec
+          - /status
+          kind: Prometheus
+          name: rancher-monitoring-prometheus
+        - apiVersion: monitoring.coreos.com/v1
+          jsonPointers:
+          - /spec
+          - /status
+          kind: Alertmanager
+          name: rancher-monitoring-alertmanager
     targets:
     - clusterName: local
       clusterSelector:


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

When apply storagenetwork in Harvester, CRD objects prometheus and alertmanager are changed, and prometheus will complain, which may even block upgrade.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Add them into fleet diff path.

Due to there are big amount of differences imported by the storagenetwork fix, to be sure, we skip the `/spec` and `/status` of those 2 objects.

```
    - apiVersion: monitoring.coreos.com/v1
      fieldsType: FieldsV1
      fieldsV1:
        f:spec:
          f:arbitraryFSAccessThroughSMs: {}
          f:containers: {}
          f:replicas: {}
          f:resources:
            f:limits:
              f:cpu: {}
          f:rules:
            .: {}
            f:alert: {}
          f:storage:
            f:volumeClaimTemplate:
              f:metadata: {}
              f:status: {}
        f:status:
          .: {}
          f:availableReplicas: {}
          f:paused: {}
          f:replicas: {}
          f:unavailableReplicas: {}
          f:updatedReplicas: {}
      manager: harvester
```

**Related Issue:**
https://github.com/harvester/harvester/issues/3979
[backport v1.1] [BUG] upgrade stuck while upgrading system service with alertmanager and prometheus #3979

https://github.com/harvester/harvester/issues/3839
[BUG] upgrade stuck while upgrading system service with alertmanager and prometheus


**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
Per issue description in [#3839](https://github.com/harvester/harvester/issues/3839)
