### PR TITLE
feat: add precedent image lists into iso image

### DIFF
--- a/scripts/archive-images-lists.sh
+++ b/scripts/archive-images-lists.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env sh
+set -e
+
+UPGRADE_MATRIX_FILE=$1
+IMAGES_LISTS_DIR=$2
+RANCHERD_IMAGES_DIR=$3
+IMAGES_LISTS_ARCHIVE_DIR=$4
+
+WORKING_DIR=$(mktemp -d)
+
+if [ ! -e "$UPGRADE_MATRIX_FILE" ]; then
+  echo "Could not find $UPGRADE_MATRIX_FILE, skip it"
+  exit 0
+fi
+
+# Add all the current version's images lists
+mkdir -p "$IMAGES_LISTS_ARCHIVE_DIR"/current
+find $IMAGES_LISTS_DIR -name "*.txt" -exec cat {} \; >> "$IMAGES_LISTS_ARCHIVE_DIR"/current/image_list_all.txt
+find $RANCHERD_IMAGES_DIR -name "*.txt" -exec cat {} \; >> "$IMAGES_LISTS_ARCHIVE_DIR"/current/image_list_all.txt
+cat "$IMAGES_LISTS_ARCHIVE_DIR"/current/image_list_all.txt | sort | uniq | tee "$IMAGES_LISTS_ARCHIVE_DIR"/current/image_list_all.txt
+
+# Add all the previous versions' images lists
+previous_versions=$(yq e ".versions[].name" "$UPGRADE_MATRIX_FILE" | xargs)
+for prev_ver in $(echo "$previous_versions"); do
+  ret=0
+
+  echo "Fetching $prev_ver image lists..."
+
+  mkdir "$WORKING_DIR"/"$prev_ver"
+
+  curl -fL https://releases.rancher.com/harvester/"$prev_ver"/image-lists.tar.gz -o "$WORKING_DIR"/image-lists.tar.gz || ret=$?
+  if [ "$ret" -ne 0 ]; then
+    echo "Cannot download image list tarball for version $prev_ver, skip it"
+    continue
+  fi
+  tar -zxvf "$WORKING_DIR"/image-lists.tar.gz -C "$WORKING_DIR"/"$prev_ver"/
+
+  prev_image_list="$WORKING_DIR"/image_list_all.txt
+  cat "$WORKING_DIR"/"$prev_ver"/image-lists/*.txt | sort | uniq > "$prev_image_list"
+
+  mkdir -p "$IMAGES_LISTS_ARCHIVE_DIR"/"$prev_ver"
+  cp -a "$prev_image_list" "$IMAGES_LISTS_ARCHIVE_DIR"/"$prev_ver"/
+
+  rm -rf "$WORKING_DIR"/*
+done

--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -36,6 +36,9 @@ kubevirt: ${HARVESTER_KUBEVIRT_VERSION}
 minUpgradableVersion: '${HARVESTER_MIN_UPGRADABLE_VERSION}'
 EOF
 
+# Collect all the previous versions' image lists
+${SCRIPTS_DIR}/archive-images-lists.sh "${TOP_DIR}/../harvester/package/upgrade-matrix.yaml" "${IMAGES_LISTS_DIR}" "${RANCHERD_IMAGES_DIR}" "${BUNDLE_DIR}/harvester/images-lists-archive"
+
 # Collect dependencies' versions
 ${SCRIPTS_DIR}/collect-deps.sh harvester-release.yaml
 


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

There's no way for Harvester itself to know the image list of each release. Such information is useful for the image cleanup mechanism introduced in harvester/harvester#4995.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

This will add all the previous versions' published image lists into the ISO image according to the upgrade matrix file in harvester repo

Based on [upgrade-helpers/bin/harv-purge-images.sh at d490e51c76b107c8d5df2df71d0e9b7000b392d6 · harvester/upgrade-helpers](https://github.com/harvester/upgrade-helpers/blob/d490e51c76b107c8d5df2df71d0e9b7000b392d6/bin/harv-purge-images.sh), downloading and adding all the previous versions' published image lists into the ISO image that is going to be built. These image lists will be used later for the upgrade controller to purge the unneeded container images.

**Related Issue:**

harvester/harvester#4425

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

Please reference https://github.com/harvester/harvester/issues/4425#issuecomment-1900566020