### PR TITLE
Make image list packing architecture-awared

### DIFF
--- a/scripts/archive-images-lists.sh
+++ b/scripts/archive-images-lists.sh
@@ -41,7 +41,7 @@ for prev_ver in $(echo "$previous_versions"); do
 
   image_lists_url=https://releases.rancher.com/harvester/"$prev_ver"/image-lists.tar.gz
   # arch-aware image is available after v1.3.0
-  if [ "$(version_compare "$prev_ver" "v1.3.0")"  -eq 1 ]; then
+  if [ "$(version_compare "$prev_ver" "v1.3.0")" -eq 1 ]; then
     image_lists_url=https://releases.rancher.com/harvester/"$prev_ver"/image-lists-"$ARCH".tar.gz
   fi
 

--- a/scripts/archive-images-lists.sh
+++ b/scripts/archive-images-lists.sh
@@ -13,9 +13,9 @@ version_compare() {
     local v1=$1
     local v2=$2
     if [[ "$(printf "%s\n" "$v1" "$v2" | sort -V | head -n1)" == "$v2" ]]; then
-        echo "1"  # v1 is greater than or equal to v2
+        echo 1  # v1 is greater than or equal to v2
     else
-        echo "0"  # v1 is less than v2
+        echo 0  # v1 is less than v2
     fi
 }
 
@@ -41,7 +41,7 @@ for prev_ver in $(echo "$previous_versions"); do
 
   image_lists_url=https://releases.rancher.com/harvester/"$prev_ver"/image-lists.tar.gz
   # arch-aware image is available after v1.3.0
-  if [ "$(version_compare "$prev_ver" "v1.3.0")"  -eq "1" ]; then
+  if [ "$(version_compare "$prev_ver" "v1.3.0")"  -eq 1 ]; then
     image_lists_url=https://releases.rancher.com/harvester/"$prev_ver"/image-lists-"$ARCH".tar.gz
   fi
 

--- a/scripts/archive-images-lists.sh
+++ b/scripts/archive-images-lists.sh
@@ -1,12 +1,23 @@
-#!/usr/bin/env sh
+#!/bin/bash
 set -e
 
 UPGRADE_MATRIX_FILE=$1
 IMAGES_LISTS_DIR=$2
 RANCHERD_IMAGES_DIR=$3
 IMAGES_LISTS_ARCHIVE_DIR=$4
+ARCH=$5
 
 WORKING_DIR=$(mktemp -d)
+
+version_compare() {
+    local v1=$1
+    local v2=$2
+    if [[ "$(printf "%s\n" "$v1" "$v2" | sort -V | head -n1)" == "$v2" ]]; then
+        echo "1"  # v1 is greater than or equal to v2
+    else
+        echo "0"  # v1 is less than v2
+    fi
+}
 
 if [ ! -e "$UPGRADE_MATRIX_FILE" ]; then
   echo "Could not find $UPGRADE_MATRIX_FILE, skip it"
@@ -28,7 +39,14 @@ for prev_ver in $(echo "$previous_versions"); do
 
   mkdir "$WORKING_DIR"/"$prev_ver"
 
-  curl -fL https://releases.rancher.com/harvester/"$prev_ver"/image-lists.tar.gz -o "$WORKING_DIR"/image-lists.tar.gz || ret=$?
+  image_lists_url=https://releases.rancher.com/harvester/"$prev_ver"/image-lists.tar.gz
+  # arch-aware image is available after v1.3.0
+  if [ "$(version_compare "$prev_ver" "v1.3.0")"  -eq "1" ]; then
+    image_lists_url=https://releases.rancher.com/harvester/"$prev_ver"/image-lists-"$ARCH".tar.gz
+  fi
+
+  echo "Download image lists tarball from $image_lists_url"
+  curl -fL "$image_lists_url" -o "$WORKING_DIR"/image-lists.tar.gz || ret=$?
   if [ "$ret" -ne 0 ]; then
     echo "Cannot download image list tarball for version $prev_ver, skip it"
     continue

--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -43,7 +43,7 @@ minUpgradableVersion: '${HARVESTER_MIN_UPGRADABLE_VERSION}'
 EOF
 
 # Collect all the previous versions' image lists
-${SCRIPTS_DIR}/archive-images-lists.sh "${TOP_DIR}/../harvester/package/upgrade-matrix.yaml" "${IMAGES_LISTS_DIR}" "${RANCHERD_IMAGES_DIR}" "${BUNDLE_DIR}/harvester/images-lists-archive"
+${SCRIPTS_DIR}/archive-images-lists.sh "${TOP_DIR}/../harvester/package/upgrade-matrix.yaml" "${IMAGES_LISTS_DIR}" "${RANCHERD_IMAGES_DIR}" "${BUNDLE_DIR}/harvester/images-lists-archive" "${ARCH}"
 
 # Collect dependencies' versions
 ${SCRIPTS_DIR}/collect-deps.sh harvester-release.yaml


### PR DESCRIPTION
**Problem:**
The script archive-image-lists.sh lacks architecture awareness and could potentially lead to failures within our CI pipeline, particularly if newer versions (> 1.3.0) have been released.

**Solution:**
Compare the version in `upgrade-matrix.yaml` with v1.3.0, if version >= v1.3.0, which means that version already support different architecture images, and we need to download the image lists tarball from  `https://releases.rancher.com/harvester/{VERSION}/image-lists-{ARCH}.tar.gz`.

**Related Issue:**
https://github.com/harvester/harvester/issues/5313

**Test plan:**
1. Download harvester repo
2. replace [this line](https://github.com/harvester/harvester/blob/master/scripts/build-iso#L12) with `git clone --branch HARV-5313 --single-branch --depth 1 https://github.com/brandboat/harvester-installer.git ../harvester-installer`
3. add below yaml code snippet to [upgrade-matrix.yaml](https://github.com/harvester/harvester/blob/master/package/upgrade-matrix.yaml)
    ```yaml
    - name: v1.3.0
      minUpgradableVersion: v1.2.1
    ```
4. execute `make build-iso` without error

As you can see the console output shows that the script download v1.3.0 image list tarball with a specific architecture amd64, while others still use generic URL without architecture specification.
![image](https://github.com/harvester/harvester-installer/assets/4344302/d53aa7a2-c7d1-49dc-9e09-eecdcfc3fa3c)

