### PR TITLE
harv-install: deactivate LVM in spite of global_filter

### DIFF
--- a/package/harvester-os/files/usr/sbin/harv-install
+++ b/package/harvester-os/files/usr/sbin/harv-install
@@ -495,6 +495,26 @@ trap cleanup exit
 
 check_iso
 
+# When `lvm` is run (which happens inside `blkdeactivate` in our case),
+# it will complain of leaked file descriptors for /dev/tty1 (the console)
+# and a socket.  This is harmless, it just means those FDs weren't closed
+# by `harvester-installer` before invoking this script (they don't have
+# the FD_CLOEXEC flag set), so let's suppress these warnings to avoid
+# making a mess of the console output.
+export LVM_SUPPRESS_FD_WARNINGS=1
+
+# https://github.com/harvester/os2/pull/86 adds a global_filter to
+# /etc/lvm/lvm.conf to avoid activing LVM on the host.  Unfortunately,
+# dracut-initqueue runs _very_ early in the boot process (before any of
+# the elemental stages are run), so this filter isn't taken into account
+# on boot, and LVM volumes are still potentially activated.  Later, when
+# we try to run `blkdeactivate` here, it doesn't work, because the filter
+# _is_ active then, so it skips deactivation and then the subsequent
+# disk repartitioning fails.  We can work around this here by setting up
+# a temporary lvm config which has that global_filter stripped out.
+export LVM_SYSTEM_DIR=$(mktemp -d)
+lvmconfig | sed /global_filter/d > ${LVM_SYSTEM_DIR}/lvm.conf
+
 # Tear down LVM and MD devices on the system, if the installing device is occuipied, the
 # partitioning operation could fail later. Be forgiven here.
 blkdeactivate --lvmoptions wholevg,retry --dmoptions force,retry --errors || true


### PR DESCRIPTION
**Problem:**

https://github.com/harvester/os2/pull/86 adds a global_filter to /etc/lvm/lvm.conf to avoid activing LVM on the host.  Unfortunately, dracut-initqueue runs _very_ early in the boot process (before any of the elemental stages are run), so this filter isn't taken into account on boot, and LVM volumes are still potentially activated.  Later, when we try to run `blkdeactivate` in `harv-install`, it doesn't work, because the filter _is_ active then, so it skips deactivation and then the subsequent disk repartitioning fails.

**Solution:**

We can work around this by setting up a temporary lvm config which has that global_filter stripped out.

**Related Issue:**

https://github.com/harvester/harvester/issues/5398

**Test plan:**

Note: this requires real hardware (I couldn't reproduce the problem running the installer in a VM):

1. Create LVM volumes on the disk you plan to install on. There's several ways to do this, including:
   - Boot the installer, then switch to the second console, use `pvcreate`, `vgcreate` and `lvcreate` to create a volume or volumes on the disk you plan to install on.
   - Install a Linux distro (whichever you like), ensuring that LVM is set up during the partitioning step.
2. Boot the 1.3.0 ISO and try to install. Verify that installation fails as described in the related issue.
3. Boot the ISO with this fix, and verify that installation succeeds, or at least that the LVM volumes are deactivated and the disk is successfully repartitioned (once we get past that point, we know we're good - we don't need to wait for the entire installation to complete).

