### PR TITLE
Clarify wording of VirtCheck failure, fix weird line wrapping

### DIFF
--- a/pkg/preflight/checks.go
+++ b/pkg/preflight/checks.go
@@ -118,7 +118,7 @@ func (c VirtCheck) Run() (msg string, err error) {
 		}
 		return
 	}
-	msg = fmt.Sprintf("System is virtualized (%s) which is not supported.", virt)
+	msg = fmt.Sprintf("System is virtualized (%s) which is not supported in production.", virt)
 	return
 }
 

--- a/pkg/preflight/checks_test.go
+++ b/pkg/preflight/checks_test.go
@@ -95,7 +95,7 @@ func TestVirtCheck(t *testing.T) {
 	defer func() { execCommand = exec.Command }()
 
 	expectedOutputs := map[string]string{
-		"kvm":   "System is virtualized (kvm) which is not supported.",
+		"kvm":   "System is virtualized (kvm) which is not supported in production.",
 		"metal": "",
 	}
 

--- a/pkg/widgets/panel.go
+++ b/pkg/widgets/panel.go
@@ -139,7 +139,9 @@ func (p *Panel) SetLocation(x0, y0, x1, y1 int) {
 }
 
 func (p *Panel) SetContent(content string) {
-	panelWidth := p.X1 - p.X0
+	// Need to subtract 1 from panelWidth here to match the view.Size()
+	// calculation done in gocui's view.Draw() function
+	panelWidth := p.X1 - p.X0 - 1
 	if panelWidth > 0 {
 		p.Content = ""
 		lines := strings.Split(content, "\n")


### PR DESCRIPTION
**Problem:**
When running under virtualization the current warning message says "System is virtualized (kvm) which is not supported", but should say "not supported in production". Also, in some cases, there's extra linebreaks in the warning messages, e.g.:

![image (6)](https://github.com/harvester/harvester-installer/assets/754700/f78e90a5-5f49-440d-a9e3-627073937bc8)

**Solution:**
This PR

**Related Issue:**
https://github.com/harvester/harvester/issues/1154

**Test plan:**
N/A

