### PR TITLE
minor change to panel flow when machine has multiple disks

### DIFF
--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -614,6 +614,9 @@ func addDataDiskPanel(c *Console) error {
 
 	gotoNextPage := func() error {
 		closeThisPage()
+		if installModeOnly {
+			return showNext(c, passwordConfirmPanel, passwordPanel)
+		}
 		return showHostnamePage(c)
 	}
 


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
PR introduces a minor change to the installer to direct panel flow to password panel when node has multiple disks.

When multiple disks are present the disk choose page, after choosing the installation disk, the installer guides user to hostname panel even when install node is present.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
The PR changes the workflow when additional disks are present on the node.

**Related Issue:**

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

