### PR TITLE
Add ability to set hostname via DHCP during install

### DIFF
--- a/pkg/console/constant.go
+++ b/pkg/console/constant.go
@@ -83,4 +83,6 @@ const (
 	persistentSizeNote     = "Note: persistent partition stores data like system package and container images, not the VM data. \nYou can specify a size like 200Gi or 153600Mi. \nLeave it blank to use the default value."
 
 	authorizedFile = "/home/rancher/.ssh/authorized_keys"
+
+	defaultHostname = "rancher"
 )

--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -2054,8 +2054,8 @@ func addInstallPanel(c *Console) error {
 
 				if c.config.Install.ManagementInterface.Method == config.NetworkMethodDHCP {
 					printToPanel(c.Gui, "Configuring network...", installPanel)
-					if _, err := applyNetworks(c.config.ManagementInterface, c.config.Hostname); err != nil {
-						printToPanel(c.Gui, fmt.Sprintf("can't apply networks: %s", err), installPanel)
+					if output, err := applyNetworks(c.config.ManagementInterface, c.config.Hostname); err != nil {
+						printToPanel(c.Gui, fmt.Sprintf("Can't apply networks: %s\n%s", err, string(output)), installPanel)
 						return
 					}
 				}

--- a/pkg/console/network.go
+++ b/pkg/console/network.go
@@ -24,6 +24,29 @@ func applyNetworks(network config.Network, hostname string) ([]byte, error) {
 		return nil, err
 	}
 
+	// If called without a hostname set, we enable setting hostname via the
+	// DHCP server, in case the DHCP server is configured to give us a
+	// hostname we can use by default.
+	//
+	// If we move the network interface page of the installer so it's before
+	// the hostname page, this function will activate once the management
+	// NIC is configured, and if the DHCP server is configured correctly,
+	// the system hostname will be set to the one provided by the server.
+	// Later, on the hostname page, we can default the hostname field to
+	// the current system hostname.
+
+	dhclientSetHostname := "no"
+	if hostname == "" {
+		dhclientSetHostname = "yes"
+	}
+	output, err := exec.Command("sed", "-i",
+		fmt.Sprintf(`s/^DHCLIENT_SET_HOSTNAME=.*/DHCLIENT_SET_HOSTNAME="%s"/`, dhclientSetHostname),
+		"/etc/sysconfig/network/dhcp").CombinedOutput()
+	if err != nil {
+		logrus.Error(err, string(output))
+		return nil, err
+	}
+
 	conf := &yipSchema.YipConfig{
 		Name: "Network Configuration",
 		Stages: map[string][]yipSchema.Stage{
@@ -33,7 +56,7 @@ func applyNetworks(network config.Network, hostname string) ([]byte, error) {
 			},
 		},
 	}
-	_, err := config.UpdateManagementInterfaceConfig(&conf.Stages["live"][1], network, true)
+	_, err = config.UpdateManagementInterfaceConfig(&conf.Stages["live"][1], network, true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/console/network.go
+++ b/pkg/console/network.go
@@ -79,6 +79,10 @@ func applyNetworks(network config.Network, hostname string) ([]byte, error) {
 	cmd := exec.Command("/usr/bin/yip", "-s", "live", tempFile.Name())
 	cmd.Env = os.Environ()
 	bytes, err = cmd.CombinedOutput()
+	if err != nil {
+		logrus.Error(err, string(bytes))
+		return nil, err
+	}
 	// Restore Down NIC to up
 	if err := upAllLinks(); err != nil {
 		logrus.Errorf("failed to bring all link up: %s", err.Error())

--- a/pkg/console/network.go
+++ b/pkg/console/network.go
@@ -44,7 +44,7 @@ func applyNetworks(network config.Network, hostname string) ([]byte, error) {
 		"/etc/sysconfig/network/dhcp").CombinedOutput()
 	if err != nil {
 		logrus.Error(err, string(output))
-		return nil, err
+		return output, err
 	}
 
 	conf := &yipSchema.YipConfig{
@@ -81,7 +81,7 @@ func applyNetworks(network config.Network, hostname string) ([]byte, error) {
 	bytes, err = cmd.CombinedOutput()
 	if err != nil {
 		logrus.Error(err, string(bytes))
-		return nil, err
+		return bytes, err
 	}
 	// Restore Down NIC to up
 	if err := upAllLinks(); err != nil {


### PR DESCRIPTION
**Problem:**
We need to provide the option of allowing system hostnames to be set via DHCP.

**Solution:**
When installing Harvester, if the management interface is configured via DHCP, we will default the system hostname to the client hostname specified by the DHCP server.
    
For interactive installation, the order of the "Configure hostname" and "Configure network" pages is swapped, so that "Configure network" comes first.  This allows us to set DHCLIENT_SET_HOSTNAME="yes" when applying the management NIC config.  If DHCP is used, and the DHCP server is configured to specify a hostname, the live environment will then automatically have its hostname set to whatever it got from the DHCP server.  Then, on the hostname page, we can default the hostname to that value, which the user is still free to change should they wish.
    
For automated/PXE installation, it works like this:
- If os.hostname is specified in the harvester config, we use that.
- If os.hostname is not specified, we use the DHCP provided hostname if set, otherwise we fall back to a randomly generated hostname.

(This is an alternative to https://github.com/harvester/harvester-installer/pull/717 - the advantage with this approach is that we set the hostname once, during installation, whereas #717 potentially allows the DHCP server to change the hostname of an installed system later, which would likely cause all sorts of trouble)

**Related Issue:**
https://github.com/harvester/harvester/issues/1444

**Test plan:**
- Configure a DHCP server, but don't have it set to provide client hostnames (i.e. _don't_ use `option host-name XXX` or `use-host-decl-names on` in `dhcpd.conf`)
- Boot the installer ISO and walk through the installation process, selecting DHCP for the management interface.
- Verify that the network page now comes before the hostname page, but that the hostname by default remains blank.
- Verify that installation completes successfully
- Do a PXE install, set to use DHCP, and verify that it completes as usual.
- Reconfigure the DHCP server to provide client hostnames.
- Boot the installer ISO and walk through the installation process, selecting DHCP for the management interface.
- Verify that when you get to the hostname page, the hostname defaults to whatever was specified in the DHCP server config for this host, but that you can also still change the hostname if you want.
- Verify that the install completes successfully
- Do a PXE install, but make sure `os.hostname` is _not_ set in the harvester config yaml.
- Verify that the installation completes successfully, and that the system picks up the DHCP-provided hostname.

Example dhcpd.conf snippet which should set the hostname to "harv-0-dhcp" for the MAC address 02:00:00:0D:62:E2:

```
host harvest_node_0 {
    hardware ethernet 02:00:00:0D:62:E2;
    fixed-address 192.168.0.30;
    option host-name "harv-0-dhcp";
}
```