### PR TITLE
Don't cut off last line of text in panel above select widget

### DIFF
--- a/pkg/widgets/select.go
+++ b/pkg/widgets/select.go
@@ -47,9 +47,12 @@ func (s *Select) Show() error {
 		return err
 	}
 	optionViewName := s.Name + "-options"
-	offset := len(strings.Split(s.Content, "\n"))
-	y0 := s.Y0 + offset - 1
-	y1 := s.Y0 + offset + len(s.options)
+	offset := 0
+	if len(s.Content) > 0 {
+		offset = len(strings.Split(s.Content, "\n")) + 1
+	}
+	y0 := s.Y0 + offset
+	y1 := s.Y0 + offset + len(s.options) + 1
 	v, err := s.g.SetView(optionViewName, s.X0, y0, s.X1, y1)
 	if err != nil {
 		if err != gocui.ErrUnknownView {


### PR DESCRIPTION
**Problem:**
There's an off-by-one (or possibly off-by-two) error in the current implementation of the select widget, when there's content in the panel above it.  This means the last line of text in the panel is overwritten by the select widget (i.e. the select widget is one line too high). See the below screenshot where the text finishes with `Your disk will be formatted and Harvester will be installed with`:

![installer-1 2 1-confirm-cutoff](https://github.com/harvester/harvester-installer/assets/754700/c6def7db-c4dd-4af6-908e-4cde2bedd62f)

**Solution:**
This commit changes the logic slightly to offset the select widget by the number of lines of panel content plus one, allowing all the text in the panel to be shown. Now we can see the full confirmation message plus a blank line above the select widget:

![installer-offset-confirm-fixed](https://github.com/harvester/harvester-installer/assets/754700/f8eac76e-1b84-49a2-8dc7-35f534f06f18)

**Related Issue:**
None (should I open one, or is it OK to just randomly fix things?)

**Test plan:**
- Run through the installer.
- Verify that select widgets with _no_ content above still look sensible (i.e. no extra blank lines above the select widget on the "Choose installation mode" screen, and the NIC select widget appears exactly on top of the "Management NIC" field)
- Verify that the text isn't cut off on the final "Confirm installation options" screen.
