### PR TITLE
update pcidevices addon to v0.2.5-rc2

### DIFF
--- a/pkg/config/templates/rancherd-22-addons.yaml
+++ b/pkg/config/templates/rancherd-22-addons.yaml
@@ -22,11 +22,9 @@ resources:
     metadata:
       name: pcidevices-controller
       namespace: harvester-system
-      labels:
-        addon.harvesterhci.io/experimental: "true"
     spec:
       repo: http://harvester-cluster-repo.cattle-system.svc/charts
-      version: "0.2.5-rc1"
+      version: "0.2.5-rc2"
       chart: harvester-pcidevices-controller
       {{- if and .Addons .Addons.harvester_pcidevices_controller }}
       enabled: {{ .Addons.harvester_pcidevices_controller.Enabled }}
@@ -35,7 +33,7 @@ resources:
       {{- end }}
       valuesContent: |
         image:
-          tag: v0.2.5-rc1
+          tag: v0.2.5-rc2
         fullnameOverride: harvester-pcidevices-controller
   - apiVersion: harvesterhci.io/v1beta1
     kind: Addon

--- a/scripts/build-bundle
+++ b/scripts/build-bundle
@@ -25,8 +25,8 @@ IMAGES_LISTS_DIR="${BUNDLE_DIR}/harvester/images-lists"
 RANCHERD_IMAGES_DIR="${BUNDLE_DIR}/rancherd/images"
 VM_IMPORT_CONTROLLER_CHART_VERSION="0.1.4"
 VM_IMPORT_CONTROLLER_IMAGE="rancher/harvester-vm-import-controller:v0.1.4"
-PCIDEVICES_CONTROLLER_CHART_VERSION="0.2.5-rc1"
-PCIDEVICES_CONTROLLER_IMAGE="rancher/harvester-pcidevices:v0.2.5-rc1"
+PCIDEVICES_CONTROLLER_CHART_VERSION="0.2.5-rc2"
+PCIDEVICES_CONTROLLER_IMAGE="rancher/harvester-pcidevices:v0.2.5-rc2"
 mkdir -p ${CHARTS_DIR}
 mkdir -p ${IMAGES_DIR}
 mkdir -p ${IMAGES_LISTS_DIR}


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
PR introduces pcidevices controller addon v0.2.5-rc2 chart.
PCIDevices Addon is no longer label experimental.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Related Issue:**

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

