### PR TITLE
Bump golang to v1.21

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,13 +7,14 @@ linters:
     - revive
     - gosec
     - prealloc
-run:
-  skip-files:
+issues:
+  exclude-files:
     - /zz_generated_
     - _generated
-  skip-dirs:
+  exclude-dirs:
     - generated
-  deadline: 5m
+run:
+  timeout: 5m
   tests: true
   build-tags:
     - test

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,6 +1,6 @@
 FROM quay.io/costoolkit/releases-teal:grub2-live-0.0.4-2 as grub2-mbr
 FROM quay.io/costoolkit/releases-teal:grub2-efi-image-live-0.0.4-2 as grub2-efi
-FROM registry.suse.com/bci/golang:1.20
+FROM registry.suse.com/bci/golang:1.21
 
 ARG http_proxy=$http_proxy
 ARG https_proxy=$https_proxy

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -19,7 +19,7 @@ ENV ARCH $DAPPER_HOST_ARCH
 RUN zypper -n rm container-suseconnect && \
     zypper -n install git curl docker gzip tar wget zstd squashfs xorriso awk jq mtools dosfstools unzip rsync patch
 RUN curl -sfL https://github.com/mikefarah/yq/releases/download/v4.21.1/yq_linux_${ARCH} -o /usr/bin/yq && chmod +x /usr/bin/yq
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.55.2
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.57.1
 
 # only needed for raw image generation. currently skipped for arm builds
 RUN if [ "${ARCH}" == "amd64" ]; then \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/harvester/harvester-installer
 
