### PR TITLE
add privileged permission to build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -14,6 +14,7 @@ trigger:
 steps:
 - name: build
   image: rancher/dapper:v0.5.8
+  privileged: true
   commands:
   - dapper ci
   volumes:
@@ -43,4 +44,3 @@ volumes:
 - name: docker
   host:
     path: /var/run/docker.sock
-


### PR DESCRIPTION
**Problem:**
CI failed on https://drone-publish.rancher.io/harvester/harvester-installer/1516/1/2 with 
```
generating harvester install mode qcow
Formatting '/go/src/github.com/harvester/harvester-installer/dist/artifacts/harvester-master-amd64.raw', fmt=raw size=268435456000
Could not access KVM kernel module: No such file or directory
qemu-system-x86_64: failed to initialize kvm: No such file or directory
time="2023-07-07T03:27:11Z" level=fatal msg="exit status 1"
```

**Solution:**
add privileged permission to build


**Related Issue:**

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

