### PR TITLE
Use dmidecode to check available RAM in preflight checks

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -82,7 +82,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", inline: <<-SHELL
     zypper ar --no-gpgcheck https://download.opensuse.org/repositories/home:/vcheng:/Packages/15.4/home:vcheng:Packages.repo
     zypper --gpg-auto-import-keys refresh
-    zypper --non-interactive in yip
+    zypper --non-interactive in yip dmidecode
     echo -e '#!/bin/sh\necho "fake $0"' > /usr/local/bin/fake
     chmod a+x /usr/local/bin/fake
     for f in /usr/sbin/harv-install /usr/sbin/cos-installer-shutdown ; do


### PR DESCRIPTION
**Problem:**
The current implementation of the preflight memory check uses `MemTotal` from `/proc/meminfo` to try to figure out how much RAM there is.  This number will always be a little bit low, which is confusing ("Why is it reporting only 60GiB when I know I have 64GiB?!?") and means we have to allow a certain amount of wiggle room when determining whether or not the system meets the minimum production requirements.

**Solution:**
This commit makes the following changes:

1. We use `dmidecode -t 19` to get the exact amount of memory installed in the system.  No weird low values, no need for wiggle room.
2. In case the above fails and we have to fall back to `/proc/meminfo`, increase the wiggle room from 5% to 10%.
3. For really low RAM scenarios (e.g. tiny test VMs with <1GiB RAM), report available memory in MiB rather than KiB (nobody thinks in KiB anymore, right?)

**Related Issue:**
https://github.com/harvester/harvester/issues/5599

**Test plan:**
- Boot a system with <64GiB RAM. Verify that the warning message gives the exact amount of RAM you actually have (e.g. 16GiB, 32GiB), vs. undercounting like it used to do (e.g. 7GiB on an 8GiB system).

