### PR TITLE
Bump harvester-eventrouter to v0.1.2

### DIFF
--- a/pkg/config/templates/rancherd-22-addons.yaml
+++ b/pkg/config/templates/rancherd-22-addons.yaml
@@ -96,7 +96,7 @@ resources:
           controlNamespace: cattle-logging-system
           workloadOverrides:
             containers:
-            - image: rancher/harvester-eventrouter:v0.1.1
+            - image: rancher/harvester-eventrouter:v0.1.2
               name: event-tailer
               resources:
                 limits:

--- a/scripts/images/harvester-additional-images.txt
+++ b/scripts/images/harvester-additional-images.txt
@@ -1,2 +1,2 @@
 registry.suse.com/suse/vmdp/vmdp:2.5.4.2
-rancher/harvester-eventrouter:v0.1.1
+rancher/harvester-eventrouter:v0.1.2


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

harvester-eventrouter image has been updated with some enhancements, refer: https://github.com/harvester/eventrouter/releases/tag/v0.1.2

Harvester v1.3.0 still uses the old image.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Use new image of harvester-eventrouter.

**Related Issue:**

https://github.com/harvester/harvester/issues/4940

NOTE: this PR only updates harvester-eventrouter, the `ranhcer-logging` will be bumped in another PR.

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

(1) Install new cluster
(2) Enable addon rancher-logging
(3) Check the eventrouter POD in `cattle-logging-system` runs correctly, the POD is using v0.1.2 image instead of old image v0.1.1