### PR TITLE
Add CPU Manager related configs

### DIFF
--- a/pkg/config/cos.go
+++ b/pkg/config/cos.go
@@ -397,6 +397,21 @@ func initRancherdStage(config *HarvesterConfig, stage *yipSchema.Stage) error {
 		)
 	}
 
+	reservedResourceConfig, err := render("rke2-99-z00-harvester-reserved-resources.yaml", config)
+	if err != nil {
+		return err
+	}
+
+	stage.Files = append(stage.Files,
+		yipSchema.File{
+			Path:        "/etc/rancher/rke2/config.yaml.d/99-z00-harvester-reserved-resources.yaml",
+			Content:     reservedResourceConfig,
+			Permissions: 0600,
+			Owner:       0,
+			Group:       0,
+		},
+	)
+
 	return nil
 }
 

--- a/pkg/config/cos_test.go
+++ b/pkg/config/cos_test.go
@@ -126,6 +126,16 @@ func TestConvertToCos_VerifyNetworkInstallMode(t *testing.T) {
 	assert.False(t, containsFile(yipConfig.Stages["initramfs"][0].Files, "/etc/sysconfig/network/ifcfg-ens3"))
 }
 
+func TestConvertToCos_Remove_CPUManagerState(t *testing.T) {
+	conf, err := LoadHarvesterConfig(util.LoadFixture(t, "harvester-config.yaml"))
+	assert.NoError(t, err)
+
+	yipConfig, err := ConvertToCOS(conf)
+	assert.NoError(t, err)
+
+	assert.Contains(t, yipConfig.Stages["initramfs"][0].Commands, "rm -f /var/lib/kubelet/cpu_manager_state")
+}
+
 func containsFile(files []yipSchema.File, fileName string) bool {
 	for _, v := range files {
 		if v.Path == fileName {

--- a/pkg/config/templates/rke2-99-z00-harvester-reserved-resources.yaml
+++ b/pkg/config/templates/rke2-99-z00-harvester-reserved-resources.yaml
@@ -1,0 +1,3 @@
+kubelet-arg+:
+- {{ printf "%q" .GetSystemReserved }}
+- {{ printf "%q" .GetKubeReserved }}


### PR DESCRIPTION
**Problem:**
This is a prerequisite pr for implementing CPU Pinning. We need to add the cpu manager configs first. `system-reserved`, `kube-reserved`, `cpu-manager-policy`.

**Solution:**
Introduced two configs files:
- `rke2-99-z00-harvester-reserved-resources.yaml`
  -  include two configs`system-reserved` and `kube-reserved`, both of which follow [GKE CPU reservation formula](https://cloud.google.com/kubernetes-engine/docs/concepts/plan-node-sizes) for calculating reserved CPU resources.
- `rke2-99-z01-harvester-cpu-manager.yaml`
  -  include cpu manager policy setting, currently the value is "none" (which is the default value)
> [!NOTE]  
> Here I add these files instead of adding configs in 90-harvester-server.yaml or 90-harvester-worker.yaml since we will have 99-max-pods.yaml (after upgrade to a newer harvester version) which overrides kubelet args to "max-pods=200".
https://github.com/harvester/harvester/blob/226f72aa58532071232ad548e27970c1cec55733/package/upgrade/upgrade_node.sh#L490-L495

**Related Issue:**
related to https://github.com/harvester/harvester/issues/2305
HEP: https://github.com/harvester/harvester/pull/5803

**Test Plan:**
Setup harvester with one node which has 8 CPUs and check if the two config files exist under `/etc/rancher/rke2/config.yaml.d/` and have correct settings.
in `99-z00-harvester-reserved-resources.yaml`. The content should be
```yaml
kubelet-arg+:
- "system-reserved=cpu=490m"
- "kube-reserved=cpu=490m"
```
in `99-z01-harvester-cpu-manager.yaml`. The content should be
```yaml
kubelet-arg+:
- "cpu-manager-policy=none"
```

