### PR TITLE
feat: add EnableGoCoverDir

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -122,8 +122,9 @@ type StorageClass struct {
 }
 
 type HarvesterChartValues struct {
-	StorageClass StorageClass        `json:"storageClass,omitempty"`
-	Longhorn     LonghornChartValues `json:"longhorn,omitempty"`
+	StorageClass     StorageClass        `json:"storageClass,omitempty"`
+	Longhorn         LonghornChartValues `json:"longhorn,omitempty"`
+	EnableGoCoverDir bool                `json:"enableGoCoverDir,omitempty"`
 }
 
 type Install struct {

--- a/pkg/config/templates/rancherd-10-harvester.yaml
+++ b/pkg/config/templates/rancherd-10-harvester.yaml
@@ -124,6 +124,9 @@ resources:
       storageClass:
         replicaCount: {{ .Harvester.StorageClass.ReplicaCount }}
       {{- end }}
+      {{- if .Harvester.EnableGoCoverDir }}
+      enableGoCoverDir: true
+      {{- end }}
       kubevirt:
         spec:
           monitorAccount: rancher-monitoring-operator


### PR DESCRIPTION
**Solution:**
Add `EnableGoCoverDir` to config.

**Related Issue:**
https://github.com/harvester/harvester/issues/2666

**Test plan:**
1. Add following to https://github.com/harvester/ipxe-examples/blob/main/vagrant-pxe-harvester/ansible/roles/harvester/templates/config-create.yaml.j2.
```yaml
install:
  # ...
  harvester:
    enableGoCoverDir: true
```
2. Run `./setup_harvester.sh` with master-head images.
3. After the cluster is ready, check whether there is `/coverdatafiles` folder in harvester pod.

**Additional context:**
Wait for https://github.com/harvester/harvester/pull/4722.
