### PR TITLE
Fix grafana login issue

### DIFF
--- a/pkg/config/templates/patch/rancher-monitoring/102.0.0+up40.1.2/nginx-config.yaml
+++ b/pkg/config/templates/patch/rancher-monitoring/102.0.0+up40.1.2/nginx-config.yaml
@@ -91,9 +91,10 @@ data:
       }
 
       map $http_referer $final_appSubUrl {
-        ~.*/k8s/clusters/(c-m-.+)/.*      '"appSubUrl":"/k8s/clusters/$1/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy"';
+        ~.*/k8s/clusters/(c-m-.+)/api/v1/namespaces/cattle-monitoring-system/.*      '"appSubUrl":"/k8s/clusters/$1/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy"';
         ~.*/dashboard/harvester/c/(c-m-.+)/kubevirt.io.virtualmachine/.*/.* '"appSubUrl":"/k8s/clusters/$1/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy"';
         ~.*/dashboard/harvester/c/(c-m-.+)/.*      '"appSubUrl":"/k8s/clusters/$1/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy"';
+        ~.*/api/v1/namespaces/cattle-monitoring-system/.*    '"appSubUrl":"/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy"';
         default '"appSubUrl":"/k8s/clusters/local/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy"';
       }
 


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
The `grafana` login page showed 404.

A main reason is, when accesing grafana from the local cluster, the general URL is `https://1.2.3.4/k8s/clusters/local/api/v1/....`, the Rancher will trim `/k8s/clusters/local/`, this works fine for normal link. But for `login`, it is another story, the `grafana` will return a `302` code with a new `Location`, unfortunately, the `Rancher` will NOT add `/k8s/clusters/local` back to the `Location`. When grafana's front page code runs, it will get a different `appSubUrl` and assume error, then showed 404 page.

For rancher managed cluster, the regex processing in appSubUrl is not perfect to deal with `302`.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
(1) For local cluster, add a fallback item in the nginx sub-filter
(2) For rancher-managed cluster, use long match in regex to avoid duplicate URL elements.

**Related Issue:**
https://github.com/harvester/harvester/issues/4756

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
1. Install a new Harvester v1.3.0 cluster, enable `rancher-monitoring` addon.   Or use this workaround https://github.com/harvester/harvester/issues/4756#issuecomment-1874242139 in existing v1.2.1/v1.3.0 cluster.
2. Click `grafana` from the `Dashboard` page, which will open a new page.
3. Click `login`, try `login`; or return to previous page, all should run smoothly.

In Rancher-integration scenario, repeat the same processes.