### PR TITLE
Feat: create a net-install ISO

### DIFF
--- a/package/harvester-os/files/usr/sbin/harv-install
+++ b/package/harvester-os/files/usr/sbin/harv-install
@@ -282,6 +282,13 @@ preload_rancherd_images()
     cp ${ISOMNT}/bundle/rancherd/images/* $TARGET/var/lib/rancher/agent/images
 }
 
+defer_preload_images()
+{
+    echo "Save image tarball(s) to $TARGET/var/lib/rancher/rke2/agent/images"
+    mkdir -p $TARGET/var/lib/rancher/rke2/agent/images
+    cp ${ISOMNT}/bundle/harvester/images/*.tar.zst $TARGET/var/lib/rancher/rke2/agent/images
+}
+
 do_preload()
 {
     # Bind mount persistent folder to preload images
@@ -294,8 +301,14 @@ do_preload()
         mount -o bind $TARGET/$state_dir $TARGET/$i
     done
 
-    preload_rancherd_images
-    preload_rke2_images
+    if [ -n "$HARVESTER_WITH_NET_IMAGES" ]; then
+        # Preload images after the installing node reboots and RKE2 starts
+        defer_preload_images
+    else
+        # Preload all images now
+        preload_rancherd_images
+        preload_rke2_images
+    fi
 
     for i in ${BIND_MOUNTS[@]}; do
         umount $TARGET/$i

--- a/package/harvester-os/iso/boot/grub2/grub.cfg
+++ b/package/harvester-os/iso/boot/grub2/grub.cfg
@@ -22,7 +22,7 @@ if [ -f ${font} ];then
 fi
 menuentry "Harvester Installer ${harvester_version}" --class os --unrestricted {
     echo Loading kernel...
-    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 rd.cos.disable net.ifnames=1
+    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 rd.cos.disable net.ifnames=1 ${extra_iso_cmdline}
     echo Loading initrd...
     $initrd ($root)/boot/initrd
 }
@@ -30,7 +30,7 @@ menuentry "Harvester Installer ${harvester_version}" --class os --unrestricted {
 menuentry "Harvester Installer ${harvester_version} (VGA 1024x768)" --class os --unrestricted {
     set gfxpayload=1024x768x24,1024x768
     echo Loading kernel...
-    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 rd.cos.disable net.ifnames=1
+    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 rd.cos.disable net.ifnames=1 ${extra_iso_cmdline}
     echo Loading initrd...
     $initrd ($root)/boot/initrd
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -136,17 +136,18 @@ type Install struct {
 	VipHwAddr string `json:"vipHwAddr,omitempty"`
 	VipMode   string `json:"vipMode,omitempty"`
 
-	ForceEFI  bool   `json:"forceEfi,omitempty"`
-	Device    string `json:"device,omitempty"`
-	ConfigURL string `json:"configUrl,omitempty"`
-	Silent    bool   `json:"silent,omitempty"`
-	ISOURL    string `json:"isoUrl,omitempty"`
-	PowerOff  bool   `json:"powerOff,omitempty"`
-	NoFormat  bool   `json:"noFormat,omitempty"`
-	Debug     bool   `json:"debug,omitempty"`
-	TTY       string `json:"tty,omitempty"`
-	ForceGPT  bool   `json:"forceGpt,omitempty"`
-	Role      string `json:"role,omitempty"`
+	ForceEFI      bool   `json:"forceEfi,omitempty"`
+	Device        string `json:"device,omitempty"`
+	ConfigURL     string `json:"configUrl,omitempty"`
+	Silent        bool   `json:"silent,omitempty"`
+	ISOURL        string `json:"isoUrl,omitempty"`
+	PowerOff      bool   `json:"powerOff,omitempty"`
+	NoFormat      bool   `json:"noFormat,omitempty"`
+	Debug         bool   `json:"debug,omitempty"`
+	TTY           string `json:"tty,omitempty"`
+	ForceGPT      bool   `json:"forceGpt,omitempty"`
+	Role          string `json:"role,omitempty"`
+	WithNetImages bool   `json:"withNetImages,omitempty"`
 
 	// Following options are not cOS installer flag
 	ForceMBR bool   `json:"forceMbr,omitempty"`

--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -79,9 +79,9 @@ func (c *Console) layoutInstall(g *gocui.Gui) error {
 		}
 
 		if cfg, err := config.ReadConfig(); err == nil {
+			c.config.Merge(cfg)
 			if cfg.Install.Automatic && isFirstConsoleTTY() {
 				logrus.Info("Start automatic installation...")
-				c.config.Merge(cfg)
 				// setup InstallMode to ensure that during automatic install
 				// we are only copying binaries and ignoring network / rancherd setup
 				// needed for generating pre-installed qcow2 image

--- a/scripts/lib/iso
+++ b/scripts/lib/iso
@@ -1,0 +1,27 @@
+pack_iso() {
+    local extract_dir=$1
+    local vol_id=$2
+    local iso_file=$3
+
+    echo "Creating ISO ${iso_file} from ${extract_dir}, vol_id: ${vol_id}..."
+
+    xorriso -volid "$vol_id" \
+        -joliet on -padding 0 \
+        -outdev "$iso_file" \
+        -map "${extract_dir}" / -chmod 0755 -- \
+        -boot_image grub bin_path="boot/x86_64/loader/eltorito.img" \
+        -boot_image grub grub2_mbr="${extract_dir}/boot/x86_64/loader/boot_hybrid.img" \
+        -boot_image grub grub2_boot_info=on \
+        -boot_image any partition_offset=16 \
+        -boot_image any cat_path="boot/x86_64/boot.catalog" \
+        -boot_image any cat_hidden=on \
+        -boot_image any boot_info_table=on \
+        -boot_image any platform_id=0x00 \
+        -boot_image any emul_type=no_emulation \
+        -boot_image any load_size=2048 \
+        -append_partition 2 0xef "${extract_dir}/boot/uefi.img" \
+        -boot_image any next \
+        -boot_image any efi_path=--interval:appended_partition_2:all:: \
+        -boot_image any platform_id=0xef \
+        -boot_image any emul_type=no_emulation
+}

--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -16,6 +16,7 @@ source ${SCRIPTS_DIR}/version-rancher
 source ${SCRIPTS_DIR}/version-harvester ${TOP_DIR}/../harvester
 source ${SCRIPTS_DIR}/version-monitoring
 source ${SCRIPTS_DIR}/version-logging
+source ${SCRIPTS_DIR}/lib/iso
 
 BASE_OS_IMAGE="rancher/harvester-os:sle-micro-head"
 HARVESTER_OS_IMAGE=rancher/harvester-os:$VERSION
@@ -108,25 +109,29 @@ mcopy -s -i "${uefi_img}" "${extract_dir}/EFI" ::
 
 # Remove original ISO, and repack it using xorriso
 rm -f "${ARTIFACTS_DIR}/${ISO_PREFIX}.iso"
-xorriso -volid "$(yq '.iso.label' manifest.yaml)" \
-    -joliet on -padding 0 \
-    -outdev "${ARTIFACTS_DIR}/${ISO_PREFIX}.iso" \
-    -map "${extract_dir}" / -chmod 0755 -- \
-    -boot_image grub bin_path="boot/x86_64/loader/eltorito.img" \
-    -boot_image grub grub2_mbr="${extract_dir}/boot/x86_64/loader/boot_hybrid.img" \
-    -boot_image grub grub2_boot_info=on \
-    -boot_image any partition_offset=16 \
-    -boot_image any cat_path="boot/x86_64/boot.catalog" \
-    -boot_image any cat_hidden=on \
-    -boot_image any boot_info_table=on \
-    -boot_image any platform_id=0x00 \
-    -boot_image any emul_type=no_emulation \
-    -boot_image any load_size=2048 \
-    -append_partition 2 0xef "${extract_dir}/boot/uefi.img" \
-    -boot_image any next \
-    -boot_image any efi_path=--interval:appended_partition_2:all:: \
-    -boot_image any platform_id=0xef \
-    -boot_image any emul_type=no_emulation
+iso_vol_id="$(yq '.iso.label' manifest.yaml)"
+pack_iso "${extract_dir}" "$iso_vol_id" "${ARTIFACTS_DIR}/${ISO_PREFIX}.iso"
+
+
+# Net-install ISO
+echo "set extra_iso_cmdline=harvester.install.with_net_images=true" >> ${extract_dir}/boot/grub2/harvester.cfg
+
+# bundle the harvester-cluster-repo image for net-install ISO
+mkdir ${extract_dir}/bundle.new
+yq '.images.common[] | select(.list == "*harvester-repo-images-*.txt") | {"images": {"common": [.]}}' \
+  ${extract_dir}/bundle/metadata.yaml > ${extract_dir}/bundle.new/metadata.yaml
+cluster_repo_image_list=$(yq '.images.common[0].list' ${extract_dir}/bundle.new/metadata.yaml)
+cluster_repo_image_list_dir=${extract_dir}/bundle.new/$(dirname $cluster_repo_image_list)
+cluster_repo_image_archive=$(yq '.images.common[0].archive' ${extract_dir}/bundle.new/metadata.yaml)
+cluster_repo_image_archive_dir=${extract_dir}/bundle.new/$(dirname $cluster_repo_image_archive)
+mkdir -p $cluster_repo_image_list_dir && cp ${extract_dir}/bundle/$cluster_repo_image_list $cluster_repo_image_list_dir
+mkdir -p $cluster_repo_image_archive_dir && cp ${extract_dir}/bundle/$cluster_repo_image_archive $cluster_repo_image_archive_dir
+rm -rf ${extract_dir}/bundle
+mv ${extract_dir}/bundle.new ${extract_dir}/bundle
+chmod -R a=r,u+w,a+X "${extract_dir}/bundle"
+
+pack_iso "${extract_dir}" "$iso_vol_id" "${ARTIFACTS_DIR}/${ISO_PREFIX}-net-install.iso"
+
 
 # Cleanup
 rm -rf "${extract_dir}"


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
To create a net-install ISO.
- Save time for downloading the installation medium.
- (hopefully) Prevent issues on buggy BMC ISO redirection feature: https://github.com/harvester/harvester/issues/2651

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
We can ship a net-install ISO without image tarballs since we already https://github.com/harvester/harvester/issues/2670.

**Related Issue:**
https://github.com/harvester/harvester/issues/4295


**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
- Build the code
- Boot the net-install ISO (Its name is similar to `harvester-74e9450-dirty-amd64-net-install.iso`) and verify the installation. Both interactive mode and ipxe mode should work.

**Additional context**

- Add a kernel parameter `harvester.install.with_net_images=true` to GRUB menuentry in the net-install ISO. The installer only preloads the `harvester-cluste-repo` image if it sees the parameter. We still preload this image to ease development.
- The kernel parameter `harvester.install.with_net_images=true` also works for the ordinary ISO.

