### PR TITLE
build: use newer elemental to build iso

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,6 +1,5 @@
-FROM quay.io/costoolkit/releases-green:luet-toolchain-0.21.2 as luet
-FROM quay.io/costoolkit/elemental-cli:v0.2.5 as elemental
-
+FROM quay.io/costoolkit/releases-teal:grub2-live-0.0.4-2 as grub2-mbr
+FROM quay.io/costoolkit/releases-teal:grub2-efi-image-live-0.0.4-2 as grub2-efi
 FROM registry.suse.com/bci/golang:1.20
 
 ARG http_proxy=$http_proxy
@@ -28,16 +27,17 @@ RUN zypper addrepo http://download.opensuse.org/distribution/leap/15.4/repo/oss/
     zypper --gpg-auto-import-keys refresh && \
     zypper in -y qemu-x86 qemu-tools
 
+RUN mkdir /grub2-mbr
+COPY --from=grub2-mbr / /grub2-mbr
+RUN mkdir /grub2-efi
+COPY --from=grub2-efi / /grub2-efi
+
 # set up helm
 ENV HELM_VERSION v3.3.1
 ENV HELM_URL=https://get.helm.sh/helm-${HELM_VERSION}-linux-${ARCH}.tar.gz
 RUN mkdir /usr/tmp && \
     curl ${HELM_URL} | tar xvzf - --strip-components=1 -C /usr/tmp/ && \
     mv /usr/tmp/helm /usr/bin/helm
-
-# luet & elemental
-COPY --from=luet /usr/bin/luet /usr/bin/luet
-COPY --from=elemental /usr/bin/elemental /usr/bin/elemental
 
 # You cloud defined your own rke2 url by setup `RKE2_IMAGE_REPO`
 ENV DAPPER_ENV REPO TAG DRONE_TAG DRONE_BRANCH CROSS RKE2_IMAGE_REPO USE_LOCAL_IMAGES BUILD_QCOW DRONE_BUILD_EVENT

--- a/package/harvester-os/manifest.yaml
+++ b/package/harvester-os/manifest.yaml
@@ -1,11 +1,8 @@
 iso:
   uefi:
-    - channel:live/grub2-efi-image
+    - dir:/grub2-efi
   image:
-    - channel:live/grub2
-    - channel:live/grub2-efi-image
+    - dir:/grub2-mbr
+    - dir:/grub2-efi
+    - dir:/boot-files
   label: "COS_LIVE"
-repositories:
-  - name: cOS
-    uri: quay.io/costoolkit/releases-teal
-    type: docker

--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -52,13 +52,20 @@ else
   PROJECT_PREFIX+="-master"
 fi
 
+# Create kernel, initrd folder for iso
+# If we use the dir format on the manifest, we need to handle it
+mkdir -p /boot-files/boot
+
 # Copy kernel, initrd out for PXE boot
 KERNEL=$(docker run --rm ${HARVESTER_OS_IMAGE} readlink /boot/vmlinuz)
 INITRD=$(docker run --rm ${HARVESTER_OS_IMAGE} readlink /boot/initrd)
 docker create --cidfile=os-img-container ${HARVESTER_OS_IMAGE}
 docker cp $(<os-img-container):/boot/${KERNEL} ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-vmlinuz-${ARCH}
 docker cp $(<os-img-container):/boot/${INITRD} ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-initrd-${ARCH}
+docker cp $(<os-img-container):/usr/bin/elemental /usr/bin/elemental
 chmod +r ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-initrd-${ARCH}
+docker cp $(<os-img-container):/boot/${KERNEL} /boot-files/boot/kernel
+docker cp $(<os-img-container):/boot/${INITRD} /boot-files/boot/initrd
 docker rm $(<os-img-container) && rm -f os-img-container
 
 # Make sure files under bundle dir can be read by nginx
@@ -69,7 +76,7 @@ ISO_PREFIX="${PROJECT_PREFIX}-${ARCH}"
 cp harvester-release.yaml iso
 echo "set harvester_version=${VERSION}" > iso/boot/grub2/harvester.cfg
 
-elemental build-iso --config-dir "$(pwd)" "docker:${HARVESTER_OS_IMAGE}" -a x86_64 \
+elemental build-iso --debug --config-dir "$(pwd)" "docker:${HARVESTER_OS_IMAGE}" \
           --local \
           -n "${ISO_PREFIX}" \
           -o "${ARTIFACTS_DIR}" \


### PR DESCRIPTION
**Problem:**
We want to bump elemental to the newer version and drop luet.

**Solution:**
update the build flow to match the new elemental binary

**Related Issue:**

**Test plan:**
1. Make sure the installation work as usual
2. Make sure the cluster operation as susal
