### PR TITLE
[v1.3] Bump eventrouter to v0.2.0

### DIFF
--- a/pkg/config/templates/rancherd-22-addons.yaml
+++ b/pkg/config/templates/rancherd-22-addons.yaml
@@ -91,7 +91,7 @@ resources:
           controlNamespace: cattle-logging-system
           workloadOverrides:
             containers:
-            - image: rancher/harvester-eventrouter:v0.1.2
+            - image: rancher/harvester-eventrouter:v0.2.0
               name: event-tailer
               resources:
                 limits:

--- a/scripts/images/harvester-additional-images.txt
+++ b/scripts/images/harvester-additional-images.txt
@@ -1,2 +1,2 @@
 registry.suse.com/suse/vmdp/vmdp:2.5.4.2
-rancher/harvester-eventrouter:v0.1.2
+rancher/harvester-eventrouter:v0.2.0


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Task: https://github.com/harvester/harvester/issues/5947

Image release:
https://github.com/harvester/eventrouter/releases/tag/v0.2.0

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Bump image tag to v0.2.0

**Related Issue:**

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

New install, check eventrouter tag is v0.3.0
Upgrade, check eventrouter tag is v0.3.0

This is a manual backport of:
https://github.com/harvester/harvester-installer/pull/752
and
https://github.com/harvester/addons/pull/1 (only for harvester master-head)