### PR TITLE
build: keep the boot partition with label COS_GRUB

### DIFF
--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -96,7 +96,7 @@ cp "${extract_dir}/rootfs.squashfs" "${ARTIFACTS_DIR}/${PROJECT_PREFIX}-rootfs-$
 # and copy EFI files to it to make it UEFI bootable
 uefi_img="${extract_dir}/boot/uefi.img"
 dd if=/dev/zero of="${uefi_img}" bs=1k count=4096 status=progress
-mkfs.vfat "${uefi_img}"
+mkfs.vfat "${uefi_img}" -n COS_GRUB
 mcopy -s -i "${uefi_img}" "${extract_dir}/EFI" ::
 
 # Remove original ISO, and repack it using xorriso


### PR DESCRIPTION
**Problem:**
The boot partition changed after we repacked to support the legacy BIOS.
That would make the installation hang because of the wrong partition. We depend on the COS_LIVE to mount the data partition on installation.

**Solution:**
Keep the boot partition has the `COS_GRUB` label

**Related Issue:**
https://github.com/harvester/harvester/issues/4510

**Test plan:**
Make sure the whole installation works as usual.

