### PR TITLE
Add grubcustom manually to prevent stuck on GRUB menu when using BOSS-S1 RAID card.

### DIFF
--- a/package/harvester-os/files/usr/sbin/harv-install
+++ b/package/harvester-os/files/usr/sbin/harv-install
@@ -377,6 +377,12 @@ update_grub_settings()
         grub2-editenv ${GRUBENV_FILE} create
     fi
 
+    # PATCH: add /oem/grubcustom too to prevent stuck when using BOSS-S1
+    GRUBCUSTOM_FILE="${oem_dir}/grubcustom"
+    if ! [ -f ${GRUBCUSTOM_FILE} ]; then
+        grub2-editenv ${GRUBCUSTOM_FILE} create
+    fi
+
     add_debug_grub_entry
 }
 


### PR DESCRIPTION
**Problem:**
We might stuck in `Welcome to GRUB!` message for ~30min when installing Harvester on baremetal machines with Dell's [BOSS-S1 RAID card](https://www.dell.com/support/manuals/en-us/poweredge-r7425/boss_s1_ug_publication).

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Add `/oem/grubcustom` manually to prevent long time search for this file when booting up.

**Related Issue:**
https://github.com/harvester/harvester/issues/4334

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
1. Find a server with BOSS-S1 card, and some M.2 disks installed on the card;
2. Build an ISO using this branch;
3. Use the ISO just built to install Harvester on this server, must be installed on the disk installed on BOSS-S1 card;
4. Boot up the machine, and it should not stuck on `Welcome to GRUB!` for too long.

**Additional context:**
If you want to test this on Equinix Metal machines, here is the step:
1. Find an environment with public IP address and build/put image from this branch, and serve the image using nginx;
2. Use terraform scripts [here](https://github.com/rancherlabs/harvester-equinix-terraform), edit `variables.tf`, fill in the project name and version (should be master), set node number to 1, choose server location that close to you (e.g HK or SG), set plan to `m3.large.x86`;
3. Create ipxe script, you can copy one from existing scripts, change image url to your image http server, and put this script to your http server too;
4. Change `ipxe_script` url to your http server;
5. Apply this terraform configuration according to `README.md`, and you should see a new server created in Equinix Metal dashboard;
6. Use Out-of-Band SSH console to see serial output. It should works just like KVM remote console.