### PR TITLE
feat: Show DNS Servers on Confirm Install Panel

### DIFF
--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -1910,6 +1910,9 @@ func addConfirmInstallPanel(c *Console) error {
 			options += fmt.Sprintf("install role: %v\n", c.config.Install.Role)
 		}
 		options += fmt.Sprintf("hostname: %v\n", c.config.OS.Hostname)
+		if userInputData.DNSServers != "" {
+			options += fmt.Sprintf("dns servers: %v\n", userInputData.DNSServers)
+		}
 		if userInputData.NTPServers != "" {
 			options += fmt.Sprintf("ntp servers: %v\n", userInputData.NTPServers)
 		}


### PR DESCRIPTION
* if the user inputs DNS servers during the interactive ISO install they are then going to be shown during the confirm install panel

Resolves: feat/confirm-install-panel-show-dns-servers
See also: https://github.com/harvester/harvester/issues/5696

**Problem:**
Show the DNS Servers the user input from the interactive iso install on the confirm installation panel

**Solution:**
When the User is inputing DNS servers in the field seperated by comma on the interactive ISO install, currently, the user "cannot" see those input DNS servers on the final step of the interactive ISO install on the confirm installation panel.  This allows the user to see those DNS servers they input.  If the user did not input anything in the DNS Server section, the DNS servers will not be shown.

**Related Issue:**
https://github.com/harvester/harvester/issues/5696

**Test plan:**
Path A:
- User inputs DNS server entries in interactive ISO install and sees them on the final confirm installation panel

Path B:
- User leaves the DNS server field blank, during interactive ISO installation, the user then will not see any `dns servers: A.B.C.D,E.F.G.H` etc. on the final confirm installtion panel, as it will be left blank entirely

### Cross Ref Photos:
![Screenshot from 2024-04-26 14-15-35](https://github.com/harvester/harvester-installer/assets/5370752/f829728d-b933-44fd-a87d-eaf62722405d)
![Screenshot from 2024-04-26 14-16-14](https://github.com/harvester/harvester-installer/assets/5370752/00ccd390-b78b-407f-9e11-9f2f2f2facb2)
![Screenshot from 2024-04-26 14-14-27](https://github.com/harvester/harvester-installer/assets/5370752/b9bb6815-ce46-4016-8953-96bc15115f80)

