### PR TITLE
bump vmdp image

### DIFF
--- a/scripts/images/harvester-additional-images.txt
+++ b/scripts/images/harvester-additional-images.txt
@@ -1,4 +1,4 @@
 busybox:1.32.0
 alpine:3
-registry.suse.com/suse/vmdp/vmdp:2.5.3
+registry.suse.com/suse/vmdp/vmdp:2.5.4.2
 rancher/harvester-eventrouter:v0.1.1


### PR DESCRIPTION
**Problem:**
bump the vmdp driver to the newer version that SUSE supports https://www.suse.com/lifecycle#product-suse-linux-enterprise-virtual-machine-driver-pack

**Solution:**
bump vmdp Windows driver image to [v2.5.4.2](https://github.com/SUSE/vmdp/releases/tag/v2.5.4.2)

**Related Issue:**
https://github.com/harvester/harvester/issues/4365

**Test plan:**
Refer to https://github.com/harvester/harvester/pull/4351#issue-1830684793 VMDP test, also the image is preloaded in the OS.
