### PR TITLE
fix: Harvester management chart is modified

### DIFF
--- a/pkg/config/templates/rancherd-10-harvester.yaml
+++ b/pkg/config/templates/rancherd-10-harvester.yaml
@@ -104,6 +104,34 @@ resources:
         - /status/storedVersions
         kind: CustomResourceDefinition
         name: volumes.longhorn.io
+      - apiVersion: apiextensions.k8s.io/v1
+        jsonPointers:
+        - /status/acceptedNames
+        - /status/conditions
+        - /status/storedVersions
+        kind: CustomResourceDefinition
+        name: settings.longhorn.io
+      - apiVersion: apiextensions.k8s.io/v1
+        jsonPointers:
+        - /status/acceptedNames
+        - /status/conditions
+        - /status/storedVersions
+        kind: CustomResourceDefinition
+        name: replicas.longhorn.io
+      - apiVersion: apiextensions.k8s.io/v1
+        jsonPointers:
+        - /status/acceptedNames
+        - /status/conditions
+        - /status/storedVersions
+        kind: CustomResourceDefinition
+        name: instancemanagers.longhorn.io
+      - apiVersion: apiextensions.k8s.io/v1
+        jsonPointers:
+        - /status/acceptedNames
+        - /status/conditions
+        - /status/storedVersions
+        kind: CustomResourceDefinition
+        name: engines.longhorn.io
     repoName: harvester-charts
     targets:
     - clusterName: local


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Harvester ManagedChart is in modified status.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Ignore the status fields on some Longhorn CRDs.

**Related Issue:**

https://github.com/harvester/harvester/issues/5566

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

- Create a new cluster.
- Run `kubectl get bundles -n fleet-local mcc-harvester`, the `BUNDLEDEPLOYMENTS-READY` should be `1/1` and `STATUS` should be empty. For example:

    ```
    NAME            BUNDLEDEPLOYMENTS-READY   STATUS
    mcc-harvester   1/1
    ```
