### PR TITLE
Fix partition table type

### DIFF
--- a/pkg/config/cos.go
+++ b/pkg/config/cos.go
@@ -97,7 +97,7 @@ func ConvertToElementalConfig(config *HarvesterConfig) (*ElementalConfig, error)
 
 	elementalConfig.Install.PartTable = "gpt"
 	if !config.Install.ForceGPT {
-		elementalConfig.Install.PartTable = "mbr"
+		elementalConfig.Install.PartTable = "msdos"
 	}
 
 	resolvedDevPath, err := filepath.EvalSymlinks(config.Install.Device)


### PR DESCRIPTION
**Problem:**
Invalid setup when setting partition table type to MBR in the installer. The string in the elemental `config.yaml` should be `msdos`, not `mbr`


**Solution:**
Change the string in `PartTable` to the correct value

**Related Issue:**

harvester/harvester#4515

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

