### PR TITLE
Change installation disk space limit to 180Gi when using different disk for data.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,7 +31,8 @@ const (
 )
 
 const (
-	HardMinDiskSizeGiB     = 250
+	SingleDiskMinSizeGiB   = 250
+	MultipleDiskMinSizeGiB = 180
 	HardMinDataDiskSizeGiB = 50
 	MaxPods                = 200
 )

--- a/pkg/console/constant.go
+++ b/pkg/console/constant.go
@@ -78,7 +78,7 @@ const (
 	dnsServersNote         = "Note: You can use comma to add more DNS servers. Leave blank to use default DNS."
 	bondNote               = "Note: Select one or more NICs for the Management NIC.\nUse the default value for the Bond Mode if only one NIC is selected."
 	forceMBRNote           = "Note: GPT is used by default. You can use MBR if you encountered compatibility issues."
-	persistentSizeNote     = "Note: persistent partition stores data like system package and container images, not the VM data. \nYou can specify a size like 200Gi or 15360Mi. \nLeave it blank to use the default value."
+	persistentSizeNote     = "Note: persistent partition stores data like system package and container images, not the VM data. \nYou can specify a size like 200Gi or 153600Mi. \nLeave it blank to use the default value."
 
 	authorizedFile = "/home/rancher/.ssh/authorized_keys"
 )

--- a/pkg/console/helper.go
+++ b/pkg/console/helper.go
@@ -32,13 +32,7 @@ func (p *passwordWrapper) passwordVEscapeKeyBinding(g *gocui.Gui, v *gocui.View)
 	p.passwordV.Close()
 	p.passwordConfirmV.Close()
 	if installModeOnly {
-		if canChoose, err := canChooseDataDisk(); err != nil {
-			return err
-		} else if canChoose {
-			return showDataDiskPage(p.c)
-		} else {
-			return showDiskPage(p.c)
-		}
+		return showDiskPage(p.c)
 	}
 	if err := p.c.setContentByName(notePanel, ""); err != nil {
 		return err
@@ -85,13 +79,7 @@ func (p *passwordWrapper) passwordConfirmVKeyEscape(g *gocui.Gui, v *gocui.View)
 		return err
 	}
 	if installModeOnly {
-		if canChoose, err := canChooseDataDisk(); err != nil {
-			return err
-		} else if canChoose {
-			return showDataDiskPage(p.c)
-		} else {
-			return showDiskPage(p.c)
-		}
+		return showDiskPage(p.c)
 	}
 	return showNext(p.c, tokenPanel)
 }

--- a/pkg/console/util.go
+++ b/pkg/console/util.go
@@ -627,13 +627,18 @@ func harvesterInstalled() (bool, error) {
 	return false, nil
 }
 
-func validateDiskSize(devPath string) error {
+func validateDiskSize(devPath string, single bool) error {
 	diskSizeBytes, err := util.GetDiskSizeBytes(devPath)
 	if err != nil {
 		return err
 	}
-	if util.ByteToGi(diskSizeBytes) < config.HardMinDiskSizeGiB {
-		return fmt.Errorf("Disk size is too small. Minimum %dGi is required", config.HardMinDiskSizeGiB)
+
+	limit := config.SingleDiskMinSizeGiB
+	if !single {
+		limit = config.MultipleDiskMinSizeGiB
+	}
+	if util.ByteToGi(diskSizeBytes) < uint64(limit) {
+		return fmt.Errorf("Disk size is too small. Minimum %dGi is required", limit)
 	}
 
 	return nil

--- a/pkg/widgets/dropdown.go
+++ b/pkg/widgets/dropdown.go
@@ -165,6 +165,10 @@ func (d *DropDown) GetMultiData() []string {
 func (d *DropDown) SetData(data string) error {
 	v, err := d.g.View(d.ViewName)
 	if err != nil {
+		// Ignore ErrUnknownView for now
+		if err == gocui.ErrUnknownView {
+			return nil
+		}
 		return err
 	}
 	v.Clear()


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
When selecting different disk for data, 250Gi limit for installation disk is too large.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Change the limit to 180Gi when using different disk for data.

**Related Issue:**
https://github.com/harvester/harvester/issues/4133

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
### ISO Installation

#### Single Disk
1. Build an ISO from this branch;
2. Boot into the installer, the installer should limit the installation disk at 250Gi minimum.

#### Multiple Disk
1. Build an ISO from this branch;
2. Boot into the installer, and use the same disk for installation disk and data disk;
3. The installer should limit the installation disk at 250Gi minimum;
4. When choosing different disk for installation and data, the installer should limit the installation disk at 180Gi minimum.

### PXE Installation

#### Single disk
1. Build artifacts from this branch;
2. Use PXE to install Harvester artifacts you just built, when disk is smaller than 250Gi it should not continue.

#### Multiple disk
1. Build artifacts from this branch;
2. Prepare a Harvester config yaml, use another disk for data;
3. Use PXE to install Harvester artifacts you just built, when installation disk is smaller than 180Gi or data disk is smaller than 50Gi the installer should not continue.