### PR TITLE
config: make sftp could be configured dynamically

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -186,8 +186,16 @@ type OS struct {
 	Password       string            `json:"password,omitempty"`
 	Environment    map[string]string `json:"environment,omitempty"`
 	Labels         map[string]string `json:"labels,omitempty"`
+	SSHD           SSHDConfig        `json:"sshd,omitempty"`
 
 	PersistentStatePaths []string `json:"persistentStatePaths,omitempty"`
+}
+
+// SSHDConfig is the SSHD configuration for the node
+//
+//   - SFTP: the switch to enable/disable SFTP
+type SSHDConfig struct {
+	SFTP bool `json:"sftp,omitempty"`
 }
 
 type HarvesterConfig struct {

--- a/pkg/config/cos.go
+++ b/pkg/config/cos.go
@@ -205,6 +205,9 @@ func ConvertToCOS(config *HarvesterConfig) (*yipSchema.YipConfig, error) {
 		},
 	}
 
+	// Handle the sshd components
+	overwriteSSHDComponent(config)
+
 	// Add after-install-chroot stage
 	if len(config.OS.AfterInstallChrootCommands) > 0 {
 		afterInstallChroot := yipSchema.Stage{}
@@ -215,6 +218,13 @@ func ConvertToCOS(config *HarvesterConfig) (*yipSchema.YipConfig, error) {
 	}
 
 	return cosConfig, nil
+}
+
+func overwriteSSHDComponent(config *HarvesterConfig) {
+	if config.OS.SSHD.SFTP {
+		config.OS.AfterInstallChrootCommands = append(config.OS.AfterInstallChrootCommands, "mkdir -p /etc/ssh/sshd_config.d")
+		config.OS.AfterInstallChrootCommands = append(config.OS.AfterInstallChrootCommands, "echo 'Subsystem	sftp	/usr/lib/ssh/sftp-server' > /etc/ssh/sshd_config.d/sftp.conf")
+	}
 }
 
 func overwriteAfterInstallChrootStage(config *HarvesterConfig, stage *yipSchema.Stage) error {


### PR DESCRIPTION
**Problem:**
Give the way to config `sftp` dynamically

**Solution:**
We could set up the `harvester.os.sshd.sftp` to true.
The harvester-installer would create the related config file by stage `AfterInstallChrootCommands`

We also need the https://github.com/harvester/os2/pull/78
That would include the customer config that we would like to add.

**Related Issue:**
https://github.com/harvester/harvester/issues/4480

**Test plan:**

- Perform an ipxe-example installation with this config
    ```
    os:
      sshd:
         sftp: true
    ```
- Try to access sftp
    ```
    sftp rancher@192.168.0.30
    (rancher@192.168.0.30) Password:
    Connected to 192.168.0.30.
    sftp> 
    ```

