### PR TITLE
Fix grafana vm metrics 404 error in multi cluster

### DIFF
--- a/pkg/config/templates/patch/rancher-monitoring/102.0.0+up40.1.2/nginx-config.yaml
+++ b/pkg/config/templates/patch/rancher-monitoring/102.0.0+up40.1.2/nginx-config.yaml
@@ -92,6 +92,7 @@ data:
 
       map $http_referer $final_appSubUrl {
         ~.*/k8s/clusters/(c-m-.+)/.*      '"appSubUrl":"/k8s/clusters/$1/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy"';
+        ~.*/dashboard/harvester/c/(c-m-.+)/kubevirt.io.virtualmachine/.*/.* '"appSubUrl":"/k8s/clusters/$1/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy"';
         ~.*/dashboard/harvester/c/(c-m-.+)/.*      '"appSubUrl":"/k8s/clusters/$1/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy"';
         default '"appSubUrl":"/k8s/clusters/local/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy"';
       }


### PR DESCRIPTION
When accessing vm metrics from Rancher to Harvester to VM, 404 error is return due to wrong appSubUrl

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

When accessing vm metrics from Rancher to Harvester to VM, 404 error is return. 

Such a field is returned:

>"appSubUrl": "/k8s/clusters/c-m-8zxqjrgg/kubevirt.io.virtualmachine/default/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy",

The expected value is:

>"appSubUrl": "/k8s/clusters/c-m-8zxqjrgg/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy",


**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

In nginx config, add long match for http referer field, to filter the path like `kubevirt.io.virtualmachine/default/vm2`
```
Referer:
https://VIP/dashboard/harvester/c/c-m-8zxqjrgg/kubevirt.io.virtualmachine/default/vm2
```
is matched by nginx rule:

```
~.*/dashboard/harvester/c/(c-m-.+)/kubevirt.io.virtualmachine/.*/.* '"appSubUrl":"/k8s/clusters/$1/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy"';
```

In the Harvester dashboard, the vm metrics is referred as:
```
Referer:
https://VIP/dashboard/harvester/c/c-m-8zxqjrgg/harvesterhci.io.dashboard
```

is matched by nginx rule:
```
~.*/dashboard/harvester/c/(c-m-.+)/.* '"appSubUrl":"/k8s/clusters/$1/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy"';
```


**Related Issue:**
https://github.com/harvester/harvester/issues/4343
**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Install a new Harvester cluster with this fix, and enable `rancher-monitoring` addon
2. Import this new cluster into Rancher
3. Create a new VM in Harvester
4. View VM metrics from Harvester local, from both dashboard and VM page
5. View VM metrics from Rancher->Harvester, from both dashboard and VM page