### PR TITLE
Add preflight check for hardware-assisted virtualization

### DIFF
--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -158,6 +158,7 @@ func (c *Console) doRun() error {
 			preflight.CPUCheck{},
 			preflight.MemoryCheck{},
 			preflight.VirtCheck{},
+			preflight.KVMHostCheck{},
 		}
 		for _, c := range checks {
 			msg, err := c.Run()

--- a/pkg/preflight/checks_test.go
+++ b/pkg/preflight/checks_test.go
@@ -129,3 +129,21 @@ func TestMemoryCheck(t *testing.T) {
 		assert.Equal(t, expectedOutput, msg)
 	}
 }
+
+func TestKVMHostCheck(t *testing.T) {
+	defaultDevKvm := devKvm
+	defer func() { devKvm = defaultDevKvm }()
+
+	expectedOutputs := map[string]string{
+		"./testdata/dev-kvm-does-not-exist": "Harvester requires hardware-assisted virtualization, but /dev/kvm does not exist.",
+		"./testdata/dev-kvm":                "",
+	}
+
+	check := KVMHostCheck{}
+	for file, expectedOutput := range expectedOutputs {
+		devKvm = file
+		msg, err := check.Run()
+		assert.Nil(t, err)
+		assert.Equal(t, expectedOutput, msg)
+	}
+}


### PR DESCRIPTION
**Problem:**
We need to make sure the host we're installing on supports hardware-assisted virtualization.

**Solution:**
This is pretty quick and dirty, but I hope should not be unreasonable. https://help.ubuntu.com/community/KVM/Installation tells us that we need to run `egrep -c '(vmx|svm)' /proc/cpuinfo` to check for hardware-assisted virtualization on x86_64 systems, but I think we can short-circuit that.

I reviewed the kvm-ok script (https://bazaar.launchpad.net/~cpu-checker-dev/cpu-checker/trunk/view/head:/kvm-ok) and it first checks for those CPU flags, and then next checks for the existence of /dev/kvm.  If both succeed, we're good.  But I don't think we actually need the CPU flag check, at least on SUSE distros.  I did some testing, and AFAICT if the CPU supports hardware virtualization, the appropriate kvm kernel module (e.g. kvm_intel) is loaded automatically, so /dev/kvm will exist.  If not, the module doesn't get loaded and /dev/kvm doesn't exist.

More recent changes to kvm-ok in Debian-based distros (see https://sources.debian.org/patches/cpu-checker/0.7-1.3/) add support for other architectures (aarch64, ppc*, s390x, riscv64), but in all those cases, the only thing that happens is a check for the existence of /dev/kvm.

**Related Issue:**
https://github.com/harvester/harvester/issues/1154

**Test plan:**
N/A (should be covered by unit tests in this PR)

