### PR TITLE
additional installer option to wipe all disks before install

### DIFF
--- a/package/harvester-os/files/usr/sbin/harv-install
+++ b/package/harvester-os/files/usr/sbin/harv-install
@@ -7,17 +7,46 @@ DATA_DISK_FSLABEL="HARV_LH_DEFAULT"
 
 clear_disk_label()
 {
-    # Clear the label of partitions that has $DATA_DISK_FSLABEL to prevent misidentification
-    # Also, while yip is partitioning the disk, if it sees the LABEL to be used exists,
-    # it won't create the partition. So it's necessary to clear the label
-    for part in $(blkid -t LABEL="$DATA_DISK_FSLABEL" -o device); do
-        echo "Remove filesystem label from $part"
-        # Run this tune2fs twice because sometimes the first run would show "Recovering journal"
-        # and label is not modified
-        tune2fs -L "" $part > /dev/null
-        tune2fs -L "" $part > /dev/null
-    done
-    udevadm settle
+    # For internal automation environments we need to be able to wipe all disks on the node
+    # to ensure that host does not boot off partitions from another disk in the host
+    # lsblk produces the following json output, which we filter using jq to identify disks
+    # which we will be wiping
+    # lsblk -d -n -J -o NAME,TYPE
+    # {
+    #  "blockdevices": [
+    #  {
+    #     "name": "loop0",
+    #     "type": "loop"
+    #  },{
+    #     "name": "sr0",
+    #     "type": "rom"
+    #  },{
+    #     "name": "vda",
+    #     "type": "disk"
+    #     }
+    #   ]
+    # }
+    if [ "$HARVESTER_WIPE_DISKS" == "true" ]; then
+        echo "wiping all disks"
+        for disk in $(lsblk -d -n -J -o NAME,TYPE | jq -r '.blockdevices[] | select(.type == "disk") | .name')
+        do
+            sgdisk -Z /dev/$disk
+            partprobe -s /dev/$disk
+        done
+    else
+        # Clear the label of partitions that has $DATA_DISK_FSLABEL to prevent misidentification
+        # Also, while yip is partitioning the disk, if it sees the LABEL to be used exists,
+        # it won't create the partition. So it's necessary to clear the label
+        for part in $(blkid -t LABEL="$DATA_DISK_FSLABEL" -o device); do
+            echo "Remove filesystem label from $part"
+            # Run this tune2fs twice because sometimes the first run would show "Recovering journal"
+            # and label is not modified
+            tune2fs -L "" $part > /dev/null
+            tune2fs -L "" $part > /dev/null
+        done
+        udevadm settle
+    fi
+   
 }
 
 umount_target() {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -149,6 +149,7 @@ type Install struct {
 	ForceGPT      bool   `json:"forceGpt,omitempty"`
 	Role          string `json:"role,omitempty"`
 	WithNetImages bool   `json:"withNetImages,omitempty"`
+	WipeDisks     bool   `json:"wipeDisks,omitempty"`
 
 	// Following options are not cOS installer flag
 	ForceMBR bool   `json:"forceMbr,omitempty"`


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
During out internal automation testing it is possible different disks were used to install of harvester.
When the disk is changed the older installation is left intact which can cause unexpected results during reboots.
To ensure this does not happen we need to be able to allow wiping of disks via the installer.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
PR adds an additional option in harvester config `wipeDisks` which can be passed via a config url or kernel arguments `harvester.install.wipe_disks=true` and will result in the harv-install script wiping all disks on the node.

**Related Issue:**
https://github.com/harvester/harvester/issues/2066
https://github.com/harvester/harvester/issues/2781
https://github.com/harvester/harvester/issues/4527

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

