### PR TITLE
installer: rename the role name witness instead etcd

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -277,6 +277,10 @@ func (c *HarvesterConfig) GetKubeletArgs() ([]string, error) {
 		)
 	}
 
+	if c.Role == RoleWitness {
+		args = append(args, "--register-with-taints=node-role.kubernetes.io/etcd=true:NoExecute")
+	}
+
 	return args, nil
 }
 

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -7,7 +7,7 @@ const (
 	ModeInstall = "install"
 
 	RoleDefault = "default"
-	RoleEtcd    = "etcd"
+	RoleWitness = "witness"
 
 	NetworkMethodDHCP   = "dhcp"
 	NetworkMethodStatic = "static"

--- a/pkg/config/cos.go
+++ b/pkg/config/cos.go
@@ -374,6 +374,23 @@ func initRancherdStage(config *HarvesterConfig, stage *yipSchema.Stage) error {
 		},
 	)
 
+	if config.Role == RoleWitness {
+		rke2WitnessConfig, err := render("rke2-99-harvester-witness.yaml", config)
+		if err != nil {
+			return err
+		}
+		rke2WitnessConfig = strings.TrimSpace(rke2WitnessConfig)
+		stage.Files = append(stage.Files,
+			yipSchema.File{
+				Path:        "/etc/rancher/rke2/config.yaml.d/99-harvester-witness.yaml",
+				Content:     rke2WitnessConfig,
+				Permissions: 0600,
+				Owner:       0,
+				Group:       0,
+			},
+		)
+	}
+
 	return nil
 }
 

--- a/pkg/config/templates/rke2-99-harvester-witness.yaml
+++ b/pkg/config/templates/rke2-99-harvester-witness.yaml
@@ -1,0 +1,2 @@
+node-taint:
+- "node-role.kubernetes.io/etcd=true:NoExecute"

--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -770,8 +770,8 @@ func addAskRolePanel(c *Console) error {
 				Value: config.RoleDefault,
 				Text:  "Default Role (Master or Worker)",
 			}, {
-				Value: config.RoleEtcd,
-				Text:  "Worker (Etcd only)",
+				Value: config.RoleWitness,
+				Text:  "Witness Role",
 			},
 		}, nil
 	}

--- a/pkg/console/util.go
+++ b/pkg/console/util.go
@@ -457,11 +457,11 @@ func doInstall(g *gocui.Gui, hvstConfig *config.HarvesterConfig, webhooks Render
 	}
 
 	// specific the node label for the specific node role
-	if hvstConfig.Role == config.RoleEtcd {
+	if hvstConfig.Role == config.RoleWitness {
 		if hvstConfig.Labels == nil {
 			hvstConfig.Labels = make(map[string]string)
 		}
-		hvstConfig.Labels[util.HarvesterEtcdNodeLabelKey] = "true"
+		hvstConfig.Labels[util.HarvesterWitnessNodeLabelKey] = "true"
 	}
 
 	env, elementalConfig, err := generateEnvAndConfig(g, hvstConfig)
@@ -777,11 +777,11 @@ func configureInstalledNode(g *gocui.Gui, hvstConfig *config.HarvesterConfig, we
 	webhooks.Handle(EventInstallStarted)
 
 	// specific the node label for the specific node role
-	if hvstConfig.Role == config.RoleEtcd {
+	if hvstConfig.Role == config.RoleWitness {
 		if hvstConfig.Labels == nil {
 			hvstConfig.Labels = make(map[string]string)
 		}
-		hvstConfig.Labels[util.HarvesterEtcdNodeLabelKey] = "true"
+		hvstConfig.Labels[util.HarvesterWitnessNodeLabelKey] = "true"
 	}
 
 	// skip rancherd and network config in the cos config

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	HarvesterNodeRoleLabelPrefix = "node-role.harvesterhci.io/"
-	HarvesterEtcdNodeLabelKey    = HarvesterNodeRoleLabelPrefix + "etcd"
+	HarvesterWitnessNodeLabelKey = HarvesterNodeRoleLabelPrefix + "witness"
 
 	sizeRegexp = regexp.MustCompile(`^(\d+)(Mi|Gi)$`)
 )


### PR DESCRIPTION
**Problem:**
We can use `witness` instead `etcd`. The `witness` seems more suitable for the configuration.

**Solution:**
Change the console and label content. 

**Related Issue:**
https://github.com/harvester/harvester/issues/4840

**Test plan:**
Make sure the interactive console show the `Witness Role`.

And node label should be `node-role.harvesterhci.io/witness: true`

