### PR TITLE
[v1.3] Add addon version check with the repo

### DIFF
--- a/scripts/build-bundle
+++ b/scripts/build-bundle
@@ -135,6 +135,82 @@ tar zxvf ${CHARTS_DIR}/nvidia-driver-runtime-${NVIDIA_DRIVER_RUNTIME_CHART_VERSI
 # Create Helm repo index after charts are ready
 helm repo index ${CHARTS_DIR}
 
+# Check the matching of addon chart version and repo chart version
+check_addon_chart_version_matching() {
+  echo "charts packed in Harvester repo"
+  ls -alht ${CHARTS_DIR}
+
+  echo "addon template files"
+  ls -alht ${TOP_DIR}/pkg/config/templates/rancherd-22-addons.yaml
+
+  for filename in ${TOP_DIR}/pkg/config/templates/rancherd-22-addons.yaml; do
+    local tmpfile=/tmp/$(basename ${filename})
+    grep -v "{{" ${filename} > ${tmpfile}
+    local cnt=$(yq '.resources | length' ${tmpfile})
+
+    local i=0
+    while [[ $i -lt $cnt ]] ; do
+      local chart=$(idx=$i yq '.resources[env(idx)].spec.chart' ${tmpfile})
+      local version=$(idx=$i yq '.resources[env(idx)].spec.version' ${tmpfile})
+      echo addon: "$chart" version: $version
+
+      local EXIT_CODE=0
+      local repover=$(chart=$chart yq '.entries[strenv(chart)][0].version' < ${CHARTS_DIR}/index.yaml) || EXIT_CODE=$?
+      if [ $EXIT_CODE != 0 ]; then
+       echo WARNING: addon $chart is defined, but the chart is not packed into repo / repo struct is changed
+       continue
+      fi
+
+      # some charts are not packed into arm64 ISO, the above yq will return `null`
+      if [[ $repover == "null" ]] && [[ ${ARCH} == "arm64" ]]; then
+       echo  WARNING: addon "$chart" is defined with version "$version" but the chart is not packed into repo in ${ARCH}
+      elif [[ $repover != $version ]]; then
+       echo  addon "$chart" has version mis-matching: in repo is "$repover" but in addon is "$version"
+       return 1
+      fi
+      (( i += 1 ))
+    done
+  done
+  echo "all addons have matched version with the repo"
+}
+
+check_addon_chart_version_matching
+
+check_upgrade_addon_chart_version_matching() {
+  echo "upgrade addon files"
+  ls -alht ${harvester_path}/package/upgrade/addons
+
+  for filename in ${harvester_path}/package/upgrade/addons/*.yaml; do
+    local tmpfile=/tmp/$(basename ${filename})
+    grep -v "{{" ${filename} > ${tmpfile}
+
+    local chart=$(yq '.spec.chart' ${tmpfile})
+    local version=$(yq '.spec.version' ${tmpfile})
+    echo upgrade addon: "$chart" version: $version
+
+    local EXIT_CODE=0
+    local repover=$(chart=$chart yq '.entries[strenv(chart)][0].version' < ${CHARTS_DIR}/index.yaml) || EXIT_CODE=$?
+    if [ $EXIT_CODE != 0 ]; then
+     echo WARNING: upgrade addon $chart is defined, but the chart is not packed into repo / repo struct is changed
+     continue
+    fi
+
+    # some charts are not packed into arm64 ISO, the above yq will return `null`
+    if [[ $repover == "null" ]] && [[ ${ARCH} == "arm64" ]]; then
+     echo  WARNING: upgrade addon "$chart" is defined with version "$version" but the chart is not packed into repo in ${ARCH}
+    elif [[ $repover != $version ]]; then
+     # the upgrade addon is stored in GH harvester; but the chart repo is stored in GH harvester-installer
+     # a new version bumping generally means two PRs
+     # directly return 1 will cause failure in build
+     echo  WARNING upgrade addon "$chart" has version mis-matching: in repo is "$repover" but in addon is "$version"
+    fi
+  done
+
+  echo "all upgrade addons have matched version with the repo"
+}
+
+check_upgrade_addon_chart_version_matching
+
 # Use offline bundle cache
 if [ -n "$HARVESTER_INSTALLER_OFFLINE_BUILD" -a -e /bundle ]; then
   cp -rf /bundle/* ${BUNDLE_DIR}/


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Addon & repo chart version mis-matching (e.g. https://github.com/harvester/harvester/issues/5840)

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Check version matching in the step of build-bundle

In amd64 architecture, the mismatching will cause build failure
In arm64 architecture, the mismatching will print some WARNING messages but build continue

**Related Issue:**
https://github.com/harvester/harvester/issues/4937
https://github.com/harvester/harvester/issues/5840

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

Refer https://github.com/harvester/harvester-installer/pull/750#issue-2331553065

This is a manual backport of https://github.com/harvester/harvester-installer/pull/750, as the addon upgrade path is changed in master-head.
