### PR TITLE
silence rsync progress in harv-install

### DIFF
--- a/package/harvester-os/files/usr/sbin/harv-install
+++ b/package/harvester-os/files/usr/sbin/harv-install
@@ -161,10 +161,10 @@ preload_rke2_images()
     # Otherwise (PXE), use bind-mount directly to speed up the process
     if [ "$INSTALL_MODE" = "ISO" ]; then
         echo "Copying RKE2 images to the target location..."
-        rsync -ah --progress ${ISOMNT}/bundle/harvester/images/rke2-images.*.tar.zst $TARGET/$RKE2_IMAGES_DIR
+        rsync -a ${ISOMNT}/bundle/harvester/images/rke2-images.*.tar.zst $TARGET/$RKE2_IMAGES_DIR
         echo "Copying remaining images temporary location..."
-        rsync -ah --progress ${ISOMNT}/bundle/harvester/images/ $TARGET/$TMP_IMAGES_DIR
-        rsync -ah --progress ${ISOMNT}/bundle/harvester/images-lists/ $TARGET/$IMAGES_LISTS_DIR
+        rsync -a ${ISOMNT}/bundle/harvester/images/ $TARGET/$TMP_IMAGES_DIR
+        rsync -a ${ISOMNT}/bundle/harvester/images-lists/ $TARGET/$IMAGES_LISTS_DIR
     else
         echo "Bind-mount images directory to the target location..."
         mount --bind ${ISOMNT}/bundle/harvester/images $TARGET/$RKE2_IMAGES_DIR

--- a/package/harvester-os/files/usr/sbin/harv-install
+++ b/package/harvester-os/files/usr/sbin/harv-install
@@ -161,10 +161,10 @@ preload_rke2_images()
     # Otherwise (PXE), use bind-mount directly to speed up the process
     if [ "$INSTALL_MODE" = "ISO" ]; then
         echo "Copying RKE2 images to the target location..."
-        rsync -a ${ISOMNT}/bundle/harvester/images/rke2-images.*.tar.zst $TARGET/$RKE2_IMAGES_DIR
+        rsync -ahv ${ISOMNT}/bundle/harvester/images/rke2-images.*.tar.zst $TARGET/$RKE2_IMAGES_DIR
         echo "Copying remaining images temporary location..."
-        rsync -a ${ISOMNT}/bundle/harvester/images/ $TARGET/$TMP_IMAGES_DIR
-        rsync -a ${ISOMNT}/bundle/harvester/images-lists/ $TARGET/$IMAGES_LISTS_DIR
+        rsync -ahv ${ISOMNT}/bundle/harvester/images/ $TARGET/$TMP_IMAGES_DIR
+        rsync -ahv ${ISOMNT}/bundle/harvester/images-lists/ $TARGET/$IMAGES_LISTS_DIR
     else
         echo "Bind-mount images directory to the target location..."
         mount --bind ${ISOMNT}/bundle/harvester/images $TARGET/$RKE2_IMAGES_DIR


### PR DESCRIPTION
**Problem:**
Because this is running without a TTY, it may be affecting IPMI-based installs that take hours to read the zst files off of virtual media.  

**Solution:**
This patch removes the progress flag from rsync in the hopes that it prevents rsync from freezing during install.

**Related Issue:**

harvester/harvester#2651

**Test plan:**
Test install on slow IPMI virtual media
