### PR TITLE
Collect all images into one single txt file

### DIFF
--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -168,9 +168,21 @@ spec:
 EOF
 fi
 
-# Collect image lists to a tarball "image-lists.tar.gz"
+# Collect image lists
 OUTPUT_DIR="$TOP_DIR/dist/artifacts/image-lists"
 mkdir -p $OUTPUT_DIR
 find $IMAGES_LISTS_DIR -name "*.txt" -exec cp {} $OUTPUT_DIR \;
 find $RANCHERD_IMAGES_DIR -name "*.txt" -exec cp {} $OUTPUT_DIR \;
+
+# Write all images into one file for user convenience
+IMAGE_ALL=$TOP_DIR/dist/artifacts/harvester-images-list.txt
+rm -f ${IMAGE_ALL}
+echo "# All images in the Harvester ISO built @ " $(date) $'\n' > ${IMAGE_ALL}
+for filename in $OUTPUT_DIR/*.txt; do
+  echo "# In" $(basename ${filename}) >> ${IMAGE_ALL}
+  cat $filename >> ${IMAGE_ALL}
+  echo "" >> ${IMAGE_ALL}
+done
+
+# Write image lists to a tarball "image-lists.tar.gz"
 tar zcvf $TOP_DIR/dist/artifacts/image-lists.tar.gz -C $TOP_DIR/dist/artifacts image-lists && rm -rf $OUTPUT_DIR


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Harvester puts all container image names into a tarball `image-lists.tar.gz`, and this file is not published.

It is not very convenient to check if an image is packed into ISO file.

![image](https://github.com/harvester/harvester-installer/assets/31133476/1263336c-620a-4308-b003-590d13384c62)

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Generate an additional single txt file, which includes all images in the ISO, and `also publish this file`.

**Related Issue:**

https://github.com/harvester/harvester/issues/4176

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Build the Harvester ISO
2. Check if the `image-all.txt` is existing in the path `dist/artifacts`
3. Check all images are listed in this file
4. Check the first line of this file, the timestamp should be updated after each successful building

> cat dist/artifacts/image-all.txt 
```
# All images in the Harvester ISO built @  Thu Aug 17 13:48:28 UTC 2023 

# In  harvester-extra-master.txt
docker.io/rancher/harvester-upgrade:04c258b9
docker.io/rancher/harvester-upgrade:master-04c258b9-head

# In  harvester-images-master.txt
docker.io/banzaicloud/eventrouter:v0.1.0
docker.io/library/alpine:3
docker.io/library/busybox:1.32.0
docker.io/longhornio/backing-image-manager:v1.4.3
docker.io/longhornio/csi-attacher:v3.4.0
...
```


