### PR TITLE
Update rancherd-12-monitoring-dashboard.yaml

### DIFF
--- a/pkg/config/templates/rancherd-12-monitoring-dashboard.yaml
+++ b/pkg/config/templates/rancherd-12-monitoring-dashboard.yaml
@@ -497,7 +497,7 @@ resources:
             "timeFrom": null,
             "timeRegions": [],
             "timeShift": null,
-            "title": "Network Receive Bytes",
+            "title": "Network Receive Bits",
             "tooltip": {
               "shared": true,
               "sort": 0,
@@ -592,7 +592,7 @@ resources:
             "timeFrom": null,
             "timeRegions": [],
             "timeShift": null,
-            "title": "Network Transmit Bytes",
+            "title": "Network Transmit Bits",
             "tooltip": {
               "shared": true,
               "sort": 0,


### PR DESCRIPTION


**Problem:**
The panel titles "Network Receive Bytes" and "Network Transmit Bytes" are a bit misleading as the values are in Bits/s. And Storage Write Traffic Bytes" is really in Bytes/s.
 See expr : "metrics* 8!"
The units where already correctly shown in "MB/s".

**Solution:**
 Rename panel titles to "Bits"

**Related Issue:**

