### PR TITLE
feat: use number version in harvester-os Dockerfile

### DIFF
--- a/package/harvester-os/Dockerfile
+++ b/package/harvester-os/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_OS_IMAGE
 FROM ${BASE_OS_IMAGE}
 
-RUN curl -sfL https://github.com/rancher/wharfie/releases/latest/download/wharfie-amd64  -o /usr/bin/wharfie && chmod +x /usr/bin/wharfie
+RUN curl -sfL https://github.com/rancher/wharfie/releases/download/v0.6.2/wharfie-amd64  -o /usr/bin/wharfie && chmod +x /usr/bin/wharfie
 
 COPY files/ /
 RUN chmod 0600 /system/oem/*


### PR DESCRIPTION
**Problem:**
We used latest version to get wharfie. The CI may be broken if latest version doesn't have artifacts like https://github.com/rancher/wharfie/releases/tag/v0.6.3.

**Solution:**
Use number version.

**Related Issue:**
https://github.com/harvester/harvester/issues/4676

**Test plan:**
N/A

