### PR TITLE
Add addon version check with the repo

### DIFF
--- a/scripts/build-bundle
+++ b/scripts/build-bundle
@@ -135,6 +135,46 @@ tar zxvf ${CHARTS_DIR}/nvidia-driver-runtime-${NVIDIA_DRIVER_RUNTIME_CHART_VERSI
 # Create Helm repo index after charts are ready
 helm repo index ${CHARTS_DIR}
 
+# Check the matching of addon chart version and repo chart version
+check_addon_chart_version_matching() {
+  echo "charts packed in Harvester repo"
+  ls -alht ${CHARTS_DIR}
+
+  echo "addon template files"
+  ls -alht ${addons_path}/pkg/templates
+
+  for filename in ${addons_path}/pkg/templates/*.yaml; do
+    local tmpfile=/tmp/$(basename ${filename})
+    grep -v "{{" ${filename} > ${tmpfile}
+    local cnt=$(yq '.resources | length' ${tmpfile})
+
+    local i=0
+    while [[ $i -lt $cnt ]] ; do
+      local chart=$(idx=$i yq '.resources[env(idx)].spec.chart' ${tmpfile})
+      local version=$(idx=$i yq '.resources[env(idx)].spec.version' ${tmpfile})
+      echo addon: "$chart" version: $version
+
+      local EXIT_CODE=0
+      local repover=$(chart=$chart yq '.entries[strenv(chart)][0].version' < ${CHARTS_DIR}/index.yaml) || EXIT_CODE=$?
+      if [ $EXIT_CODE != 0 ]; then
+        echo WARNING: addon $chart is defined, but the chart is not packed into repo / repo struct is changed
+        continue
+      fi
+
+      # some charts are not packed into arm64 ISO, the above yq will return `null`
+      if [[ $repover == "null" ]] && [[ ${ARCH} == "arm64" ]]; then
+        echo  WARNING: addon "$chart" is defined with version "$version" but the chart is not packed into repo in ${ARCH}
+      elif [[ $repover != $version ]]; then
+        echo  addon "$chart" has version mis-matching: in repo is "$repover" but in addon is "$version"
+        return 1
+      fi
+      (( i += 1 ))
+    done
+  done
+}
+
+check_addon_chart_version_matching
+
 # Use offline bundle cache
 if [ -n "$HARVESTER_INSTALLER_OFFLINE_BUILD" -a -e /bundle ]; then
   cp -rf /bundle/* ${BUNDLE_DIR}/


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Addon & repo chart version mis-matching (e.g. https://github.com/harvester/harvester/issues/5840)

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Check version matching in the step of `build-bundle`

In amd64 architecture, the mismatching will cause build failure
In arm64 architecture, the mismatching will print some `WARNING` messages but build continue

**Related Issue:**
https://github.com/harvester/harvester/issues/4937
https://github.com/harvester/harvester/issues/5840

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

make iso output:
**amd64**

```
...
charts packed in Harvester repo
total 1.3M
drwxr-xr-x 2 root root 4.0K Jun  3 18:35 .
-rw-r--r-- 1 root root  12K Jun  3 18:35 index.yaml
-rw-r--r-- 1 root root 2.5K Jun  3 18:35 nvidia-driver-runtime-0.1.1.tgz
-rw-r--r-- 1 root root 3.0K Jun  3 18:35 harvester-seeder-0.1.1.tgz
-rw-r--r-- 1 root root 2.8K Jun  3 18:35 harvester-pcidevices-controller-0.3.2.tgz
-rw-r--r-- 1 root root 2.6K Jun  3 18:35 harvester-vm-import-controller-0.1.8.tgz
-rw-r--r-- 1 root root  15K Jun  3 18:35 rancher-logging-103.0.0+up3.17.10.tgz
-rw-r--r-- 1 root root  82K Jun  3 18:35 rancher-logging-crd-103.0.0+up3.17.10.tgz
-rw-r--r-- 1 root root 398K Jun  3 18:35 rancher-monitoring-crd-103.0.3+up45.31.1.tgz
-rw-r--r-- 1 root root 416K Jun  3 18:35 rancher-monitoring-103.0.3+up45.31.1.tgz
-rw-r--r-- 1 root root  66K Jun  3 18:34 harvester-crd-0.0.0-master-f9464f06.tgz
-rw-r--r-- 1 root root 211K Jun  3 18:34 harvester-0.0.0-master-f9464f06.tgz
drwxrwxr-x 1 root root 4.0K Jun  3 18:34 ..
addon template files
total 16K
drwxr-xr-x 2 root root 4.0K Jun  3 18:34 .
drwxr-xr-x 4 root root 4.0K Jun  3 18:34 ..
-rw-r--r-- 1 root root 7.2K Jun  3 18:34 rancherd-22-addons.yaml
addon: harvester-vm-import-controller version: 0.1.8
addon: harvester-pcidevices-controller version: 0.3.2
addon: rancher-logging version: 103.0.0+up3.17.10
addon: rancher-monitoring version: 103.0.3+up45.31.1
addon: harvester-seeder version: 0.1.1
addon: nvidia-driver-runtime version: 0.1.1
```

**arm64:**
```
...
drwxr-xr-x 2 root root 4.0K Jun  3 18:37 .
-rw-r--r-- 1 root root  11K Jun  3 18:37 index.yaml
-rw-r--r-- 1 root root 2.5K Jun  3 18:37 nvidia-driver-runtime-0.1.1.tgz
-rw-r--r-- 1 root root  15K Jun  3 18:37 rancher-logging-103.0.0+up3.17.10.tgz
-rw-r--r-- 1 root root  82K Jun  3 18:37 rancher-logging-crd-103.0.0+up3.17.10.tgz
-rw-r--r-- 1 root root 398K Jun  3 18:37 rancher-monitoring-crd-103.0.3+up45.31.1.tgz
-rw-r--r-- 1 root root 417K Jun  3 18:37 rancher-monitoring-103.0.3+up45.31.1.tgz
-rw-r--r-- 1 root root  66K Jun  3 18:37 harvester-crd-0.0.0-master-f9464f06.tgz
-rw-r--r-- 1 root root 215K Jun  3 18:37 harvester-0.0.0-master-f9464f06.tgz
drwxr-xr-x 1 root root 4.0K Jun  3 18:37 ..
addon template files
total 16K
drwxr-xr-x 2 root root 4.0K Jun  3 18:37 .
drwxr-xr-x 4 root root 4.0K Jun  3 18:37 ..
-rw-r--r-- 1 root root 7.2K Jun  3 18:37 rancherd-22-addons.yaml
addon: harvester-vm-import-controller version: 0.1.8
WARNING: addon harvester-vm-import-controller is defined with version 0.1.8 but the chart is not packed into repo in arm64
addon: harvester-pcidevices-controller version: 0.3.2
WARNING: addon harvester-pcidevices-controller is defined with version 0.3.2 but the chart is not packed into repo in arm64
addon: rancher-logging version: 103.0.0+up3.17.10
addon: rancher-monitoring version: 103.0.3+up45.31.1
addon: harvester-seeder version: 0.1.1
WARNING: addon harvester-seeder is defined with version 0.1.1 but the chart is not packed into repo in arm64
addon: nvidia-driver-runtime version: 0.1.1
```