### PR TITLE
console: validate disk size earlier, update error wording

### DIFF
--- a/pkg/config/cos_test.go
+++ b/pkg/config/cos_test.go
@@ -35,22 +35,22 @@ func TestCalcCosPersistentPartSize(t *testing.T) {
 		{
 			diskSize:      150,
 			partitionSize: "100Gi",
-			err:           "Disk size is too small. Minimum 250Gi is required",
+			err:           "Installation disk size is too small. Minimum 250Gi is required",
 		},
 		{
 			diskSize:      300,
 			partitionSize: "153600Ki",
-			err:           "Partition size should be ended with 'Mi', 'Gi', and no dot and negative is allowed",
+			err:           "Partition size must end with 'Mi' or 'Gi'. Decimals and negatives are not allowed.",
 		},
 		{
 			diskSize:      2000,
 			partitionSize: "1.5Ti",
-			err:           "Partition size should be ended with 'Mi', 'Gi', and no dot and negative is allowed",
+			err:           "Partition size must end with 'Mi' or 'Gi'. Decimals and negatives are not allowed.",
 		},
 		{
 			diskSize:      500,
 			partitionSize: "abcd",
-			err:           "Partition size should be ended with 'Mi', 'Gi', and no dot and negative is allowed",
+			err:           "Partition size must end with 'Mi' or 'Gi'. Decimals and negatives are not allowed.",
 		},
 	}
 

--- a/pkg/console/util.go
+++ b/pkg/console/util.go
@@ -638,7 +638,7 @@ func validateDiskSize(devPath string, single bool) error {
 		limit = config.MultipleDiskMinSizeGiB
 	}
 	if util.ByteToGi(diskSizeBytes) < uint64(limit) {
-		return fmt.Errorf("Disk size is too small. Minimum %dGi is required", limit)
+		return fmt.Errorf("Installation disk size is too small. Minimum %dGi is required", limit)
 	}
 
 	return nil
@@ -650,7 +650,7 @@ func validateDataDiskSize(devPath string) error {
 		return err
 	}
 	if util.ByteToGi(diskSizeBytes) < config.HardMinDataDiskSizeGiB {
-		return fmt.Errorf("Disk size is too small. Minimum %dGi is required", config.HardMinDataDiskSizeGiB)
+		return fmt.Errorf("Data disk size is too small. Minimum %dGi is required", config.HardMinDataDiskSizeGiB)
 	}
 
 	return nil

--- a/pkg/util/disk.go
+++ b/pkg/util/disk.go
@@ -17,12 +17,12 @@ const (
 
 func ParsePartitionSize(diskSizeBytes uint64, partitionSize string) (uint64, error) {
 	if diskSizeBytes < MinDiskSize {
-		return 0, fmt.Errorf("Disk size is too small. Minimum %dGi is required", ByteToGi(MinDiskSize))
+		return 0, fmt.Errorf("Installation disk size is too small. Minimum %dGi is required", ByteToGi(MinDiskSize))
 	}
 	actualDiskSizeBytes := diskSizeBytes - fixedOccupiedSize
 
 	if !sizeRegexp.MatchString(partitionSize) {
-		return 0, fmt.Errorf("Partition size should be ended with 'Mi', 'Gi', and no dot and negative is allowed")
+		return 0, fmt.Errorf("Partition size must end with 'Mi' or 'Gi'. Decimals and negatives are not allowed.")
 	}
 
 	size, err := strconv.ParseUint(partitionSize[:len(partitionSize)-2], 10, 64)

--- a/pkg/util/disk_test.go
+++ b/pkg/util/disk_test.go
@@ -41,32 +41,32 @@ func TestParsePartitionSize(t *testing.T) {
 		{
 			diskSize:      100 * GiByteMultiplier,
 			partitionSize: "50Gi",
-			err:           "Disk size is too small. Minimum 250Gi is required",
+			err:           "Installation disk size is too small. Minimum 250Gi is required",
 		},
 		{
 			diskSize:      249 * GiByteMultiplier,
 			partitionSize: "50Gi",
-			err:           "Disk size is too small. Minimum 250Gi is required",
+			err:           "Installation disk size is too small. Minimum 250Gi is required",
 		},
 		{
 			diskSize:      2000 * GiByteMultiplier,
 			partitionSize: "abcd",
-			err:           "Partition size should be ended with 'Mi', 'Gi', and no dot and negative is allowed",
+			err:           "Partition size must end with 'Mi' or 'Gi'. Decimals and negatives are not allowed.",
 		},
 		{
 			diskSize:      2000 * GiByteMultiplier,
 			partitionSize: "1Ti",
-			err:           "Partition size should be ended with 'Mi', 'Gi', and no dot and negative is allowed",
+			err:           "Partition size must end with 'Mi' or 'Gi'. Decimals and negatives are not allowed.",
 		},
 		{
 			diskSize:      2000 * GiByteMultiplier,
 			partitionSize: "50Ki",
-			err:           "Partition size should be ended with 'Mi', 'Gi', and no dot and negative is allowed",
+			err:           "Partition size must end with 'Mi' or 'Gi'. Decimals and negatives are not allowed.",
 		},
 		{
 			diskSize:      2000 * GiByteMultiplier,
 			partitionSize: "5.5",
-			err:           "Partition size should be ended with 'Mi', 'Gi', and no dot and negative is allowed",
+			err:           "Partition size must end with 'Mi' or 'Gi'. Decimals and negatives are not allowed.",
 		},
 		{
 			diskSize:      400 * GiByteMultiplier,


### PR DESCRIPTION
**Problem:**
The error messages are sometimes unclear when one has an installation disk that's too small.

**Solution:**
This commit adds disk size validation in the calls to `diskConfirm()` and `dataDiskConfirm()`, so that as you walk through the fields you'll see potential error messages as you go, rather than having to wait until leaving the last field on the page.  The error message clears if you press the up arrow to go to previous fields.
    
The persistent partition size check remains where it is, i.e. it's only done when you try to move to the next page.  I couldn't figure out a neat way to incorporate this into the `validateAllDiskSizes()` function, which gets called before the default persistent size is set in `persistentSizeV.PreShow()`.
    
This commit also changes the wording of the "disk size is too small" error messages to explicitly state *which* disk is too small, and makes a small tweak to the "partition size" error message.

**Related Issue:**

https://github.com/harvester/harvester/issues/4734

**Test plan:**

- Boot a system with one disk < 250Gi. Verify that when you hit ENTER or DOWN on the Installation disk field that the "Installation disk size is too small. Minimum 250Gi is required" message appears.
- Boot a system with two disks, one 120Gi, one 200Gi and verify:
  - With the 120Gi disk selected for both installation and data, you see "Installation disk size is too small. Minimum 250Gi is required"
  - With the 200Gi disk selected for both installation and data, verify the same error as above appears immediately.
  - Set the 120Gi disk for data and verify the error goes away.
- In all cases, verify that an appropriate error appears immediately after you leave each field going down (down arrow or enter key) and that the error disappears when pressing the up arrow to return to the previous field.

<!-- Make sure tests pass on the Circle CI. -->