-go 1.20
+go 1.21
 
 require (
 	github.com/harvester/go-common v0.0.0-20230718010724-11313421a8f5

--- a/go.sum
+++ b/go.sum
@@ -127,6 +127,7 @@ github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
 github.com/containerd/stargz-snapshotter/estargz v0.12.1 h1:+7nYmHJb0tEkcRaAW+MHqoKaJYZmkikupxCqVtmPuY0=
+github.com/containerd/stargz-snapshotter/estargz v0.12.1/go.mod h1:12VUuCq3qPq4y8yUW+l5w3+oXV3cx2Po3KSe/SmPGqw=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -298,11 +299,13 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-containerregistry v0.12.2-0.20230106184643-b063f6aeac72 h1:mjNVVKGHs3+xtaGPnTHz4ozBphZNsxsgqFR4+TNwRVM=
 github.com/google/go-containerregistry v0.12.2-0.20230106184643-b063f6aeac72/go.mod h1:J9FQ+eSS4a1aC2GNZxvNpbWhgp0487v+cgiilB4FqDo=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
+github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
 github.com/google/martian/v3 v3.1.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -589,6 +592,7 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/rancher-sandbox/cloud-init v1.14.3-0.20210913085759-bf90bf5eb77e h1:1GSTIPu7CB2UCkS++2/wMygc3S+aa5O0VbTsdDrYupE=
 github.com/rancher-sandbox/cloud-init v1.14.3-0.20210913085759-bf90bf5eb77e/go.mod h1:qbJr82AYxRKlEa4ZSm6qENOmXebBxPXne8BWbtll4cg=
 github.com/rancher/dynamiclistener v0.3.5 h1:5TaIHvkDGmZKvc96Huur16zfTKOiLhDtK4S+WV0JA6A=
+github.com/rancher/dynamiclistener v0.3.5/go.mod h1:dW/YF6/m2+uEyJ5VtEcd9THxda599HP6N9dSXk81+k0=
 github.com/rancher/lasso v0.0.0-20221227210133-6ea88ca2fbcc/go.mod h1:dEfC9eFQigj95lv/JQ8K5e7+qQCacWs1aIA6nLxKzT8=
 github.com/rancher/mapper v0.0.0-20190814232720-058a8b7feb99 h1:rGnt9h1Uk7Yw4qNPyGq0LWHGdPyag/+Fg/wJWSTkKx4=
 github.com/rancher/mapper v0.0.0-20190814232720-058a8b7feb99/go.mod h1:zU4cm21k7ZBFVQhUu2aSH7NwouY317rLYxruOn+wdOQ=
@@ -684,6 +688,7 @@ github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGr
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/vbatts/tar-split v0.11.2 h1:Via6XqJr0hceW4wff3QRzD5gAk/tatMw/4ZA7cTlIME=
+github.com/vbatts/tar-split v0.11.2/go.mod h1:vV3ZuO2yWSVsz+pfFzDG/upWH1JhjOiEaWq6kXyQ3VI=
 github.com/vishvananda/netlink v0.0.0-20170808154308-f5a6f697a596/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
 github.com/vishvananda/netlink v1.1.0 h1:1iyaYNBLmP6L0220aDnYQpo1QEV4t4hJ+xEEhhJH8j0=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
@@ -1010,6 +1015,7 @@ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuX
 golang.org/x/term v0.3.0/go.mod h1:q750SLmJuPmVoN1blW3UFBPREJfb1KmY3vwxfr+nFDA=
 golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
 golang.org/x/term v0.13.0 h1:bb+I9cTfFazGW51MZqBVmZy7+JEJMouUHTUSKVQLBek=
+golang.org/x/term v0.13.0/go.mod h1:LTmsnFJwVN6bCy1rVCoS+qHT1HhALEFxKncY3WNNh4U=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -1287,6 +1293,7 @@ k8s.io/klog/v2 v2.10.0/go.mod h1:hy9LJ/NvuK+iVyP4Ehqva4HxZG/oXyIS3n3Jmire4Ec=
 k8s.io/klog/v2 v2.60.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
 k8s.io/klog/v2 v2.70.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
 k8s.io/klog/v2 v2.80.1 h1:atnLQ121W371wYYFawwYx1aEY2eUfs4l3J72wtgAwV4=
+k8s.io/klog/v2 v2.80.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
 k8s.io/kube-aggregator v0.25.4/go.mod h1:PH65mLSQoUld53w0VkdYcsIGh7wjJGZ5DyfoARronz0=
 k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e/go.mod h1:vHXdDvt9+2spS2Rx9ql3I8tycm3H9FDfdUoIuKCefvw=
 k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42/go.mod h1:Z/45zLw8lUo4wdiUkI+v/ImEGAvu3WatcZl3lPMR4Rk=

--- a/pkg/config/coerce.go
+++ b/pkg/config/coerce.go
@@ -34,7 +34,7 @@ func (t *typeConverter) ToInternal(data map[string]interface{}) error {
 	return t.mappers.ToInternal(data)
 }
 
-func (t *typeConverter) ModifySchema(schema *mapper.Schema, schemas *mapper.Schemas) error {
+func (t *typeConverter) ModifySchema(schema *mapper.Schema, _ *mapper.Schemas) error {
 	for name, field := range schema.ResourceFields {
 		if field.Type == t.fieldType {
 			t.mappers = append(t.mappers, fieldConverter{

--- a/pkg/config/cos_test.go
+++ b/pkg/config/cos_test.go
@@ -40,17 +40,17 @@ func TestCalcCosPersistentPartSize(t *testing.T) {
 		{
 			diskSize:      300,
 			partitionSize: "153600Ki",
-			err:           "Partition size must end with 'Mi' or 'Gi'. Decimals and negatives are not allowed.",
+			err:           "Partition size must end with 'Mi' or 'Gi'. Decimals and negatives are not allowed",
 		},
 		{
 			diskSize:      2000,
 			partitionSize: "1.5Ti",
-			err:           "Partition size must end with 'Mi' or 'Gi'. Decimals and negatives are not allowed.",
+			err:           "Partition size must end with 'Mi' or 'Gi'. Decimals and negatives are not allowed",
 		},
 		{
 			diskSize:      500,
 			partitionSize: "abcd",
-			err:           "Partition size must end with 'Mi' or 'Gi'. Decimals and negatives are not allowed.",
+			err:           "Partition size must end with 'Mi' or 'Gi'. Decimals and negatives are not allowed",
 		},
 	}
 

--- a/pkg/config/rename.go
+++ b/pkg/config/rename.go
@@ -28,7 +28,7 @@ func (f *FuzzyNames) addName(name, toName string) {
 	f.names[strings.ToLower(convert.ToYAMLKey(name))] = toName
 }
 
-func (f *FuzzyNames) ModifySchema(schema *mapper.Schema, schemas *mapper.Schemas) error {
+func (f *FuzzyNames) ModifySchema(schema *mapper.Schema, _ *mapper.Schemas) error {
 	f.names = map[string]string{}
 
 	for name := range schema.ResourceFields {

--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -196,6 +196,6 @@ func setGlobalKeyBindings(g *gocui.Gui) error {
 	return nil
 }
 
-func quit(g *gocui.Gui, v *gocui.View) error {
+func quit(_ *gocui.Gui, _ *gocui.View) error {
 	return gocui.ErrQuit
 }

--- a/pkg/console/dashboard_panels.go
+++ b/pkg/console/dashboard_panels.go
@@ -171,7 +171,7 @@ func logoPanel(g *gocui.Gui) error {
 	return nil
 }
 
-func toShell(g *gocui.Gui, v *gocui.View) error {
+func toShell(g *gocui.Gui, _ *gocui.View) error {
 	g.Cursor = true
 	maxX, _ := g.Size()
 	adminPasswordFrameV := widgets.NewPanel(g, "adminPasswordFrame")
@@ -191,7 +191,7 @@ func toShell(g *gocui.Gui, v *gocui.View) error {
 	validatorV.Focus = false
 
 	adminPasswordV.KeyBindings = map[gocui.Key]func(*gocui.Gui, *gocui.View) error{
-		gocui.KeyEnter: func(g *gocui.Gui, v *gocui.View) error {
+		gocui.KeyEnter: func(_ *gocui.Gui, _ *gocui.View) error {
 			passwd, err := adminPasswordV.GetData()
 			if err != nil {
 				return err
@@ -205,7 +205,7 @@ func toShell(g *gocui.Gui, v *gocui.View) error {
 			validatorV.SetContent("Invalid credential or password hash algorithm not supported.")
 			return nil
 		},
-		gocui.KeyEsc: func(g *gocui.Gui, v *gocui.View) error {
+		gocui.KeyEsc: func(g *gocui.Gui, _ *gocui.View) error {
 			g.Cursor = false
 			if err := adminPasswordFrameV.Close(); err != nil {
 				return err

--- a/pkg/console/helper.go
+++ b/pkg/console/helper.go
@@ -13,7 +13,7 @@ type passwordWrapper struct {
 	passwordConfirmV *widgets.Input
 }
 
-func (p *passwordWrapper) passwordVConfirmKeyBinding(g *gocui.Gui, v *gocui.View) error {
+func (p *passwordWrapper) passwordVConfirmKeyBinding(_ *gocui.Gui, _ *gocui.View) error {
 	password1V, err := p.c.GetElement(passwordPanel)
 	if err != nil {
 		return err
@@ -28,7 +28,7 @@ func (p *passwordWrapper) passwordVConfirmKeyBinding(g *gocui.Gui, v *gocui.View
 	return showNext(p.c, passwordConfirmPanel)
 }
 
-func (p *passwordWrapper) passwordVEscapeKeyBinding(g *gocui.Gui, v *gocui.View) error {
+func (p *passwordWrapper) passwordVEscapeKeyBinding(_ *gocui.Gui, _ *gocui.View) error {
 	p.passwordV.Close()
 	p.passwordConfirmV.Close()
 	if installModeOnly {
@@ -40,7 +40,7 @@ func (p *passwordWrapper) passwordVEscapeKeyBinding(g *gocui.Gui, v *gocui.View)
 	return showNext(p.c, tokenPanel)
 }
 
-func (p *passwordWrapper) passwordConfirmVArrowUpKeyBinding(g *gocui.Gui, v *gocui.View) error {
+func (p *passwordWrapper) passwordConfirmVArrowUpKeyBinding(_ *gocui.Gui, _ *gocui.View) error {
 	var err error
 	userInputData.PasswordConfirm, err = p.passwordConfirmV.GetData()
 	if err != nil {
@@ -49,7 +49,7 @@ func (p *passwordWrapper) passwordConfirmVArrowUpKeyBinding(g *gocui.Gui, v *goc
 	return showNext(p.c, passwordPanel)
 }
 
-func (p *passwordWrapper) passwordConfirmVKeyEnter(g *gocui.Gui, v *gocui.View) error {
+func (p *passwordWrapper) passwordConfirmVKeyEnter(_ *gocui.Gui, _ *gocui.View) error {
 	var err error
 	userInputData.PasswordConfirm, err = p.passwordConfirmV.GetData()
 	if err != nil {
@@ -72,7 +72,7 @@ func (p *passwordWrapper) passwordConfirmVKeyEnter(g *gocui.Gui, v *gocui.View) 
 	return showNext(p.c, ntpServersPanel)
 }
 
-func (p *passwordWrapper) passwordConfirmVKeyEscape(g *gocui.Gui, v *gocui.View) error {
+func (p *passwordWrapper) passwordConfirmVKeyEscape(_ *gocui.Gui, _ *gocui.View) error {
 	p.passwordV.Close()
 	p.passwordConfirmV.Close()
 	if err := p.c.setContentByName(notePanel, ""); err != nil {

--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -74,7 +74,7 @@ func (c *Console) doNetworkSpeedCheck(interfaces []config.NetworkInterface) (war
 	return
 }
 
-func (c *Console) layoutInstall(g *gocui.Gui) error {
+func (c *Console) layoutInstall(_ *gocui.Gui) error {
 	var err error
 	once.Do(func() {
 		setPanels(c)
@@ -475,7 +475,7 @@ func addDiskPanel(c *Console) error {
 			persistentSizePanel,
 		)
 	}
-	gotoPrevPage := func(g *gocui.Gui, v *gocui.View) error {
+	gotoPrevPage := func(_ *gocui.Gui, _ *gocui.View) error {
 		closeThisPage()
 		diskConfirmed = false
 		if c.config.Install.Mode == config.ModeJoin {
@@ -483,7 +483,7 @@ func addDiskPanel(c *Console) error {
 		}
 		return showNext(c, askCreatePanel)
 	}
-	gotoNextPage := func(g *gocui.Gui, v *gocui.View) error {
+	gotoNextPage := func(_ *gocui.Gui, _ *gocui.View) error {
 		// Don't proceed to the next page if disk size validation fails
 		if valid, err := validateAllDiskSizes(); !valid || err != nil {
 			return err
@@ -509,7 +509,7 @@ func addDiskPanel(c *Console) error {
 		return showHostnamePage(c)
 	}
 
-	diskConfirm := func(g *gocui.Gui, v *gocui.View) error {
+	diskConfirm := func(_ *gocui.Gui, _ *gocui.View) error {
 		device, err := diskV.GetData()
 		if err != nil {
 			return err
@@ -548,7 +548,7 @@ func addDiskPanel(c *Console) error {
 	diskV.KeyBindings = map[gocui.Key]func(*gocui.Gui, *gocui.View) error{
 		gocui.KeyEnter:     diskConfirm,
 		gocui.KeyArrowDown: diskConfirm,
-		gocui.KeyArrowUp: func(g *gocui.Gui, v *gocui.View) error {
+		gocui.KeyArrowUp: func(_ *gocui.Gui, _ *gocui.View) error {
 			return updateValidatorMessage("")
 		},
 		gocui.KeyEsc: gotoPrevPage,
@@ -592,7 +592,7 @@ func addDiskPanel(c *Console) error {
 	dataDiskV.KeyBindings = map[gocui.Key]func(*gocui.Gui, *gocui.View) error{
 		gocui.KeyEnter:     dataDiskConfirm,
 		gocui.KeyArrowDown: dataDiskConfirm,
-		gocui.KeyArrowUp: func(g *gocui.Gui, v *gocui.View) error {
+		gocui.KeyArrowUp: func(_ *gocui.Gui, _ *gocui.View) error {
 			if err := updateValidatorMessage(""); err != nil {
 				return err
 			}
@@ -630,7 +630,7 @@ func addDiskPanel(c *Console) error {
 	}
 	persistentSizeV.KeyBindings = map[gocui.Key]func(*gocui.Gui, *gocui.View) error{
 		gocui.KeyEnter: persistentSizeConfirm,
-		gocui.KeyArrowUp: func(g *gocui.Gui, v *gocui.View) error {
+		gocui.KeyArrowUp: func(_ *gocui.Gui, _ *gocui.View) error {
 			diskConfirmed = false
 			if len(diskOpts) > 1 {
 				if err := updateValidatorMessage(""); err != nil {
@@ -673,7 +673,7 @@ func addDiskPanel(c *Console) error {
 	}
 	askForceMBRV.KeyBindings = map[gocui.Key]func(*gocui.Gui, *gocui.View) error{
 		gocui.KeyEnter: mbrConfirm,
-		gocui.KeyArrowUp: func(g *gocui.Gui, v *gocui.View) error {
+		gocui.KeyArrowUp: func(_ *gocui.Gui, _ *gocui.View) error {
 			diskConfirmed = false
 
 			disk, err := diskV.GetData()
@@ -728,7 +728,7 @@ func addPreflightCheckPanel(c *Console) error {
 		return c.setContentByName(titlePanel, "Hardware Checks")
 	}
 	preflightCheckV.KeyBindings = map[gocui.Key]func(*gocui.Gui, *gocui.View) error{
-		gocui.KeyEnter: func(g *gocui.Gui, v *gocui.View) error {
+		gocui.KeyEnter: func(_ *gocui.Gui, _ *gocui.View) error {
 			proceed, err := preflightCheckV.GetData()
 			if err != nil {
 				return err
@@ -799,7 +799,7 @@ func addAskCreatePanel(c *Console) error {
 		return c.setContentByName(titlePanel, "Choose installation mode")
 	}
 	askCreateV.KeyBindings = map[gocui.Key]func(*gocui.Gui, *gocui.View) error{
-		gocui.KeyEnter: func(g *gocui.Gui, v *gocui.View) error {
+		gocui.KeyEnter: func(_ *gocui.Gui, _ *gocui.View) error {
 			selected, err := askCreateV.GetData()
 			if err != nil {
 				return err
@@ -881,7 +881,7 @@ func addAskRolePanel(c *Console) error {
 	if err != nil {
 		return err
 	}
-	gotoPrevPage := func(g *gocui.Gui, v *gocui.View) error {
+	gotoPrevPage := func(_ *gocui.Gui, _ *gocui.View) error {
 		c.CloseElements(askRolePanel)
 		return showNext(c, askCreatePanel)
 	}
@@ -890,7 +890,7 @@ func addAskRolePanel(c *Console) error {
 		return c.setContentByName(titlePanel, "Choose installation role")
 	}
 	askRoleV.KeyBindings = map[gocui.Key]func(*gocui.Gui, *gocui.View) error{
-		gocui.KeyEnter: func(g *gocui.Gui, v *gocui.View) error {
+		gocui.KeyEnter: func(_ *gocui.Gui, _ *gocui.View) error {
 			selected, err := askRoleV.GetData()
 			if err != nil {
 				return err
@@ -922,7 +922,7 @@ func addServerURLPanel(c *Console) error {
 		return c.setContentByName(notePanel, serverURLNote)
 	}
 	serverURLV.KeyBindings = map[gocui.Key]func(*gocui.Gui, *gocui.View) error{
-		gocui.KeyEnter: func(g *gocui.Gui, v *gocui.View) error {
+		gocui.KeyEnter: func(_ *gocui.Gui, _ *gocui.View) error {
 			asyncTaskV, err := c.GetElement(spinnerPanel)
 			if err != nil {
 				return err
@@ -953,21 +953,21 @@ func addServerURLPanel(c *Console) error {
 			go func(g *gocui.Gui) {
 				if err = validatePingServerURL(pingServerURL); err != nil {
 					spinner.Stop(true, err.Error())
-					g.Update(func(g *gocui.Gui) error {
+					g.Update(func(_ *gocui.Gui) error {
 						return showNext(c, serverURLPanel)
 					})
 					return
 				}
 				spinner.Stop(false, "")
 				c.config.ServerURL = fmtServerURL
-				g.Update(func(g *gocui.Gui) error {
+				g.Update(func(_ *gocui.Gui) error {
 					serverURLV.Close()
 					return showNext(c, tokenPanel)
 				})
 			}(c.Gui)
 			return nil
 		},
-		gocui.KeyEsc: func(g *gocui.Gui, v *gocui.View) error {
+		gocui.KeyEsc: func(g *gocui.Gui, _ *gocui.View) error {
 			g.Cursor = false
 			serverURLV.Close()
 			return showNext(c, dnsServersPanel)
@@ -1054,7 +1054,7 @@ func addSSHKeyPanel(c *Console) error {
 		return showNext(c, cloudInitPanel)
 	}
 	sshKeyV.KeyBindings = map[gocui.Key]func(*gocui.Gui, *gocui.View) error{
-		gocui.KeyEnter: func(g *gocui.Gui, v *gocui.View) error {
+		gocui.KeyEnter: func(_ *gocui.Gui, _ *gocui.View) error {
 			url, err := sshKeyV.GetData()
 			if err != nil {
 				return err
@@ -1077,7 +1077,7 @@ func addSSHKeyPanel(c *Console) error {
 					pubKeys, err := getRemoteSSHKeys(url)
 					if err != nil {
 						spinner.Stop(true, err.Error())
-						g.Update(func(g *gocui.Gui) error {
+						g.Update(func(_ *gocui.Gui) error {
 							return showNext(c, sshKeyPanel)
 						})
 						return
@@ -1085,7 +1085,7 @@ func addSSHKeyPanel(c *Console) error {
 					spinner.Stop(false, "")
 					logrus.Debug("SSH public keys: ", pubKeys)
 					c.config.SSHAuthorizedKeys = pubKeys
-					g.Update(func(g *gocui.Gui) error {
+					g.Update(func(_ *gocui.Gui) error {
 						return gotoNextPage()
 					})
 				}(c.Gui)
@@ -1093,7 +1093,7 @@ func addSSHKeyPanel(c *Console) error {
 			}
 			return gotoNextPage()
 		},
-		gocui.KeyEsc: func(g *gocui.Gui, v *gocui.View) error {
+		gocui.KeyEsc: func(_ *gocui.Gui, _ *gocui.View) error {
 			closeThisPage()
 			return showNext(c, proxyPanel)
 		},
@@ -1134,7 +1134,7 @@ func addTokenPanel(c *Console) error {
 		return tokenV.Close()
 	}
 	tokenV.KeyBindings = map[gocui.Key]func(*gocui.Gui, *gocui.View) error{
-		gocui.KeyEnter: func(g *gocui.Gui, v *gocui.View) error {
+		gocui.KeyEnter: func(_ *gocui.Gui, _ *gocui.View) error {
 			token, err := tokenV.GetData()
 			if err != nil {
 				return err
@@ -1149,7 +1149,7 @@ func addTokenPanel(c *Console) error {
 			closeThisPage()
 			return showNext(c, passwordConfirmPanel, passwordPanel)
 		},
-		gocui.KeyEsc: func(g *gocui.Gui, v *gocui.View) error {
+		gocui.KeyEsc: func(g *gocui.Gui, _ *gocui.View) error {
 			closeThisPage()
 			if c.config.Install.Mode == config.ModeCreate {
 				g.Cursor = false
@@ -1204,7 +1204,7 @@ func addHostnamePanel(c *Console) error {
 		return showNetworkPage(c)
 	}
 
-	prev := func(g *gocui.Gui, v *gocui.View) error {
+	prev := func(_ *gocui.Gui, _ *gocui.View) error {
 		c.CloseElements(hostnamePanel, hostnameValidatorPanel)
 		if alreadyInstalled {
 			if c.config.Install.Mode == config.ModeJoin {
@@ -1239,7 +1239,7 @@ func addHostnamePanel(c *Console) error {
 	}
 	hostnameV.KeyBindings = map[gocui.Key]func(*gocui.Gui, *gocui.View) error{
 		gocui.KeyArrowUp: prev,
-		gocui.KeyEnter: func(g *gocui.Gui, v *gocui.View) error {
+		gocui.KeyEnter: func(_ *gocui.Gui, _ *gocui.View) error {
 			message, err := validate()
 			if err != nil {
 				return err
@@ -1328,7 +1328,7 @@ func addNetworkPanel(c *Console) error {
 	}
 
 	gotoNextPanel := func(c *Console, name []string, hooks ...func() (string, error)) func(g *gocui.Gui, v *gocui.View) error {
-		return func(g *gocui.Gui, v *gocui.View) error {
+		return func(_ *gocui.Gui, _ *gocui.View) error {
 			c.CloseElement(networkValidatorPanel)
 			for _, hook := range hooks {
 				msg, err := hook()
@@ -1414,12 +1414,12 @@ func addNetworkPanel(c *Console) error {
 
 				spinner.Stop(isErr, errMsg)
 				// Go back to the panel that triggered gotoNextPage
-				g.Update(func(g *gocui.Gui) error {
+				g.Update(func(_ *gocui.Gui) error {
 					return showNext(c, fromPanel)
 				})
 			} else {
 				spinner.Stop(false, "")
-				g.Update(func(g *gocui.Gui) error {
+				g.Update(func(_ *gocui.Gui) error {
 					closeThisPage()
 					return showNext(c, getNextPagePanel()...)
 				})
@@ -1428,7 +1428,7 @@ func addNetworkPanel(c *Console) error {
 		return nil
 	}
 
-	gotoPrevPage := func(g *gocui.Gui, v *gocui.View) error {
+	gotoPrevPage := func(_ *gocui.Gui, _ *gocui.View) error {
 		closeThisPage()
 		return showHostnamePage(c)
 	}
@@ -1526,7 +1526,7 @@ func addNetworkPanel(c *Console) error {
 		}
 		return nil
 	}
-	askBondModeVConfirm := func(g *gocui.Gui, v *gocui.View) error {
+	askBondModeVConfirm := func(_ *gocui.Gui, _ *gocui.View) error {
 		mode, err := askBondModeV.GetData()
 		mgmtNetwork.BondOptions = map[string]string{
 			"mode":   mode,
@@ -1553,7 +1553,7 @@ func addNetworkPanel(c *Console) error {
 	c.AddElement(askBondModePanel, askBondModeV)
 
 	// askNetworkMethodV
-	askNetworkMethodVConfirm := func(g *gocui.Gui, _ *gocui.View) error {
+	askNetworkMethodVConfirm := func(_ *gocui.Gui, _ *gocui.View) error {
 		selected, err := askNetworkMethodV.GetData()
 		if err != nil {
 			return err
@@ -1677,7 +1677,7 @@ func addNetworkPanel(c *Console) error {
 		mgmtNetwork.MTU = mtu
 		return "", nil
 	}
-	mtuVConfirm := func(g *gocui.Gui, v *gocui.View) error {
+	mtuVConfirm := func(_ *gocui.Gui, _ *gocui.View) error {
 		msg, err := validateMTU()
 		if err != nil {
 			return err
@@ -1789,7 +1789,7 @@ func addProxyPanel(c *Console) error {
 		return c.setContentByName(notePanel, proxyNote)
 	}
 	proxyV.KeyBindings = map[gocui.Key]func(*gocui.Gui, *gocui.View) error{
-		gocui.KeyEnter: func(g *gocui.Gui, v *gocui.View) error {
+		gocui.KeyEnter: func(_ *gocui.Gui, _ *gocui.View) error {
 			proxy, err := proxyV.GetData()
 			if err != nil {
 				return err
@@ -1809,7 +1809,7 @@ func addProxyPanel(c *Console) error {
 			noteV.Close()
 			return showNext(c, sshKeyPanel)
 		},
-		gocui.KeyEsc: func(g *gocui.Gui, v *gocui.View) error {
+		gocui.KeyEsc: func(_ *gocui.Gui, _ *gocui.View) error {
 			proxyV.Close()
 			c.CloseElement(notePanel)
 			return showNext(c, ntpServersPanel)
@@ -1834,7 +1834,7 @@ func addCloudInitPanel(c *Console) error {
 		return showNext(c, confirmInstallPanel)
 	}
 	cloudInitV.KeyBindings = map[gocui.Key]func(*gocui.Gui, *gocui.View) error{
-		gocui.KeyEnter: func(g *gocui.Gui, v *gocui.View) error {
+		gocui.KeyEnter: func(_ *gocui.Gui, _ *gocui.View) error {
 			configURL, err := cloudInitV.GetData()
 			if err != nil {
 				return err
@@ -1854,13 +1854,13 @@ func addCloudInitPanel(c *Console) error {
 				go func(g *gocui.Gui) {
 					if _, err = getRemoteConfig(configURL); err != nil {
 						spinner.Stop(true, err.Error())
-						g.Update(func(g *gocui.Gui) error {
+						g.Update(func(_ *gocui.Gui) error {
 							return showNext(c, cloudInitPanel)
 						})
 						return
 					}
 					spinner.Stop(false, "")
-					g.Update(func(g *gocui.Gui) error {
+					g.Update(func(_ *gocui.Gui) error {
 						return gotoNextPage()
 					})
 				}(c.Gui)
@@ -1868,7 +1868,7 @@ func addCloudInitPanel(c *Console) error {
 			}
 			return gotoNextPage()
 		},
-		gocui.KeyEsc: func(g *gocui.Gui, v *gocui.View) error {
+		gocui.KeyEsc: func(_ *gocui.Gui, _ *gocui.View) error {
 			cloudInitV.Close()
 			return showNext(c, sshKeyPanel)
 		},
@@ -1937,7 +1937,7 @@ func addConfirmInstallPanel(c *Console) error {
 		return c.setContentByName(titlePanel, "Confirm installation options")
 	}
 	confirmV.KeyBindings = map[gocui.Key]func(*gocui.Gui, *gocui.View) error{
-		gocui.KeyEnter: func(g *gocui.Gui, v *gocui.View) error {
+		gocui.KeyEnter: func(_ *gocui.Gui, _ *gocui.View) error {
 			confirmed, err := confirmV.GetData()
 			if err != nil {
 				return err
@@ -1952,7 +1952,7 @@ func addConfirmInstallPanel(c *Console) error {
 			confirmV.Close()
 			return showNext(c, installPanel)
 		},
-		gocui.KeyEsc: func(g *gocui.Gui, v *gocui.View) error {
+		gocui.KeyEsc: func(_ *gocui.Gui, _ *gocui.View) error {
 			confirmV.Close()
 			if installModeOnly {
 				return showNext(c, passwordConfirmPanel, passwordPanel)
@@ -1984,7 +1984,7 @@ func addConfirmUpgradePanel(c *Console) error {
 		return c.setContentByName(titlePanel, fmt.Sprintf("Confirm upgrading Harvester to %s?", version.Version))
 	}
 	confirmV.KeyBindings = map[gocui.Key]func(*gocui.Gui, *gocui.View) error{
-		gocui.KeyEnter: func(g *gocui.Gui, v *gocui.View) error {
+		gocui.KeyEnter: func(_ *gocui.Gui, _ *gocui.View) error {
 			confirmed, err := confirmV.GetData()
 			if err != nil {
 				return err
@@ -1995,7 +1995,7 @@ func addConfirmUpgradePanel(c *Console) error {
 			}
 			return showNext(c, upgradePanel)
 		},
-		gocui.KeyEsc: func(g *gocui.Gui, v *gocui.View) error {
+		gocui.KeyEsc: func(_ *gocui.Gui, _ *gocui.View) error {
 			confirmV.Close()
 			return showNext(c, askCreatePanel)
 		},
@@ -2185,15 +2185,15 @@ func addVIPPanel(c *Console) error {
 			vipTextPanel)
 	}
 
-	gotoPrevPage := func(g *gocui.Gui, v *gocui.View) error {
+	gotoPrevPage := func(_ *gocui.Gui, _ *gocui.View) error {
 		closeThisPage()
 		return showNext(c, dnsServersPanel)
 	}
-	gotoNextPage := func(g *gocui.Gui, v *gocui.View) error {
+	gotoNextPage := func(_ *gocui.Gui, _ *gocui.View) error {
 		closeThisPage()
 		return showNext(c, tokenPanel)
 	}
-	gotoVipPanel := func(g *gocui.Gui, v *gocui.View) error {
+	gotoVipPanel := func(g *gocui.Gui, _ *gocui.View) error {
 		selected, err := askVipMethodV.GetData()
 		if err != nil {
 			return err
@@ -2206,7 +2206,7 @@ func addVIPPanel(c *Console) error {
 				vip, err := getVipThroughDHCP(mgmtName)
 				if err != nil {
 					spinner.Stop(true, err.Error())
-					g.Update(func(g *gocui.Gui) error {
+					g.Update(func(_ *gocui.Gui) error {
 						return showNext(c, askVipMethodPanel)
 					})
 					return
@@ -2215,13 +2215,13 @@ func addVIPPanel(c *Console) error {
 				c.config.Vip = vip.ipv4Addr
 				c.config.VipMode = selected
 				c.config.VipHwAddr = vip.hwAddr
-				g.Update(func(g *gocui.Gui) error {
+				g.Update(func(_ *gocui.Gui) error {
 					return vipV.SetData(vip.ipv4Addr)
 				})
 			}(c.Gui)
 		} else {
 			vipTextV.SetContent("")
-			g.Update(func(gui *gocui.Gui) error {
+			g.Update(func(_ *gocui.Gui) error {
 				return vipV.SetData("")
 			})
 			c.config.VipMode = config.NetworkMethodStatic
@@ -2259,7 +2259,7 @@ func addVIPPanel(c *Console) error {
 
 		return gotoNextPage(g, v)
 	}
-	gotoAskVipMethodPanel := func(g *gocui.Gui, v *gocui.View) error {
+	gotoAskVipMethodPanel := func(_ *gocui.Gui, _ *gocui.View) error {
 		return showNext(c, askVipMethodPanel)
 	}
 	askVipMethodV.KeyBindings = map[gocui.Key]func(*gocui.Gui, *gocui.View) error{
@@ -2314,7 +2314,7 @@ func addNTPServersPanel(c *Console) error {
 		c.CloseElement(notePanel)
 		return ntpServersV.Close()
 	}
-	gotoPrevPage := func(g *gocui.Gui, v *gocui.View) error {
+	gotoPrevPage := func(_ *gocui.Gui, _ *gocui.View) error {
 		userInputData.HasCheckedNTPServers = false
 		closeThisPage()
 		return showNext(c, passwordConfirmPanel, passwordPanel)
@@ -2326,13 +2326,13 @@ func addNTPServersPanel(c *Console) error {
 	}
 	gotoSpinnerErrorPage := func(g *gocui.Gui, spinner *Spinner, msg string) {
 		spinner.Stop(true, msg)
-		g.Update(func(g *gocui.Gui) error {
+		g.Update(func(_ *gocui.Gui) error {
 			return showNext(c, ntpServersPanel)
 		})
 	}
 
 	ntpServersV.KeyBindings = map[gocui.Key]func(*gocui.Gui, *gocui.View) error{
-		gocui.KeyEnter: func(g *gocui.Gui, v *gocui.View) error {
+		gocui.KeyEnter: func(_ *gocui.Gui, _ *gocui.View) error {
 			// get ntp servers input
 			ntpServers, err := ntpServersV.GetData()
 			if err != nil {
@@ -2387,7 +2387,7 @@ func addNTPServersPanel(c *Console) error {
 				}
 
 				spinner.Stop(false, "")
-				g.Update(func(g *gocui.Gui) error {
+				g.Update(func(_ *gocui.Gui) error {
 					return gotoNextPage()
 				})
 			}(c.Gui)
@@ -2429,7 +2429,7 @@ func addDNSServersPanel(c *Console) error {
 		c.CloseElement(notePanel)
 		return dnsServersV.Close()
 	}
-	gotoPrevPage := func(g *gocui.Gui, v *gocui.View) error {
+	gotoPrevPage := func(_ *gocui.Gui, _ *gocui.View) error {
 		closeThisPage()
 		return showNetworkPage(c)
 	}
@@ -2442,13 +2442,13 @@ func addDNSServersPanel(c *Console) error {
 	}
 	gotoSpinnerErrorPage := func(g *gocui.Gui, spinner *Spinner, msg string) {
 		spinner.Stop(true, msg)
-		g.Update(func(g *gocui.Gui) error {
+		g.Update(func(_ *gocui.Gui) error {
 			return showNext(c, dnsServersPanel)
 		})
 	}
 
 	dnsServersV.KeyBindings = map[gocui.Key]func(*gocui.Gui, *gocui.View) error{
-		gocui.KeyEnter: func(g *gocui.Gui, v *gocui.View) error {
+		gocui.KeyEnter: func(_ *gocui.Gui, _ *gocui.View) error {
 			// init asyncTaskV
 			asyncTaskV, err := c.GetElement(spinnerPanel)
 			if err != nil {
@@ -2492,7 +2492,7 @@ func addDNSServersPanel(c *Console) error {
 					c.config.OS.DNSNameservers = dnsServerList
 				}
 				spinner.Stop(false, "")
-				g.Update(func(g *gocui.Gui) error {
+				g.Update(func(_ *gocui.Gui) error {
 					return gotoNextPage()
 				})
 			}(c.Gui)

--- a/pkg/console/util.go
+++ b/pkg/console/util.go
@@ -464,7 +464,7 @@ func roleSetup(c *config.HarvesterConfig) error {
 	case config.RoleDefault:
 		// do not set any label
 	default:
-		return fmt.Errorf("unknown role %s, please correct it!", c.Role)
+		return fmt.Errorf("unknown role %s, please correct it", c.Role)
 	}
 	return nil
 }

--- a/pkg/console/util_test.go
+++ b/pkg/console/util_test.go
@@ -39,7 +39,7 @@ func TestGetSSHKeysFromURL(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				fmt.Fprintln(w, testCase.httpResp)
 			}))
 			defer ts.Close()

--- a/pkg/console/webhooks_test.go
+++ b/pkg/console/webhooks_test.go
@@ -150,7 +150,7 @@ func TestParsedWebhook_Send(t *testing.T) {
 			if tt.fields.TLS {
 				newTestServer = httptest.NewTLSServer
 			}
-			ts := newTestServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ts := newTestServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 				recorder.Method = r.Method
 				recorder.Headers = dupHeaders(r.Header)
 				defer r.Body.Close()

--- a/pkg/preflight/checks.go
+++ b/pkg/preflight/checks.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	// Constants here from Hardware Requirements in the documentaiton
+	// Constants here from Hardware Requirements in the documentation
 	// https://docs.harvesterhci.io/v1.3/install/requirements/#hardware-requirements
 	MinCPUTest         = 8
 	MinCPUProd         = 16
@@ -86,7 +86,7 @@ func (c MemoryCheck) Run() (msg string, err error) {
 	// - A host with 32GiB RAM may report MemTotal 32856636 = 31.11GiB
 	// - A host with 64GiB RAM may report MemTotal 65758888 = 62.71GiB
 	// - A host with 128GiB RAM may report MemTotal 131841120 = 125.73GiB
-	// This means we have to test against a slighly lower number.  Knocking
+	// This means we have to test against a slightly lower number.  Knocking
 	// 5% off is somewhat arbitrary but probably not unreasonable (e.g. for
 	// 32GB we're actually allowing anything over 30.4GB, and for 64GB we're
 	// allowing anything over 60.8GB).
@@ -151,7 +151,7 @@ func (c NetworkSpeedCheck) Run() (msg string, err error) {
 		return
 	}
 	// We need floats because 2.5Gbps ethernet is a thing.
-	var speedGbps float32 = float32(speedMbps) / 1000
+	var speedGbps = float32(speedMbps) / 1000
 	if speedGbps < MinNetworkGbpsTest {
 		// Does anyone even _have_ < 1Gbps networking kit anymore?
 		// Still, it's theoretically possible someone could have messed

--- a/pkg/preflight/checks_test.go
+++ b/pkg/preflight/checks_test.go
@@ -45,7 +45,7 @@ func fakeExecCommand(command string) *exec.Cmd {
 // may emit junk to STDERR, so this mocking technique only really
 // works for mocking return codes and content on STDOUT.  Still,
 // that's OK for our purposes here.
-func TestHelperProcess(t *testing.T) {
+func TestHelperProcess(_ *testing.T) {
 	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
 		return
 	}
@@ -65,10 +65,10 @@ func TestHelperProcess(t *testing.T) {
 	output, ok := execOutputs[args[0]]
 	if !ok {
 		os.Exit(1)
-	} else {
-		fmt.Print(output.output)
-		os.Exit(output.rc)
 	}
+
+	fmt.Print(output.output)
+	os.Exit(output.rc)
 }
 
 func TestCPUCheck(t *testing.T) {
@@ -82,7 +82,7 @@ func TestCPUCheck(t *testing.T) {
 
 	check := CPUCheck{}
 	for key, expectedOutput := range expectedOutputs {
-		execCommand = func(command string, args ...string) *exec.Cmd {
+		execCommand = func(_ string, _ ...string) *exec.Cmd {
 			return fakeExecCommand(key)
 		}
 		msg, err := check.Run()
@@ -101,7 +101,7 @@ func TestVirtCheck(t *testing.T) {
 
 	check := VirtCheck{}
 	for key, expectedOutput := range expectedOutputs {
-		execCommand = func(command string, args ...string) *exec.Cmd {
+		execCommand = func(_ string, _ ...string) *exec.Cmd {
 			return fakeExecCommand(key)
 		}
 		msg, err := check.Run()

--- a/pkg/util/disk.go
+++ b/pkg/util/disk.go
@@ -22,7 +22,7 @@ func ParsePartitionSize(diskSizeBytes uint64, partitionSize string) (uint64, err
 	actualDiskSizeBytes := diskSizeBytes - fixedOccupiedSize
 
 	if !sizeRegexp.MatchString(partitionSize) {
-		return 0, fmt.Errorf("Partition size must end with 'Mi' or 'Gi'. Decimals and negatives are not allowed.")
+		return 0, fmt.Errorf("Partition size must end with 'Mi' or 'Gi'. Decimals and negatives are not allowed")
 	}
 
 	size, err := strconv.ParseUint(partitionSize[:len(partitionSize)-2], 10, 64)

--- a/pkg/util/disk_test.go
+++ b/pkg/util/disk_test.go
@@ -51,22 +51,22 @@ func TestParsePartitionSize(t *testing.T) {
 		{
 			diskSize:      2000 * GiByteMultiplier,
 			partitionSize: "abcd",
-			err:           "Partition size must end with 'Mi' or 'Gi'. Decimals and negatives are not allowed.",
+			err:           "Partition size must end with 'Mi' or 'Gi'. Decimals and negatives are not allowed",
 		},
 		{
 			diskSize:      2000 * GiByteMultiplier,
 			partitionSize: "1Ti",
-			err:           "Partition size must end with 'Mi' or 'Gi'. Decimals and negatives are not allowed.",
+			err:           "Partition size must end with 'Mi' or 'Gi'. Decimals and negatives are not allowed",
 		},
 		{
 			diskSize:      2000 * GiByteMultiplier,
 			partitionSize: "50Ki",
-			err:           "Partition size must end with 'Mi' or 'Gi'. Decimals and negatives are not allowed.",
+			err:           "Partition size must end with 'Mi' or 'Gi'. Decimals and negatives are not allowed",
 		},
 		{
 			diskSize:      2000 * GiByteMultiplier,
 			partitionSize: "5.5",
-			err:           "Partition size must end with 'Mi' or 'Gi'. Decimals and negatives are not allowed.",
+			err:           "Partition size must end with 'Mi' or 'Gi'. Decimals and negatives are not allowed",
 		},
 		{
 			diskSize:      400 * GiByteMultiplier,

--- a/pkg/widgets/dropdown.go
+++ b/pkg/widgets/dropdown.go
@@ -88,7 +88,7 @@ func (d *DropDown) Show() error {
 				d.Text = d.Select.options[0].Text
 			}
 		}
-		err = d.g.SetKeybinding(d.ViewName, gocui.KeyTab, gocui.ModNone, func(g *gocui.Gui, v *gocui.View) error {
+		err = d.g.SetKeybinding(d.ViewName, gocui.KeyTab, gocui.ModNone, func(_ *gocui.Gui, _ *gocui.View) error {
 			d.Select.Value = d.Value
 			d.Select.Panel.SetLocation(x0, y0, x1, y0+1)
 			return d.Select.Show()
@@ -122,7 +122,7 @@ func (d *DropDown) Show() error {
 			}
 			return d.KeyBindings[gocui.KeyEnter](g, v)
 		}
-		d.Select.KeyBindings[gocui.KeyEsc] = func(g *gocui.Gui, v *gocui.View) error {
+		d.Select.KeyBindings[gocui.KeyEsc] = func(_ *gocui.Gui, _ *gocui.View) error {
 			if err = d.Select.Close(); err != nil {
 				return err
 			}

--- a/pkg/widgets/panel.go
+++ b/pkg/widgets/panel.go
@@ -159,7 +159,7 @@ func (p *Panel) SetContent(content string) {
 		// Just in case we somehow get here without valid dimensions
 		p.Content = content
 	}
-	p.g.Update(func(g *gocui.Gui) error {
+	p.g.Update(func(_ *gocui.Gui) error {
 		v, err := p.g.View(p.Name)
 		if err != nil {
 			if err != gocui.ErrUnknownView {

--- a/pkg/widgets/select.go
+++ b/pkg/widgets/select.go
@@ -201,7 +201,7 @@ func (s *Select) updateSelectedStatus(v *gocui.View) error {
 func (s *Select) setOptionsKeyBindings(viewName string) error {
 	setOptionsKeyBindings(s.g, viewName)
 	if s.multi {
-		handler := func(g *gocui.Gui, v *gocui.View) error {
+		handler := func(_ *gocui.Gui, v *gocui.View) error {
 			_, cy := v.Cursor()
 			if len(s.options) >= cy+1 {
 				s.selectedIndexes[cy] = !s.selectedIndexes[cy]

--- a/pkg/widgets/util.go
+++ b/pkg/widgets/util.go
@@ -4,7 +4,7 @@ import (
 	"github.com/jroimartin/gocui"
 )
 
-func ArrowUp(g *gocui.Gui, v *gocui.View) error {
+func ArrowUp(_ *gocui.Gui, v *gocui.View) error {
 	if v == nil || isAtTop(v) {
 		return nil
 	}
@@ -19,7 +19,7 @@ func ArrowUp(g *gocui.Gui, v *gocui.View) error {
 	return nil
 }
 
-func ArrowDown(g *gocui.Gui, v *gocui.View) error {
+func ArrowDown(_ *gocui.Gui, v *gocui.View) error {
 	if v == nil || isAtEnd(v) {
 		return nil
 	}


### PR DESCRIPTION
**Problem:**
Go v1.20 is EOL on 06 Feb 2024.

**Solution:**
Bump golang to v1.21.

**Related Issue:**
https://github.com/harvester/harvester/issues/5310
