### PR TITLE
Add installation configure of LH GuaranteedInstanceManagerCPU

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -110,6 +110,9 @@ type LHDefaultSettings struct {
 	// 0 is valid, means not setting CPU resources, use pointer to check if it is set
 	GuaranteedEngineManagerCPU  *uint32 `json:"guaranteedEngineManagerCPU,omitempty"`
 	GuaranteedReplicaManagerCPU *uint32 `json:"guaranteedReplicaManagerCPU,omitempty"`
+	// from Longhorn v1.5.0, LH merges the above two into one
+	// the above two are not used afterwards, but Harvester keeps them for compatibility
+	GuaranteedInstanceManagerCPU *uint32 `json:"guaranteedInstanceManagerCPU,omitempty"`
 }
 
 type LonghornChartValues struct {

--- a/pkg/config/cos.go
+++ b/pkg/config/cos.go
@@ -30,11 +30,12 @@ const (
 	ifcfgGlobPattern       = networkConfigDirectory + "ifcfg-*"
 	ifrouteGlobPattern     = networkConfigDirectory + "ifroute-*"
 
-	bootstrapConfigCount               = 6
-	defaultReplicaCount                = 3
-	defaultGuaranteedEngineManagerCPU  = 12   // means percentage 12%
-	defaultGuaranteedReplicaManagerCPU = 12   // means percentage 12%
-	defaultSystemImageSize             = 3072 // size of /run/initramfs/cos-state/cOS/active.img in MB
+	bootstrapConfigCount                = 6
+	defaultReplicaCount                 = 3
+	defaultGuaranteedEngineManagerCPU   = 12   // means percentage 12%
+	defaultGuaranteedReplicaManagerCPU  = 12   // means percentage 12%
+	defaultGuaranteedInstanceManagerCPU = 12   // means percentage 12%
+	defaultSystemImageSize              = 3072 // size of /run/initramfs/cos-state/cOS/active.img in MB
 )
 
 var (
@@ -279,6 +280,10 @@ func setConfigDefaultValues(config *HarvesterConfig) {
 
 	if config.Harvester.Longhorn.DefaultSettings.GuaranteedReplicaManagerCPU != nil && *config.Harvester.Longhorn.DefaultSettings.GuaranteedReplicaManagerCPU > defaultGuaranteedReplicaManagerCPU {
 		*config.Harvester.Longhorn.DefaultSettings.GuaranteedReplicaManagerCPU = defaultGuaranteedReplicaManagerCPU
+	}
+
+	if config.Harvester.Longhorn.DefaultSettings.GuaranteedInstanceManagerCPU != nil && *config.Harvester.Longhorn.DefaultSettings.GuaranteedInstanceManagerCPU > defaultGuaranteedInstanceManagerCPU {
+		*config.Harvester.Longhorn.DefaultSettings.GuaranteedInstanceManagerCPU = defaultGuaranteedInstanceManagerCPU
 	}
 }
 

--- a/pkg/config/templates/rancherd-10-harvester.yaml
+++ b/pkg/config/templates/rancherd-10-harvester.yaml
@@ -143,11 +143,8 @@ resources:
         defaultSettings:
           taintToleration: "kubevirt.io/drain:NoSchedule"
           defaultDataPath: "/var/lib/harvester/defaultdisk"
-          {{- if .Harvester.Longhorn.DefaultSettings.GuaranteedEngineManagerCPU }}
-          guaranteedEngineManagerCPU: {{ .Harvester.Longhorn.DefaultSettings.GuaranteedEngineManagerCPU }}
-          {{- end }}
-          {{- if .Harvester.Longhorn.DefaultSettings.GuaranteedReplicaManagerCPU }}
-          guaranteedReplicaManagerCPU: {{ .Harvester.Longhorn.DefaultSettings.GuaranteedReplicaManagerCPU }}
+          {{- if .Harvester.Longhorn.DefaultSettings.GuaranteedInstanceManagerCPU }}
+          guaranteedInstanceManagerCPU: {{ .Harvester.Longhorn.DefaultSettings.GuaranteedInstanceManagerCPU }}
           {{- end }}
       harvester-network-controller:
         enabled: true


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Per https://github.com/harvester/harvester/issues/5568

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Update source code and document

**Related Issue:**
https://github.com/harvester/harvester/issues/5568

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

Create new cluster, use a harvester-configuration file (step 13 of https://docs.harvesterhci.io/v1.2/install/index) with below items, after installation, check the embedded LH, the related setting is as expected.

https://longhorn.io/docs/1.5.3/references/settings/#guaranteed-instance-manager-cpu 

```
install:
  harvester:
    longhorn:
      default_settings:
        guaranteedInstanceManagerCPU: 6
```
(valid values are in range [0..12], all other values are converted to 12)


LH chart:
```
chart/templates/default-setting.yaml:    {{- if not (kindIs "invalid" .Values.defaultSettings.guaranteedInstanceManagerCPU) }}
chart/templates/default-setting.yaml:    guaranteed-instance-manager-cpu: {{ .Values.defaultSettings.guaranteedInstanceManagerCPU }}
chart/README.md:| defaultSettings.guaranteedInstanceManagerCPU | Percentage of the total allocatable CPU resources on each node to be reserved for each instance manager pod when the V1 Data Engine is enabled. The default value is "12". |

```

** local test **

An expected value 3 of guaranteed-instance-manager-cpu is correctly set to LH via installation configure file.

config file
```
$ cat harvester-cfg-3.yaml 
scheme_version: 1
install:
  mode: create
  harvester:
    storageClass:
      replicaCount: 1
    longhorn:
      defaultSettings:
        guaranteedReplicaManagerCPU: 4
        guaranteedInstanceManagerCPU: 3
```

harvester saved config:
```
$ cat /oem/harvester.config 
schemeversion: 1
serverurl: ""
token: rancher
os:
...
    device: /dev/sda
    configurl: http://192.168.122.159:8000/harvester-cfg-3.yaml
...
    webhooks: []
    addons: {}
    harvester:
        storageclass:
            replicacount: 1
        longhorn:
            defaultsettings:
                guaranteedenginemanagercpu: null
                guaranteedreplicamanagercpu: 4
                guaranteedinstancemanagercpu: 3
        enablegocoverdir: false
    rawdiskimagepath: ""
    persistentpartitionsize: 150Gi
```

LH settings:

```
$ kubectl get settings.longhorn.io -A | grep gua

longhorn-system   guaranteed-instance-manager-cpu                                   3                                             35s  // target value

```
