### PR TITLE
fix: merge kernel parameters into global config

### DIFF
--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -79,9 +79,9 @@ func (c *Console) layoutInstall(g *gocui.Gui) error {
 		}
 
 		if cfg, err := config.ReadConfig(); err == nil {
+			c.config.Merge(cfg)
 			if cfg.Install.Automatic && isFirstConsoleTTY() {
 				logrus.Info("Start automatic installation...")
-				c.config.Merge(cfg)
 				// setup InstallMode to ensure that during automatic install
 				// we are only copying binaries and ignoring network / rancherd setup
 				// needed for generating pre-installed qcow2 image


### PR DESCRIPTION
Signed-off-by: Kiefer Chang <kiefer.chang@suse.com>
(cherry picked from commit 8593ff8daf3d6729bf170a23fd10198f262b0d7d)

**Problem:**

The configs specified in the kernel parameters should be merged into installer config for the wipe disk feature to work.

**Related Issue:**

https://github.com/harvester/harvester/issues/5174

