### PR TITLE
Change the active.img size to 3G

### DIFF
--- a/pkg/config/cos.go
+++ b/pkg/config/cos.go
@@ -31,8 +31,9 @@ const (
 
 	bootstrapConfigCount               = 6
 	defaultReplicaCount                = 3
-	defaultGuaranteedEngineManagerCPU  = 12 // means percentage 12%
-	defaultGuaranteedReplicaManagerCPU = 12 // means percentage 12%
+	defaultGuaranteedEngineManagerCPU  = 12   // means percentage 12%
+	defaultGuaranteedReplicaManagerCPU = 12   // means percentage 12%
+	defaultSystemImageSize             = 3072 // size of /run/initramfs/cos-state/cOS/active.img in MB
 )
 
 var (
@@ -60,6 +61,14 @@ type ElementalInstallSpec struct {
 	ExtraPartitions []ElementalPartition       `yaml:"extra-partitions,omitempty"`
 	CloudInit       string                     `yaml:"cloud-init,omitempty"`
 	Tty             string                     `yaml:"tty,omitempty"`
+	System          *ElementalSystem           `yaml:"system,omitempty"`
+}
+
+type ElementalSystem struct {
+	Label string `yaml:"label,omitempty"`
+	Size  uint   `yaml:"size,omitempty"`
+	FS    string `yaml:"fs,omitempty"`
+	URI   string `yaml:"uri,omitempty"`
 }
 
 type ElementalDefaultPartition struct {
@@ -98,6 +107,12 @@ func ConvertToElementalConfig(config *HarvesterConfig) (*ElementalConfig, error)
 	elementalConfig.Install.Target = resolvedDevPath
 	elementalConfig.Install.CloudInit = config.Install.ConfigURL
 	elementalConfig.Install.Tty = config.Install.TTY
+
+	// Since https://github.com/rancher/elemental-toolkit/commit/7b348b51342c9041741145d1426951336836c757, elemental
+	// CLI calcuates active.img's size automatically. Specify the size to make the size consistent with previous versions.
+	elementalConfig.Install.System = &ElementalSystem{
+		Size: defaultSystemImageSize,
+	}
 
 	return elementalConfig, nil
 }


### PR DESCRIPTION
Elemental calculates the image size automatically now. Change the image size back to 3G for consistency.

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Elemental calculates the image size automatically. So right now the image is near 1.5 G, which is inconsistent with previous versions.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Use elemental config and change the image size back to 3G.

**Related Issue:**
https://github.com/harvester/harvester/issues/4479

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

- Create a new installation.
- Check active.img and passive.img size is 3G.
```
node1:~ # ls -alh /run/initramfs/cos-state/cOS/*
-rw-r--r-- 1 root root 3.0G Sep  5 16:15 /run/initramfs/cos-state/cOS/active.img
-rw-r--r-- 1 root root 3.0G Sep  5 16:15 /run/initramfs/cos-state/cOS/passive.img
```

