### PR TITLE
Specify --xz explicitly when calling dracut to make initrd.

### DIFF
--- a/package/harvester-os/files/usr/sbin/gen-kdump-initrd
+++ b/package/harvester-os/files/usr/sbin/gen-kdump-initrd
@@ -27,13 +27,12 @@ DRACUT_CONFDIR=$TMP_DIR/dracut.conf.d
 mkdir -p $INITRD_EXTRACTED_DIR
 mkdir -p $DRACUT_CONFDIR
 
-
 # specify a new dracut config dir to avoid including cOS configs in /etc/dracut.conf.d
 cat > $DRACUT_CONFDIR/99-tmp.conf <<EOF
 early_microcode="no"
 host_only="yes"
 EOF
-/usr/bin/dracut --confdir $DRACUT_CONFDIR --force --omit "plymouth resume usrmount" --add kdump $TMP_INITRD $KERNEL_VERSION
+/usr/bin/dracut --xz --confdir $DRACUT_CONFDIR --force --omit "plymouth resume usrmount" --add kdump $TMP_INITRD $KERNEL_VERSION
 
 # extract initrd and replace fstab and kdump config
 cd $INITRD_EXTRACTED_DIR


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
By default `dracut` uses Zstandard to compress initrd, and we're trying to use xzcat to decompress initrd which makes `kdump.service` fail to start.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Add `--xz` when calling dracut to use xz compression.

**Related Issue:**
https://github.com/harvester/harvester/issues/3928

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
1. Build an ISO from this branch and deploy;
2. Select debug mode when booting;
3. After booted up, use command `systemctl status kdump.service` to confirm `kdump.service` is up and running;
4. After `kdump.service` exited, use command `echo c > /proc/sysrq-trigger` to trigger a kernel crash manually;
5. The system should reboot automatically and a progress bar (sort of) of kernel dump should show up;
6. After rebooted, select debug mode again, and see if anything under `/var/crash` is generated.

