### PR TITLE
Add hardware spec preflight checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ command line parameter `harvester.install.automatic=true` causes the
 interactive part to be skipped, and config will be retrieved from the
 URL specified by `harvester.install.config_url`.
 
+The installer will run some preflight checks to ensure the system
+meets minimum hardware requirements.  If any of these checks
+fail when run interactively, the first page of the installer will
+indicate which checks failed, and give you the option to proceed or
+not.  When installing via PXE, if any checks fail, installation will
+abort and the failed checks will be visible on the system console,
+and also logged to /var/log/console.log in the installation environment.
+If you wish to bypass the preflight checks for testing purposes during
+automated installation, set the `harvester.install.skipchecks=true`
+kernel command line parmaeter.
+
 Either way (ISO or PXE), the installer writes the final config out to
 a temporary file which is passed to [harv-install](https://github.com/harvester/harvester-installer/blob/master/package/harvester-os/files/usr/sbin/harv-install)
 which in turn calls `elemental install` to provision the system.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -129,6 +129,7 @@ type HarvesterChartValues struct {
 
 type Install struct {
 	Automatic           bool    `json:"automatic,omitempty"`
+	SkipChecks          bool    `json:"skipchecks,omitempty"`
 	Mode                string  `json:"mode,omitempty"`
 	ManagementInterface Network `json:"managementInterface,omitempty"`
 

--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -154,7 +154,7 @@ func (c *Console) doRun() error {
 	}
 
 	if !alreadyInstalled {
-		checks := []preflight.PreflightCheck{
+		checks := []preflight.Check{
 			preflight.CPUCheck{},
 			preflight.MemoryCheck{},
 			preflight.VirtCheck{},

--- a/pkg/console/constant.go
+++ b/pkg/console/constant.go
@@ -12,6 +12,7 @@ const (
 	askForceMBRTitlePanel       = "askForceMBRTitle"
 	askForceMBRPanel            = "askForceMBR"
 	diskNotePanel               = "diskNote"
+	preflightCheckPanel         = "preflightCheck"
 	askCreatePanel              = "askCreate"
 	serverURLPanel              = "serverUrl"
 	passwordPanel               = "osPassword"

--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -1873,13 +1873,13 @@ func addConfirmInstallPanel(c *Console) error {
 		if !c.config.Install.Silent {
 			if alreadyInstalled {
 				confirmV.SetContent(options +
-					"\nHarvester is already installed. It will be configured with \nthe above configuration.\n Continue?\n")
+					"\nHarvester is already installed. It will be configured with the above configuration. Continue?\n")
 			} else if installModeOnly {
 				confirmV.SetContent(options +
-					"\nHarvester will be copied to local disk.\n No configuration will be performed.\n Continue?\n")
+					"\nHarvester will be copied to local disk. No configuration will be performed. Continue?\n")
 			} else {
 				confirmV.SetContent(options +
-					"\nYour disk will be formatted and Harvester will be installed with \nthe above configuration. Continue?\n")
+					"\nYour disk will be formatted and Harvester will be installed with the above configuration. Continue?\n")
 			}
 		}
 		c.Gui.Cursor = false

--- a/pkg/preflight/checks.go
+++ b/pkg/preflight/checks.go
@@ -19,11 +19,11 @@ const (
 	MinMemoryProd = 64
 )
 
-// The Run() method of a PreflightCheck returns a string.  If the string
+// The Run() method of a preflight.Check returns a string.  If the string
 // is empty, it means the check passed.  Otherwise, the string contains
 // some text explaining why the check failed.  The error value will be set
 // if the check itself failed to run at all for some reason.
-type PreflightCheck interface {
+type Check interface {
 	Run() (string, error)
 }
 

--- a/pkg/preflight/checks.go
+++ b/pkg/preflight/checks.go
@@ -19,6 +19,12 @@ const (
 	MinMemoryProd = 64
 )
 
+var (
+	// So that we can fake this stuff up for unit tests
+	execCommand = exec.Command
+	procMemInfo = "/proc/meminfo"
+)
+
 // The Run() method of a preflight.Check returns a string.  If the string
 // is empty, it means the check passed.  Otherwise, the string contains
 // some text explaining why the check failed.  The error value will be set
@@ -32,7 +38,7 @@ type MemoryCheck struct{}
 type VirtCheck struct{}
 
 func (c CPUCheck) Run() (msg string, err error) {
-	out, err := exec.Command("/usr/bin/nproc", "--all").CombinedOutput()
+	out, err := execCommand("/usr/bin/nproc", "--all").Output()
 	if err != nil {
 		return
 	}
@@ -48,7 +54,7 @@ func (c CPUCheck) Run() (msg string, err error) {
 }
 
 func (c MemoryCheck) Run() (msg string, err error) {
-	meminfo, err := os.Open("/proc/meminfo")
+	meminfo, err := os.Open(procMemInfo)
 	if err != nil {
 		return
 	}
@@ -95,7 +101,7 @@ func (c MemoryCheck) Run() (msg string, err error) {
 }
 
 func (c VirtCheck) Run() (msg string, err error) {
-	out, err := exec.Command("/usr/bin/systemd-detect-virt", "--vm").CombinedOutput()
+	out, err := execCommand("/usr/bin/systemd-detect-virt", "--vm").Output()
 	virt := strings.TrimSpace(string(out))
 	if err != nil {
 		// systemd-detect-virt will return a non-zero exit code

--- a/pkg/preflight/checks.go
+++ b/pkg/preflight/checks.go
@@ -1,0 +1,114 @@
+package preflight
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+const (
+	// Constants here from Hardware Requirements in the documentaiton
+	// https://docs.harvesterhci.io/v1.3/install/requirements/#hardware-requirements
+	MinCPUTest    = 8
+	MinCPUProd    = 16
+	MinMemoryTest = 32
+	MinMemoryProd = 64
+)
+
+// The Run() method of a PreflightCheck returns a string.  If the string
+// is empty, it means the check passed.  Otherwise, the string contains
+// some text explaining why the check failed.  The error value will be set
+// if the check itself failed to run at all for some reason.
+type PreflightCheck interface {
+	Run() (string, error)
+}
+
+type CPUCheck struct{}
+type MemoryCheck struct{}
+type VirtCheck struct{}
+
+func (c CPUCheck) Run() (msg string, err error) {
+	out, err := exec.Command("/usr/bin/nproc", "--all").CombinedOutput()
+	if err != nil {
+		return
+	}
+	nproc, _ := strconv.Atoi(strings.TrimSpace(string(out)))
+	if nproc < MinCPUTest {
+		msg = fmt.Sprintf("Only %d CPU cores detected. Harvester requires at least %d cores for testing and %d for production use.",
+			nproc, MinCPUTest, MinCPUProd)
+	} else if nproc < MinCPUProd {
+		msg = fmt.Sprintf("%d CPU cores detected. Harvester requires at least %d cores for production use.",
+			nproc, MinCPUProd)
+	}
+	return
+}
+
+func (c MemoryCheck) Run() (msg string, err error) {
+	meminfo, err := os.Open("/proc/meminfo")
+	if err != nil {
+		return
+	}
+	defer meminfo.Close()
+	scanner := bufio.NewScanner(meminfo)
+	var memTotalKiB int
+	for scanner.Scan() {
+		if n, _ := fmt.Sscanf(scanner.Text(), "MemTotal: %d kB", &memTotalKiB); n == 1 {
+			break
+		}
+	}
+	if memTotalKiB == 0 {
+		err = errors.New("unable to extract MemTotal from /proc/cpuinfo")
+		return
+	}
+	// MemTotal from /proc/cpuinfo is a bit less than the actual physical
+	// memory in the system, due to reserved RAM not being included, so
+	// we can't actually do a trivial check of MemTotalGiB < MinMemoryTest,
+	// because it will fail.  For example:
+	// - A host with 32GiB RAM may report MemTotal 32856636 = 31.11GiB
+	// - A host with 64GiB RAM may report MemTotal 65758888 = 62.71GiB
+	// - A host with 128GiB RAM may report MemTotal 131841120 = 125.73GiB
+	// This means we have to test against a slighly lower number.  Knocking
+	// 5% off is somewhat arbitrary but probably not unreasonable (e.g. for
+	// 32GB we're actually allowing anything over 30.4GB, and for 64GB we're
+	// allowing anything over 60.8GB).
+	// Note that the above also means the warning messages below will be a
+	// bit off (e.g. something like "System reports 31GiB RAM" on a 32GiB
+	// system).
+	memTotalGiB := memTotalKiB / (1 << 20)
+	memReported := fmt.Sprintf("%dGiB", memTotalGiB)
+	if memTotalGiB < 1 {
+		// Just in case someone runs it on a really tiny VM...
+		memReported = fmt.Sprintf("%dKiB", memTotalKiB)
+	}
+	if float32(memTotalGiB) < (MinMemoryTest * 0.95) {
+		msg = fmt.Sprintf("Only %s RAM detected. Harvester requires at least %dGiB for testing and %dGiB for production use.",
+			memReported, MinMemoryTest, MinMemoryProd)
+	} else if float32(memTotalGiB) < (MinMemoryProd * 0.95) {
+		msg = fmt.Sprintf("%s RAM detected. Harvester requires at least %dGiB for production use.",
+			memReported, MinMemoryProd)
+	}
+	return
+}
+
+func (c VirtCheck) Run() (msg string, err error) {
+	out, err := exec.Command("/usr/bin/systemd-detect-virt", "--vm").CombinedOutput()
+	virt := strings.TrimSpace(string(out))
+	if err != nil {
+		// systemd-detect-virt will return a non-zero exit code
+		// and print "none" if it doesn't detect a virtualization
+		// environment.  The non-zero exit code manifests as a
+		// non nil err here, so we have to handle that case and
+		// return success from this check, because we're not
+		// running virtualized.
+		if virt == "none" {
+			err = nil
+		}
+		return
+	}
+	msg = fmt.Sprintf("System is virtualized (%s) which is not supported.", virt)
+	return
+}

--- a/pkg/preflight/checks_test.go
+++ b/pkg/preflight/checks_test.go
@@ -1,0 +1,131 @@
+package preflight
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeOutput struct {
+	output string
+	rc     int
+}
+
+var (
+	execOutputs = map[string]fakeOutput{
+		"nproc 4":  {"4\n", 0},
+		"nproc 8":  {"8\n", 0},
+		"nproc 16": {"16\n", 0},
+		"kvm":      {"kvm\n", 0},
+		"metal":    {"none\n", 1},
+	}
+)
+
+// It turns out to be really irritating to mock exec.Command().
+// The trick here is: in normal execution (i.e. not under test),
+// execCommand is a pointer to exec.Command(), so it just runs as
+// usual.  When under test, we replace execCommand with a function
+// that in turn calls _this_ function, with one of the keys in the
+// execOutputs above.  This function then runs the TestHelperProcess
+// test, passing through that key...
+func fakeExecCommand(command string) *exec.Cmd {
+	cs := []string{"-test.run=TestHelperProcess", "--", command}
+	cmd := exec.Command(os.Args[0], cs...)
+	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
+	return cmd
+}
+
+// ...and TestHelperProcess looks up the key in execOutputs, and
+// behaves as mocked, i.e. it will print the fake output to STDOUT,
+// and will exit with the fake return code.
+// One irritating subtlety here is that the `go test` framework
+// may emit junk to STDERR, so this mocking technique only really
+// works for mocking return codes and content on STDOUT.  Still,
+// that's OK for our purposes here.
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	args := os.Args
+	for len(args) > 0 {
+		if args[0] == "--" {
+			args = args[1:]
+			break
+		}
+		args = args[1:]
+	}
+	if len(args) < 1 {
+		os.Exit(1)
+	}
+
+	output, ok := execOutputs[args[0]]
+	if !ok {
+		os.Exit(1)
+	} else {
+		fmt.Print(output.output)
+		os.Exit(output.rc)
+	}
+}
+
+func TestCPUCheck(t *testing.T) {
+	defer func() { execCommand = exec.Command }()
+
+	expectedOutputs := map[string]string{
+		"nproc 4":  "Only 4 CPU cores detected. Harvester requires at least 8 cores for testing and 16 for production use.",
+		"nproc 8":  "8 CPU cores detected. Harvester requires at least 16 cores for production use.",
+		"nproc 16": "",
+	}
+
+	check := CPUCheck{}
+	for key, expectedOutput := range expectedOutputs {
+		execCommand = func(command string, args ...string) *exec.Cmd {
+			return fakeExecCommand(key)
+		}
+		msg, err := check.Run()
+		assert.Nil(t, err)
+		assert.Equal(t, expectedOutput, msg)
+	}
+}
+
+func TestVirtCheck(t *testing.T) {
+	defer func() { execCommand = exec.Command }()
+
+	expectedOutputs := map[string]string{
+		"kvm":   "System is virtualized (kvm) which is not supported.",
+		"metal": "",
+	}
+
+	check := VirtCheck{}
+	for key, expectedOutput := range expectedOutputs {
+		execCommand = func(command string, args ...string) *exec.Cmd {
+			return fakeExecCommand(key)
+		}
+		msg, err := check.Run()
+		assert.Nil(t, err)
+		assert.Equal(t, expectedOutput, msg)
+	}
+
+}
+
+func TestMemoryCheck(t *testing.T) {
+	defaultMemInfo := procMemInfo
+	defer func() { procMemInfo = defaultMemInfo }()
+
+	expectedOutputs := map[string]string{
+		"./testdata/meminfo-512MiB": "Only 458112KiB RAM detected. Harvester requires at least 32GiB for testing and 64GiB for production use.",
+		"./testdata/meminfo-32GiB":  "31GiB RAM detected. Harvester requires at least 64GiB for production use.",
+		"./testdata/meminfo-64GiB":  "",
+	}
+
+	check := MemoryCheck{}
+	for file, expectedOutput := range expectedOutputs {
+		procMemInfo = file
+		msg, err := check.Run()
+		assert.Nil(t, err)
+		assert.Equal(t, expectedOutput, msg)
+	}
+}

--- a/pkg/preflight/testdata/meminfo-32GiB
+++ b/pkg/preflight/testdata/meminfo-32GiB
@@ -1,0 +1,11 @@
+MemTotal:       32856640 kB
+MemFree:        32382884 kB
+MemAvailable:   32253832 kB
+Buffers:            2824 kB
+Cached:           259024 kB
+SwapCached:            0 kB
+Active:            58916 kB
+Inactive:         245596 kB
+Active(anon):      11384 kB
+Inactive(anon):    65636 kB
+[...]

--- a/pkg/preflight/testdata/meminfo-512MiB
+++ b/pkg/preflight/testdata/meminfo-512MiB
@@ -1,0 +1,11 @@
+MemTotal:         458112 kB
+MemFree:          237300 kB
+MemAvailable:     363876 kB
+Buffers:           11060 kB
+Cached:           113268 kB
+SwapCached:            0 kB
+Active:            77428 kB
+Inactive:          72888 kB
+Active(anon):       1008 kB
+Inactive(anon):    30564 kB
+[...]

--- a/pkg/preflight/testdata/meminfo-64GiB
+++ b/pkg/preflight/testdata/meminfo-64GiB
@@ -1,0 +1,11 @@
+MemTotal:       65758888 kB
+MemFree:         4477304 kB
+MemAvailable:   21303852 kB
+Buffers:            2184 kB
+Cached:         15184228 kB
+SwapCached:       794172 kB
+Active:         18978584 kB
+Inactive:       35250536 kB
+Active(anon):   10781392 kB
+Inactive(anon): 29766196 kB
+[...]

--- a/pkg/widgets/util.go
+++ b/pkg/widgets/util.go
@@ -50,3 +50,17 @@ func isAtEnd(v *gocui.View) bool {
 	}
 	return false
 }
+
+// This will insert linebreaks in a string so that it doesn't exceed
+// the specified number of columns.
+func wrapText(text string, columns int) string {
+	if len(text) < columns {
+		return text
+	}
+	for i := len(text) - 1; i >= 0; i-- {
+		if text[i] == ' ' && i < columns {
+			return text[:i] + "\n" + wrapText(text[i+1:], columns)
+		}
+	}
+	return text
+}


### PR DESCRIPTION
**Problem:**
We need to run some checks to ensure harvester is being installed on minimum supported hardware.

**Solution:**
This adds three preflight checks:
    
- Number of CPU cores
- Available memory
- Whether the system is running virtualized or not
    
Each check will result in a warning message if it doesn't pass. If there are any warning messages, a new page is inserted at the start of the installer listing the warnings and asking the user if they wish to proceed.  If the user selects "no", the system is rebooted. If there are no warnings, this page does not appear.
    
Outstanding issues:
    
- There are no unit tests.
- The warning messages are quite long, and wrap oddly on very small screens/terminal windows.
- The preflight checks have no effect for PXE/automated installs. For this path we should fail the install if there's any warnings, but allow overriding with a flag (see https://github.com/harvester/harvester/issues/1154#issuecomment-1888723063)
- More checks?

I'm opening this PR now even though there's still outstanding work in case anyone would like to critique the approach I've taken here.

Note that this PR also includes the Vagrantfile from #631 and the select widget fix from #635. I'll rebase once those are merged.

**Related Issue:**
https://github.com/harvester/harvester/issues/1154

**Test plan:**

Requires three systems:

1. One meeting production requirements (>=16 CPU cores, >=64GiB RAM, bare metal, i.e. not running under virtualization)
2. One meeting testing requirements (8-15 CPU cores, 32-60GiB RAM, can be virtualized)
3. One that doesn't meet any of those requirements (<8 CPU cores, <32GiB RAM, can be virtualized)

Boot the Harvester ISO on each system:

1. For the system that meets production requirements, verify that the installer starts as normal on the console with no hardware check warnings, i.e. first screen is "Choose installation mode".
2. For the system that meets testing requirements, verify that the first screen of the installer shows the Hardware Checks, similar to the following:
```
8 CPU cores detected. Harvester requires at least 16 cores for production use.
3 GiB RAM detected. Harvester requires at least 64GiBfor production use.
System is virtualized (kvm) which is not supported.

Do you wish to proceeed?
```
3. For the system that doesn't meet any requirements, it should behave the same as point 2, but with warning messages calling out the testing limits, e.g.:
```
Only 4 CPU cores detected. Harvester requires at least 8 cores for testing and 16 for production use.
Only 7GiB RAM detected. Harvester requires at least 32GiB for testing and 64GiB for production use.
System is virtualized (kvm) which is not supported.
```
4. For both the above cases, selecting "Yes" to proceed should take you to the normal first page of the installer ("Choose installation mode"). Selecting "No" should reboot the system.

To verify PXE boot:

1. Deploy a system that meets the production requirements via PXE - it should deploy just fine.
2. Deploy a system that only meets the testing requirements (or doesn't meet any requirements). Ensure the `harvester.install.skipchecks=true` kernel command line parameter is _not_ specified. Installation should fail, with the above hardware check warning messages printed to the console, and also in `/var/log/console.log` in the installation environment.
3. Deploy a system that only meets the testing requirements, but use the `harvester.install.skipchecks=true` kernel command line parameter. Installation should succeed, but once the system is installed, the hardware check warnings should be present in `/oem/install/console.log` (try `grep warning /oem/install/console.log`)

**Sample Screenshots:**

Preflight warnings on a VM with 4 CPU cores and 32GiB RAM:

![installer-preflight-warnings](https://github.com/harvester/harvester-installer/assets/754700/8fb83d87-3dc4-4abe-a7db-bb9d751873c1)

Preflight warnings on a ridiculously small VM (512MB / 1 CPU), in a small terminal window, to demonstrate the poor wrapping of the long messages:

![installer-preflight-tiny-vm](https://github.com/harvester/harvester-installer/assets/754700/2697bdfe-1916-4d1b-851f-23b374f9ce1c)

I guess the easy way to fix the above is to just put explicit `'\n'` characters in the messages to cap them at about 60 columns, but then they'd look weird on large screens - it'd be nicer to maybe tweak `Panel.SetContent()` to automatically insert a linebreak in place of a space character in lines that exceed the actual width of the panel.