### PR TITLE
Change package repos in Vagrantfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ To remote debug the `harvester-installer` in your IDE, you need to
 install the `delve` package in your Vagrant box first.
 
 ```sh
- $ zypper addrepo https://download.opensuse.org/repositories/devel:languages:go/15.4/devel:languages:go.repo
+ $ zypper addrepo https://download.opensuse.org/repositories/devel:/languages:/go/SLE_15_SP4/devel:languages:go.repo
  $ zypper refresh
  $ zypper install delve
 ```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -47,7 +47,7 @@ Vagrant.configure("2") do |config|
 
   # Disable the default share of the current code directory. Doing this
   # provides improved isolation between the vagrant box and your host
-  # by making sure your Vagrantfile isn't accessable to the vagrant box.
+  # by making sure your Vagrantfile isn't accessible to the vagrant box.
   # If you use this you may want to enable additional shared subfolders as
   # shown above.
   # config.vm.synced_folder ".", "/vagrant", disabled: true
@@ -80,7 +80,7 @@ Vagrant.configure("2") do |config|
   #   apt-get install -y apache2
   # SHELL
   config.vm.provision "shell", inline: <<-SHELL
-    zypper ar --no-gpgcheck https://download.opensuse.org/repositories/home:/vcheng:/Packages/15.4/home:vcheng:Packages.repo
+    zypper ar --no-gpgcheck https://download.opensuse.org/repositories/isv:/Rancher:/Harvester:/ExtraPackages:/Dev/15.4/isv:Rancher:Harvester:ExtraPackages:Dev.repo
     zypper --gpg-auto-import-keys refresh
     zypper --non-interactive in yip dmidecode
     echo -e '#!/bin/sh\necho "fake $0"' > /usr/local/bin/fake


### PR DESCRIPTION
**Problem:**
This is necessary because the Leap 15.4 package repo, which is mentioned in the README to install `delve` for interactive debugging, is not available anymore.

**Solution:**
Change the package repos.

As the change only affects the development environment of harvester-installer, it has no effect on the installer itself.

**Related Issue:**
n/a

