### PR TITLE
installer/config: add the role setup

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -8,6 +8,8 @@ const (
 
 	RoleDefault = "default"
 	RoleWitness = "witness"
+	RoleMgmt    = "management"
+	RoleWorker  = "worker"
 
 	NetworkMethodDHCP   = "dhcp"
 	NetworkMethodStatic = "static"

--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -768,10 +768,16 @@ func addAskRolePanel(c *Console) error {
 		return []widgets.Option{
 			{
 				Value: config.RoleDefault,
-				Text:  "Default Role (Master or Worker)",
+				Text:  "Default Role (Management or Worker)",
+			}, {
+				Value: config.RoleMgmt,
+				Text:  "Management Role",
 			}, {
 				Value: config.RoleWitness,
 				Text:  "Witness Role",
+			}, {
+				Value: config.RoleWorker,
+				Text:  "Worker Role",
 			},
 		}, nil
 	}
@@ -1990,9 +1996,12 @@ func addInstallPanel(c *Console) error {
 			}
 
 			if alreadyInstalled {
-				configureInstalledNode(c.Gui, c.config, webhooks)
+				err = configureInstalledNode(c.Gui, c.config, webhooks)
 			} else {
-				doInstall(c.Gui, c.config, webhooks)
+				err = doInstall(c.Gui, c.config, webhooks)
+			}
+			if err != nil {
+				printToPanel(c.Gui, fmt.Sprintf("install failed: %s", err), installPanel)
 			}
 		}()
 		return c.setContentByName(footerPanel, "")

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -7,6 +7,8 @@ import (
 var (
 	HarvesterNodeRoleLabelPrefix = "node-role.harvesterhci.io/"
 	HarvesterWitnessNodeLabelKey = HarvesterNodeRoleLabelPrefix + "witness"
+	HarvesterMgmtNodeLabelKey    = HarvesterNodeRoleLabelPrefix + "management"
+	HarvesterWorkerNodeLabelKey  = HarvesterNodeRoleLabelPrefix + "worker"
 
 	sizeRegexp = regexp.MustCompile(`^(\d+)(Mi|Gi)$`)
 )


### PR DESCRIPTION
**Problem:**
We tried to support various roles, so the installer need the related changes.

**Solution:**
Add an interactive part for role selection. Also, we need to add the related label for it.

**Related Issue:**
https://github.com/harvester/harvester/issues/4786

**Test plan:**
We can check this feature with two parts as below.
1. 3 node cluster with one worker node. (Should only have one management(master) in the cluster)
  - create a cluster with three nodes
  - choose `worker` role on the second or third node
  - make sure the final cluster only has one management(master)

2. 5 node cluster (to test promote will promote the management role first)
  - create a cluster with five nodes
  - choose `management` role on the fifth node
  - remove the second or third management (master) node
  - it should promote the fifth node instead fourth node

