### PR TITLE
fix: Adjust Soft & Hard Min Disk Size

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,8 +30,8 @@ const (
 )
 
 const (
-	SoftMinDiskSizeGiB   = 140
-	HardMinDiskSizeGiB   = 60
+	SoftMinDiskSizeGiB   = 500
+	HardMinDiskSizeGiB   = 200
 	MinCosPartSizeGiB    = 25
 	NormalCosPartSizeGiB = 50
 	MaxPods              = 200

--- a/pkg/config/cos_test.go
+++ b/pkg/config/cos_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,50 +24,50 @@ func TestCalcCosPersistentPartSize(t *testing.T) {
 		},
 		{
 			name:        "Disk meet hard requirement",
-			input:       60,
+			input:       200,
 			output:      25,
 			expectError: false,
 		},
 		{
-			name:        "Disk a bit larger than hard requirement: 80G",
-			input:       80,
+			name:        "Disk a bit larger than hard requirement: 250G",
+			input:       250,
+			output:      29,
+			expectError: false,
+		},
+		{
+			name:        "Disk a bit larger than hard requirement: 280G",
+			input:       280,
 			output:      31,
 			expectError: false,
 		},
 		{
-			name:        "Disk a bit larger than hard requirement: 100G",
-			input:       100,
-			output:      37,
-			expectError: false,
-		},
-		{
 			name:        "Disk close to the soft requirement",
-			input:       139,
+			input:       499,
 			output:      49,
 			expectError: false,
 		},
 		{
 			name:        "Disk meet soft requirement",
 			input:       SoftMinDiskSizeGiB,
-			output:      50,
+			output:      90,
 			expectError: false,
 		},
 		{
 			name:        "200GiB",
 			input:       200,
-			output:      60,
+			output:      25,
 			expectError: false,
 		},
 		{
-			name:        "300GiB",
+			name:        "500GiB",
 			input:       300,
-			output:      70,
+			output:      33,
 			expectError: false,
 		},
 		{
 			name:        "400GiB",
 			input:       400,
-			output:      80,
+			output:      41,
 			expectError: false,
 		},
 		{
@@ -98,7 +99,12 @@ func TestCalcCosPersistentPartSize(t *testing.T) {
 				if err != nil {
 					t.Log(err)
 				}
-				assert.Equal(t, sizeGiB, testCase.output)
+				if sizeGiB != testCase.output {
+					out := fmt.Sprintf("Argument: %v\n", testCase.name) +
+						fmt.Sprintf("Expected result: %v\n", testCase.output) +
+						fmt.Sprintf("Actual result: %v\n", sizeGiB)
+					t.Fatalf(out)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
**Problem:**
Sync Soft & Hard Minimum Disk Sizing to Docs

**Solution:**
Adjust hard-coded values.
Improve readability so tests no longer report byte values.
Shifting from:
```
TestCalcCosPersistentPartSize/Disk_close_to_the_soft_requirement
    --- FAIL: TestCalcCosPersistentPartSize/Disk_meet_soft_requirement (0.00s)
        cos_test.go:101: 
                Error Trace:    /go/src/github.com/harvester/harvester-installer/pkg/config/cos_test.go:101
                Error:          Not equal: 
                                expected: 0x3c
                                actual  : 0x32
                Test:           TestCalcCosPersistentPartSize/Disk_meet_soft_requirement
```
To something more like:
```
=== RUN   TestCalcCosPersistentPartSize/500GiB#01
    cos_test.go:106: Argument: 500GiB
        Expected result: 9
        Actual result: 90
    --- FAIL: TestCalcCosPersistentPartSize/500GiB#01 (0.00s)
```

**Related Issue:**
https://github.com/harvester/harvester/issues/4039

**Test plan:**

Case A:
- validate that a disk smaller than 200GB does not meet minimum disk size

Case B:
- validate that a disk smaller than 500GB but greater than 200GB does not meet recommend disk size

Case C:
- validate that a disk that is greater than or equal to 500GB does not cause any mentions of Minimum or Recommend disk sizing


**Additional:**

https://github.com/harvester/harvester-installer/assets/5370752/609fd181-4966-4562-a017-08e03c26e4da


**Note:**
I'm unsure if the:
```go
func calcCosPersistentPartSize(diskSizeGiB uint64) (uint64, error) {
	switch {
	case diskSizeGiB < HardMinDiskSizeGiB:
		return 0, fmt.Errorf("disk too small: %dGB. Minimum %dGB is required", diskSizeGiB, HardMinDiskSizeGiB)
	case diskSizeGiB < SoftMinDiskSizeGiB:
		d := MinCosPartSizeGiB / float64(SoftMinDiskSizeGiB-HardMinDiskSizeGiB)
		partSizeGiB := MinCosPartSizeGiB + float64(diskSizeGiB-HardMinDiskSizeGiB)*d
		return uint64(partSizeGiB), nil
	default:
		partSizeGiB := NormalCosPartSizeGiB + ((diskSizeGiB-100)/100)*10
		if partSizeGiB > 100 {
			partSizeGiB = 100
		}
		return partSizeGiB, nil
	}
}
```
Needs to be adjusted any further for proper partition sizing as we increase both the Minimum & Recommended (Hard/Soft) Disk Sizing Values?
