### PR TITLE
Publish harvester-cluster-repo image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -39,6 +39,51 @@ steps:
       - push
       - cron
 
+- name: docker-publish-cluster-repo-branch
+  image: plugins/docker
+  settings:
+    context: dist/harvester-cluster-repo
+    custom_dns: 1.1.1.1
+    dockerfile: dist/harvester-cluster-repo/Dockerfile
+    repo: "rancher/harvester-cluster-repo"
+    tag: ${DRONE_BRANCH}-head-amd64
+    username:
+      from_secret: docker_username
+    password:
+      from_secret: docker_password
+  when:
+    instance:
+    - drone-publish.rancher.io
+    ref:
+      include:
+      - "refs/heads/master"
+      - "refs/heads/v*"
+    event:
+    - push
+    - cron
+
+- name: manifest-cluster-repo-branch
+  image: plugins/manifest
+  settings:
+    username:
+      from_secret: docker_username
+    password:
+      from_secret: docker_password
+    platforms:
+    - linux/amd64
+    target: "rancher/harvester-cluster-repo:${DRONE_BRANCH}-head"
+    template: "rancher/harvester-cluster-repo:${DRONE_BRANCH}-head-ARCH"
+  when:
+    instance:
+    - drone-publish.rancher.io
+    ref:
+      include:
+      - "refs/heads/master"
+      - "refs/heads/v*"
+    event:
+    - push
+    - cron
+
 volumes:
 - name: docker
   host:

--- a/scripts/package-harvester-repo
+++ b/scripts/package-harvester-repo
@@ -2,6 +2,7 @@
 
 TOP_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
 SCRIPTS_DIR="${TOP_DIR}/scripts"
+DIST_REPO_DIR="${TOP_DIR}/dist/harvester-cluster-repo"
 PACKAGE_HARVESTER_OS_DIR="${TOP_DIR}/package/harvester-os"
 PACKAGE_HARVESTER_REPO_DIR="${TOP_DIR}/package/harvester-repo"
 BUNDLE_DIR="${PACKAGE_HARVESTER_OS_DIR}/iso/bundle"
@@ -12,6 +13,10 @@ mkdir -p ${IMAGES_DIR}
 mkdir -p ${IMAGES_LISTS_DIR}
 source ${SCRIPTS_DIR}/version
 source ${SCRIPTS_DIR}/lib/image
+
+# for image publish in CI
+rm -rf ${DIST_REPO_DIR} && mkdir -p ${DIST_REPO_DIR}
+cp -r ${PACKAGE_HARVESTER_REPO_DIR}/* ${DIST_REPO_DIR}
 
 cd ${PACKAGE_HARVESTER_REPO_DIR}
 


### PR DESCRIPTION
Related issue: https://github.com/harvester/harvester/issues/2670

The image is published when:
- merging codes to master and stable branches in the harvester-installer repo (this PR).
- cron CI job runs in the harvester-installer repo (this PR).
- merging codes to master and stable branches in the harvester/harvester repo (https://github.com/harvester/harvester/pull/4223).