### PR TITLE
chore: bump harvester-seeder to v0.1.2

### DIFF
--- a/pkg/config/templates/rancherd-22-addons.yaml
+++ b/pkg/config/templates/rancherd-22-addons.yaml
@@ -212,7 +212,7 @@ resources:
       {{- end }}
       valuesContent: |
         image:
-          tag: v0.1.1
+          tag: v0.1.2
         fullnameOverride: harvester-seeder
   - apiVersion: harvesterhci.io/v1beta1
     kind: Addon

--- a/scripts/build-bundle
+++ b/scripts/build-bundle
@@ -29,7 +29,7 @@ VM_IMPORT_CONTROLLER_IMAGE="rancher/harvester-vm-import-controller:v0.1.7"
 PCIDEVICES_CONTROLLER_CHART_VERSION="0.3.2"
 PCIDEVICES_CONTROLLER_IMAGE="rancher/harvester-pcidevices:v0.3.2"
 HARVESTER_SEEDER_CHART_VERSION="0.1.1"
-HARVESTER_SEEDER_IMAGE="rancher/harvester-seeder:v0.1.1"
+HARVESTER_SEEDER_IMAGE="rancher/harvester-seeder:v0.1.2"
 NVIDIA_DRIVER_RUNTIME_CHART_VERSION="0.1.1"
 mkdir -p ${CHARTS_DIR}
 mkdir -p ${IMAGES_DIR}


### PR DESCRIPTION
This PR bumps the harvester-seeder image tag from v0.1.2; the chart is untouched.