### PR TITLE
fix: CATTLE_FLEET_MIN_VERSION or CATTLE_RANCHER_WEBHOOK_MIN_VERSION may be empty

### DIFF
--- a/scripts/collect-deps.sh
+++ b/scripts/collect-deps.sh
@@ -72,9 +72,9 @@ update_rancher_deps()
   docker rm $(<$cid_file)
 
   # Get the latest version >= min_version and update it to yaml file
-  update_chart_app_versions $repo_index fleet $CATTLE_FLEET_MIN_VERSION $output_file
-  update_chart_app_versions $repo_index fleet-crd $CATTLE_FLEET_MIN_VERSION $output_file
-  update_chart_app_versions $repo_index rancher-webhook $CATTLE_RANCHER_WEBHOOK_MIN_VERSION $output_file
+  update_chart_app_versions $repo_index fleet "$CATTLE_FLEET_MIN_VERSION" $output_file
+  update_chart_app_versions $repo_index fleet-crd "$CATTLE_FLEET_MIN_VERSION" $output_file
+  update_chart_app_versions $repo_index rancher-webhook "$CATTLE_RANCHER_WEBHOOK_MIN_VERSION" $output_file
 }
 
 


### PR DESCRIPTION
**Problem:**
In some Rancher version like `v2.8.3-rc6`, these environment variables may be empty, so `min_version` in `update_chart_app_versions` will get input for `output_file`.

**Solution:**
Make sure `min_version` can get value from `CATTLE_FLEET_MIN_VERSION` or `CATTLE_RANCHER_WEBHOOK_MIN_VERSION`.

**Related Issue:**
https://github.com/harvester/harvester/issues/4657

**Test plan:**
CI should pass without error.

