### PR TITLE
Add ability to set hostname via DHCPv4 client

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -183,6 +183,7 @@ type OS struct {
 	SSHAuthorizedKeys          []string `json:"sshAuthorizedKeys,omitempty"`
 	WriteFiles                 []File   `json:"writeFiles,omitempty"`
 	Hostname                   string   `json:"hostname,omitempty"`
+	DhclientSetHostname        bool     `json:"dhclientSetHostname,omitempty"`
 
 	Modules        []string          `json:"modules,omitempty"`
 	Sysctls        map[string]string `json:"sysctls,omitempty"`

--- a/pkg/config/cos.go
+++ b/pkg/config/cos.go
@@ -185,6 +185,7 @@ func ConvertToCOS(config *HarvesterConfig) (*yipSchema.YipConfig, error) {
 		if len(cfg.OS.DNSNameservers) > 0 {
 			initramfs.Commands = append(initramfs.Commands, getAddStaticDNSServersCmd(cfg.OS.DNSNameservers))
 		}
+		initramfs.Commands = append(initramfs.Commands, getDhclientSetHostnameCmd(cfg.OS.DhclientSetHostname))
 
 		if err := UpdateWifiConfig(&initramfs, cfg.OS.Wifi, false); err != nil {
 			return nil, err
@@ -711,6 +712,14 @@ func UpdateWifiConfig(stage *yipSchema.Stage, wifis []Wifi, run bool) error {
 
 func getAddStaticDNSServersCmd(servers []string) string {
 	return fmt.Sprintf(`sed -i 's/^NETCONFIG_DNS_STATIC_SERVERS.*/NETCONFIG_DNS_STATIC_SERVERS="%s"/' /etc/sysconfig/network/config`, strings.Join(servers, " "))
+}
+
+func getDhclientSetHostnameCmd(dhclientSetHostname bool) string {
+	yesOrNo := "no"
+	if dhclientSetHostname {
+		yesOrNo = "yes"
+	}
+	return fmt.Sprintf(`sed -i 's/^DHCLIENT_SET_HOSTNAME=.*/DHCLIENT_SET_HOSTNAME="%s"/' /etc/sysconfig/network/dhcp`, yesOrNo)
 }
 
 func (c *HarvesterConfig) ToCosInstallEnv() ([]string, error) {

--- a/pkg/console/constant.go
+++ b/pkg/console/constant.go
@@ -26,6 +26,7 @@ const (
 	bondNotePanel               = "bondNote"
 	askNetworkMethodPanel       = "askNetworkMethod"
 	hostnamePanel               = "hostname"
+	askDhclientSetHostnamePanel = "askDhclientSetHostnamePanel"
 	addressPanel                = "address"
 	gatewayPanel                = "gateway"
 	mtuPanel                    = "mtu"


### PR DESCRIPTION
**Problem:**
We need to provide the option of allowing system hostnames to be set via DHCP.

**Solution:**
This adds a boolean config option, os.dhclient_set_hostname, which maps to DHCLIENT_SET_HOSTNAME in /etc/sysconfig/network/dhcp.

When running the installer interactively, there's a new "Set via DHCP" drop down field on the hostname page.  The default is "no".

![image](https://github.com/harvester/harvester-installer/assets/754700/bd41f688-774a-4865-80cb-aff1d9c7a2b6)

If the user selects "yes", this will later be shown on the confirmation screen as "hostname: XXXX (will be set via DHCP)", to indicate that the provided hostname will be overridden by DHCP:

![image](https://github.com/harvester/harvester-installer/assets/754700/f7293a03-f3d0-41b1-8264-3eb7caf4ec10)

For automated installs, either set `os.dhclient_set_hostname: true` in the config yaml, or pass `harvester.os.dhclient_set_hostname=true` as a kernel command line argument.

In order for this setting to take effect, your DHCP server needs to be configured to send the host name option to the client.  For more information see `man dhcpd.conf` (look for "option host-name" and "use-host-decl-names on").

Note that even if os.dhclient_set_hostname is set to true, we still require the user to provide a hostname during installation, because that will be written to /etc/hostname and be used by the system briefly early in the boot process, before DHCP does its thing.

**Related Issue:**
https://github.com/harvester/harvester/issues/1444

**Test plan:**
- Configure a DHCP server to set the host name option (TBD: add more details here, possibly including tweaks to ipxe-examples)
- Boot the installer, but leave "Set via DHCP" set to "no"
- Verify that whatever hostname the DHCP server wants to set, doesn't get set.
- Repeat the above, but set "Set via DHCP" to "yes"
- Verify that whatever hostname the DHCP server wants to set, does get set, both during installation (after network config is applied), and then subsequently once the system comes up for real.
