### PR TITLE
feat: bump golangci-lint to v1.55.2

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -20,7 +20,7 @@ RUN zypper -n rm container-suseconnect && \
     zypper -n install git curl docker gzip tar wget zstd squashfs xorriso awk jq mtools dosfstools unzip rsync
 RUN curl -sfL https://github.com/mikefarah/yq/releases/download/v4.21.1/yq_linux_${ARCH} -o /usr/bin/yq && chmod +x /usr/bin/yq
 RUN if [ "${ARCH}" == "amd64" ]; then \
-    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.49.0; \
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.55.2; \
     fi
 
 RUN zypper addrepo http://download.opensuse.org/distribution/leap/15.4/repo/oss/ oss && \


### PR DESCRIPTION
**Problem:**
The golangci-lint version before v1.51.0 may have OOM issue with golang v1.20.

**Solution:**
Bump golangci-lint to a version after v1.51.0.

**Related Issue:**
https://github.com/harvester/harvester/issues/4938
