### PR TITLE
build: checkout addons in scripts/test if necessary

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -3,5 +3,13 @@ set -e
 
 cd $(dirname $0)/..
 
+# duplicated from scripts/build, so that we can run `make test` standalone
+addons_path=../addons
+if [ ! -d ${addons_path} ];then
+    echo "No existed addons source. Pulling..."
+    git clone --branch main --single-branch --depth 1 https://github.com/harvester/addons.git ../addons
+fi
+cp ${addons_path}/pkg/templates/*.yaml ./pkg/config/templates
+
 echo Running tests
 go test -cover -tags=test ./pkg/...


### PR DESCRIPTION
**Problem:**
https://github.com/harvester/harvester-installer/pull/708 moved pkg/config/templates/rancherd-22-addons.yaml to a separate "addons" repo, and added code to `scripts/build` to clone this repo during build and copy that yaml file to ./pkg/config/templates. So everything works fine if you run `make` or `make ci`.  However, if you just run `make test` by itself (which you might do during development), rancherd-22-addons.yaml isn't available, and the tests fail with:

```
Running tests
--- FAIL: TestConvertToCos_SSHKeysInYipNetworkStage (0.00s)
    cos_test.go:71:
        	Error Trace:	/go/src/github.com/harvester/harvester-installer/pkg/config/cos_test.go:71
        	Error:      	Received unexpected error:
        	            	open templates/rancherd-22-addons.yaml: file does not exist
        	Test:       	TestConvertToCos_SSHKeysInYipNetworkStage
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x731164]
```

**Solution:**
We can fix this by duplicating the addons clone code from `scripts/build` into `scripts/test`.  This has no impact on normal builds (`make` or `make ci`) because the addons repo has already been cloned by `scripts/build` in that case.

**Related Issue:**
https://github.com/harvester/harvester/issues/4937

**Test plan:**
Run `make test`. If it works, we're good ;-)

