### PR TITLE
config: update NTP to SystemSettings

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -66,6 +66,7 @@ func GetSystemSettingsAllowList() []string {
 		"vip-pools",
 		"auto-disk-provision-paths",
 		"containerd-registry",
+		"ntp-servers",
 	}
 }
 
@@ -79,6 +80,10 @@ type Network struct {
 	BondOptions  map[string]string  `json:"bondOptions,omitempty"`
 	MTU          int                `json:"mtu,omitempty"`
 	VlanID       int                `json:"vlanId,omitempty"`
+}
+
+type NTPSettings struct {
+	NTPServers []string `json:"ntpServers,omitempty"`
 }
 
 type HTTPBasicAuth struct {

--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -42,6 +42,7 @@ const (
 const (
 	ErrMsgVLANShouldBeANumberInRange string = "VLAN ID should be a number 1 ~ 4094."
 	ErrMsgMTUShouldBeANumber         string = "MTU should be a number."
+	NtpSettingName                   string = "ntp-servers"
 )
 
 var (


### PR DESCRIPTION
**Problem:**
If we can config the NTP server on UI, we need to make it consistent after the first node creation.

**Solution:**
write the related setting with the mechanism of updating the system settings

**Related Issue:**
https://github.com/harvester/harvester/issues/3133

**Test plan:**
Make sure we have `20-harvester-settings.yaml` and it should contain the ntp-servers information

