### PR TITLE
pass DRONE_BUILD_EVENT to dapper

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -40,7 +40,7 @@ COPY --from=luet /usr/bin/luet /usr/bin/luet
 COPY --from=elemental /usr/bin/elemental /usr/bin/elemental
 
 # You cloud defined your own rke2 url by setup `RKE2_IMAGE_REPO`
-ENV DAPPER_ENV REPO TAG DRONE_TAG DRONE_BRANCH CROSS RKE2_IMAGE_REPO USE_LOCAL_IMAGES BUILD_QCOW
+ENV DAPPER_ENV REPO TAG DRONE_TAG DRONE_BRANCH CROSS RKE2_IMAGE_REPO USE_LOCAL_IMAGES BUILD_QCOW DRONE_BUILD_EVENT
 ENV DAPPER_SOURCE /go/src/github.com/harvester/harvester-installer/
 ENV DAPPER_OUTPUT ./bin ./dist
 ENV DAPPER_DOCKER_SOCKET true


### PR DESCRIPTION
**Problem:**
install image build is not triggered via https://github.com/harvester/harvester-installer/pull/530

**Solution:**
pass `DRONE_BUILD_EVENT` to dapper

**Related Issue:**

**Test plan:**
need to re-run the Drone cron job to validate it.
