### PR TITLE
added additional check for first console when booting on arm hosts

### DIFF
--- a/pkg/console/tty.go
+++ b/pkg/console/tty.go
@@ -3,6 +3,7 @@ package console
 import (
 	"io/ioutil"
 	"os"
+	goruntime "runtime"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -17,6 +18,15 @@ func getFirstConsoleTTY() string {
 
 	ttys := strings.Split(strings.TrimRight(string(b), "\n"), " ")
 	if len(ttys) > 0 {
+		// arm devices generally have first console as /dev/ttyAMA0
+		// this console is skipped in iso based installs due to display resolution issues
+		// as a result of this automatic install via ipxe fails since installer runs in
+		// say /dev/tty1 but first console returned by this method is ttyAMA0
+		// we are currently adding a check to skip AMA0 if it is the first console and return
+		// the second item in the list
+		if goruntime.GOARCH == "arm64" && strings.Contains(ttys[0], "AMA0") && len(ttys) > 1 {
+			return ttys[1]
+		}
 		return ttys[0]
 	}
 	return ""


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

For iso based installs, we added logic to skip ttyAMA0 as the serial console runs into resolution issues, and this causes the installer to crash. 

Automatic install fails on arm hosts since the installer checks first console which is generally always returned as ttyAMA0. As a result of which automatic install is never triggered.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
The PR attempts to fix this by skipping ttyAMA0 if
* there are multiple consoles specified
* ttyAMA0 is the first console
* underlying host is an arm64 machine
* 
**Related Issue:**

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

