### PR TITLE
suffix os arch to harvester-images-list.txt and image-lists.tar.gz

### DIFF
--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -216,7 +216,7 @@ find $IMAGES_LISTS_DIR -name "*.txt" -exec cp {} $OUTPUT_DIR \;
 find $RANCHERD_IMAGES_DIR -name "*.txt" -exec cp {} $OUTPUT_DIR \;
 
 # Write all images into one file for user convenience
-IMAGE_ALL=$TOP_DIR/dist/artifacts/harvester-images-list.txt
+IMAGE_ALL=$TOP_DIR/dist/artifacts/harvester-images-list-${ARCH}.txt
 rm -f ${IMAGE_ALL}
 echo "# All images in the Harvester ISO built @ " $(date) $'\n' > ${IMAGE_ALL}
 for filename in $OUTPUT_DIR/*.txt; do
@@ -226,4 +226,4 @@ for filename in $OUTPUT_DIR/*.txt; do
 done
 
 # Write image lists to a tarball "image-lists.tar.gz"
-tar zcvf $TOP_DIR/dist/artifacts/image-lists.tar.gz -C $TOP_DIR/dist/artifacts image-lists && rm -rf $OUTPUT_DIR
+tar zcvf $TOP_DIR/dist/artifacts/image-lists-${ARCH}.tar.gz -C $TOP_DIR/dist/artifacts image-lists && rm -rf $OUTPUT_DIR


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Currently CI for arm64 and amd64 images overwrites the harvester-images-list.text and image-lists.tar.gz file.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
The PR adds an arch suffix to both these files.

**Related Issue:**
https://github.com/harvester/harvester/issues/371
**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

