### PR TITLE
ISO boot: do not set ttyS0 as console

### DIFF
--- a/package/harvester-os/iso/boot/grub2/grub.cfg
+++ b/package/harvester-os/iso/boot/grub2/grub.cfg
@@ -22,7 +22,7 @@ if [ -f ${font} ];then
 fi
 menuentry "Harvester Installer ${harvester_version}" --class os --unrestricted {
     echo Loading kernel...
-    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0 rd.cos.disable net.ifnames=1
+    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 rd.cos.disable net.ifnames=1
     echo Loading initrd...
     $initrd ($root)/boot/initrd
 }
@@ -30,7 +30,7 @@ menuentry "Harvester Installer ${harvester_version}" --class os --unrestricted {
 menuentry "Harvester Installer ${harvester_version} (VGA 1024x768)" --class os --unrestricted {
     set gfxpayload=1024x768x24,1024x768
     echo Loading kernel...
-    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 console=ttyS0 rd.cos.disable net.ifnames=1
+    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 rd.cos.disable net.ifnames=1
     echo Loading initrd...
     $initrd ($root)/boot/initrd
 }


### PR DESCRIPTION
Some machines have a hard time booting with the parameter on.

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Some machines have a hard time booting with the parameter on.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Remove the parameter. If the user needs it, he or she can add it manually in the GRUB menu.

**Related Issue:**
https://github.com/harvester/harvester/issues/4586

**Test plan:**

- Boot the ISO.
- check `console=ttyS0` isn't present in `/proc/cmdline`.
<!-- Make sure tests pass on the Circle CI. -->

