### PR TITLE
feat: add rancher-system-agent env.conf

### DIFF
--- a/package/harvester-os/files/etc/systemd/system/rancher-system-agent.service.d/env.conf
+++ b/package/harvester-os/files/etc/systemd/system/rancher-system-agent.service.d/env.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment="PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/rke2/bin"


### PR DESCRIPTION
**Problem:**
Run `journalctl -u rancher-system-agent.service` in harvester node and we can see log like:

```
Dec 01 02:27:39 harvester-node-0 rancher-system-agent[15569]: time="2023-12-01T02:27:39Z" level=info msg="[Applyinator] Running command: sh [-c rke2 etcd-snapshot list --etcd-s3=false 2>/dev/null]"
Dec 01 02:27:39 harvester-node-0 rancher-system-agent[15569]: time="2023-12-01T02:27:39Z" level=info msg="[Applyinator] Command sh [-c rke2 etcd-snapshot list --etcd-s3=false 2>/dev/null] finished with err: <nil> and exit code: 127"
```

**Solution:**
Add `/opt/rke2/bin` to rancher-system-agent `PATH`.

**Related Issue:**
https://github.com/harvester/harvester/issues/4803

**Test plan:**
1. Install harvester.
2. Run `journalctl -u rancher-system-agent.service` and see `rke2 etcd-snapshot list` with exit code `0`:
```
msg="[Applyinator] Running command: sh [-c rke2 etcd-snapshot list --etcd-s3=false 2>/dev/null]"
msg="[9fbfd1d387d3a1762da058468cc7c49cb89e6481208ee1bd164b864d40917b55_0:stdout]: Name                                      Location                                                                                   Size     Created"
msg="[9fbfd1d387d3a1762da058468cc7c49cb89e6481208ee1bd164b864d40917b55_0:stdout]: etcd-snapshot-harvester-node-0-1701345604 file:///var/lib/rancher/rke2/server/db/snapshots/etcd-snapshot-harvester-node-0-1701345604 56201248 2023-11-30T12:00:04Z"
msg="[9fbfd1d387d3a1762da058468cc7c49cb89e6481208ee1bd164b864d40917b55_0:stdout]: etcd-snapshot-harvester-node-0-1701388801 file:///var/lib/rancher/rke2/server/db/snapshots/etcd-snapshot-harvester-node-0-1701388801 56201248 2023-12-01T00:00:01Z"
msg="[Applyinator] Command sh [-c rke2 etcd-snapshot list --etcd-s3=false 2>/dev/null] finished with err: <nil> and exit code: 0"
msg="[K8s] updated plan secret fleet-local/custom-92281fa60bd5-machine-plan with feedback"
```

