### PR TITLE
fix rancher-monitoring-crd 102.0.0+up40.1.2 chart RBAC issue

### DIFF
--- a/pkg/config/templates/patch/rancher-monitoring-crd/102.0.0+up40.1.2/rbac.yaml
+++ b/pkg/config/templates/patch/rancher-monitoring-crd/102.0.0+up40.1.2/rbac.yaml
@@ -1,0 +1,76 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Chart.Name }}-manager
+  labels:
+    app: {{ .Chart.Name }}-manager
+rules:
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs: ['create', 'get', 'patch', 'delete', 'update']
+{{- if .Values.global.cattle.psp.enabled }}
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - {{ .Chart.Name }}-manager
+{{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Chart.Name }}-manager
+  labels:
+    app: {{ .Chart.Name }}-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Chart.Name }}-manager
+subjects:
+- kind: ServiceAccount
+  name: {{ .Chart.Name }}-manager
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Chart.Name }}-manager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Chart.Name }}-manager
+---
+{{- if .Values.global.cattle.psp.enabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ .Chart.Name }}-manager
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Chart.Name }}-manager
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+  volumes:
+    - 'configMap'
+    - 'secret'
+{{- end }}

--- a/scripts/build-bundle
+++ b/scripts/build-bundle
@@ -16,6 +16,7 @@ source ${SCRIPTS_DIR}/lib/http
 source ${SCRIPTS_DIR}/lib/image
 source ${SCRIPTS_DIR}/hack/patch-rancher-monitoring
 source ${SCRIPTS_DIR}/hack/patch-rancher-logging
+source ${SCRIPTS_DIR}/hack/patch-rancher-monitoring-crd
 
 BUNDLE_DIR="${PACKAGE_HARVESTER_OS_DIR}/iso/bundle"
 CHARTS_DIR="${PACKAGE_HARVESTER_REPO_DIR}/charts"
@@ -65,6 +66,10 @@ helm pull https://charts.rancher.io/assets/rancher-monitoring/rancher-monitoring
 # patch rancher-monitoring chart to fix issues
 PKG_PATCH_MONITORING_PATH="${TOP_DIR}/pkg/config/templates/patch/rancher-monitoring"
 patch_rancher_monitoring_chart ${CHARTS_DIR} ${MONITORING_VERSION} ${PKG_PATCH_MONITORING_PATH}
+
+# patch rancher-monitoring-crd chart to fix issues
+PKG_PATCH_MONITORING_CRD_PATH="${TOP_DIR}/pkg/config/templates/patch/rancher-monitoring-crd"
+patch_rancher_monitoring_crd_chart ${CHARTS_DIR} ${MONITORING_VERSION} ${PKG_PATCH_MONITORING_CRD_PATH}
 
 # make chart sanity check
 tar zxvf ${CHARTS_DIR}/rancher-monitoring-crd-${MONITORING_VERSION}.tgz >/dev/null --warning=no-timestamp

--- a/scripts/hack/patch-rancher-monitoring-crd
+++ b/scripts/hack/patch-rancher-monitoring-crd
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+patch_rancher_monitoring_crd_chart()
+{
+  local chart_dir=$1 #${CHARTS_DIR}
+  local monitoring_version=$2 #MONITORING_VERSION
+  local pkg_monitoring_crd_path=$3 #${PKG_PATCH_MONITORING_PATH}
+  local cwd=$(pwd)
+
+  if [ ! -d "${pkg_monitoring_crd_path}/${monitoring_version}" ]; then
+    echo "NOTE: there is no related path: ${pkg_monitoring_crd_path}/${monitoring_version} to patch, SKIP"
+    return 0
+  fi
+
+  cd ${chart_dir}
+  tar zxf rancher-monitoring-crd-${monitoring_version}.tgz --warning=no-timestamp
+
+  local origfile="./rancher-monitoring-crd/templates/rbac.yaml"
+  local newfile="${pkg_monitoring_crd_path}/${monitoring_version}/rbac.yaml"
+  echo "patch original file $origfile"
+  if [ -f "$origfile" ]; then
+    ls -alth "$origfile"
+    echo "diff"
+    # when files are different, `diff` will return 1
+    diff "$origfile" "$newfile" || true
+    rm -f "$origfile"
+  else
+    echo "original file $origfile is not found"
+  fi
+
+  # replace with new file
+  cp -f "$newfile" "$origfile"
+  echo "patched file"
+  ls -alth "$origfile"
+
+  # remove existing chart
+  rm -f ${chart_dir}/rancher-monitoring-crd-${monitoring_version}.tgz
+
+  # helm pack new
+  helm package rancher-monitoring-crd
+  echo "finish patch ranch-monitoring-crd chart"
+  cd $cwd
+}
+


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

The `rancher-monitoring-crd` is not fully installed, and error log is observed in https://github.com/harvester/harvester/issues/3969.

The root cause is that the chart installer job has RBAC issue.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Fix the RBAC

**Related Issue:**
Harvester: https://github.com/harvester/harvester/issues/3969

Upstream: https://github.com/rancher/charts/issues/2505

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Befor this PR, when enable `rancher-monitoring` addon, the error message is observed per https://github.com/harvester/harvester/issues/3969

2. With this PR, when enable `rancher-monitoring` addon, the error message is gone.


** Other **
make log:

```
...
patch original file ./rancher-monitoring-crd/templates/rbac.yaml
-rw-r--r-- 1 root root 1.7K Mar 14 17:51 ./rancher-monitoring-crd/templates/rbac.yaml
diff
12c12
<   verbs: ['create', 'get', 'patch', 'delete']
---
>   verbs: ['create', 'get', 'patch', 'delete', 'update']
patched file
-rw-r--r-- 1 root root 1.7K Jun 11 21:21 ./rancher-monitoring-crd/templates/rbac.yaml
Successfully packaged chart and saved it to: /go/src/github.com/harvester/harvester-installer/package/harvester-repo/charts/rancher-monitoring-crd-102.0.0+up40.1.2.tgz
finish patch ranch-monitoring-crd chart

```