### PR TITLE
force remove files

### DIFF
--- a/package/harvester-os/files/usr/sbin/harv-install
+++ b/package/harvester-os/files/usr/sbin/harv-install
@@ -46,7 +46,6 @@ clear_disk_label()
         done
         udevadm settle
     fi
-   
 }
 
 umount_target() {
@@ -251,8 +250,8 @@ preload_rke2_images()
       if [ "$install_mode" = "ISO" ]; then
         echo "Stop RKE2 and remove temporary RKE2 files..."
         pkill rke2
-        rm /rke2.log
-        rm /etc/rancher/rke2/rke2.yaml
+        rm -f /rke2.log
+        rm -f /etc/rancher/rke2/rke2.yaml
         rm -rf /var/lib/rancher/rke2/server
         rm -rf /var/lib/rancher/rke2/agent/pod-manifests/*
 
@@ -279,12 +278,12 @@ preload_rke2_images()
       if [ "$install_mode" = "ISO" ]; then
         echo "Stop containerd..."
         pkill containerd
-        rm /containerd.log
+        rm -f /containerd.log
       else
         echo "Stop RKE2..."
         pkill rke2
-        rm /rke2.log
-        rm /etc/rancher/rke2/rke2.yaml
+        rm -f /rke2.log
+        rm -f /etc/rancher/rke2/rke2.yaml
         rm -rf /var/lib/rancher/rke2/server
         rm -rf /var/lib/rancher/rke2/agent/pod-manifests/*
       fi
@@ -402,7 +401,7 @@ update_grub_settings()
         # patch kernel in bootargs.cfg to Image on arm nodes
         sed -i "s/kernel=\/boot\/vmlinuz/kernel=\/boot\/Image/g" ${TARGET}/etc/cos/bootargs.cfg
     fi
-    
+
     # calculate recommended crashkernel allocation size
     CRASH_KERNEL_PARAMS=$(get_crashkernel_params || true)
     if [ -n "$CRASH_KERNEL_PARAMS" ]; then


### PR DESCRIPTION
Force remove files (rm -f), so the install script doesn't fail if the files don't exist.

**Problem:**
Sometimes the installer may hit a problem where it tries to remove a file that isn't there. If that happens, it shouldn't crash, but rather try to continue and recover.

```
time="2024-06-21T03:28:54Z" level=info msg="[stdout]: sending incremental file list"
time="2024-06-21T03:28:54Z" level=info msg="[stdout]: ./"
time="2024-06-21T03:28:54Z" level=info msg="[stdout]: harvester-images-v1.3.1.txt"
time="2024-06-21T03:28:54Z" level=info msg="[stdout]: harvester-repo-images-v1.3.1.txt"
time="2024-06-21T03:28:54Z" level=info msg="[stdout]: rancher-images-v2.8.3.txt"
time="2024-06-21T03:28:54Z" level=info msg="[stdout]: rke2-images-multus.linux-amd64-v1.27.13-rke2r1.txt"
time="2024-06-21T03:28:54Z" level=info msg="[stdout]: rke2-images.linux-amd64-v1.27.13-rke2r1.txt"
time="2024-06-21T03:28:54Z" level=info msg="[stdout]: "
time="2024-06-21T03:28:54Z" level=info msg="[stdout]: sent 5.29K bytes  received 114 bytes  10.80K bytes/sec"
time="2024-06-21T03:28:54Z" level=info msg="[stdout]: total size is 4.81K  speedup is 0.89"
time="2024-06-21T03:28:54Z" level=info msg="[stdout]: Loading images. This may take a few minutes..."
time="2024-06-21T03:28:55Z" level=info msg="[stderr]: time=\"2024-06-21T03:28:55Z\" level=info msg=\"Extract mapping / => /usr/local/tmp.f5FEZvLkHK\""
time="2024-06-21T03:28:55Z" level=info msg="[stderr]: time=\"2024-06-21T03:28:55Z\" level=info msg=\"Checking local image archives in /var/lib/rancher/agent/images for index.docker.io/rancher/system-agent-installer-rke2:v1.27.13-rke2r1\""
time="2024-06-21T03:28:55Z" level=info msg="[stderr]: time=\"2024-06-21T03:28:55Z\" level=info msg=\"Extracting file installer.sh to /usr/local/tmp.f5FEZvLkHK/installer.sh\""
time="2024-06-21T03:28:55Z" level=info msg="[stderr]: time=\"2024-06-21T03:28:55Z\" level=info msg=\"Extracting file rke2.linux-amd64.tar.gz to /usr/local/tmp.f5FEZvLkHK/rke2.linux-amd64.tar.gz\""
time="2024-06-21T03:28:55Z" level=info msg="[stderr]: time=\"2024-06-21T03:28:55Z\" level=info msg=\"Extracting file sha256sum-amd64.txt to /usr/local/tmp.f5FEZvLkHK/sha256sum-amd64.txt\""
time="2024-06-21T03:28:55Z" level=info msg="[stderr]: time=\"2024-06-21T03:28:55Z\" level=info msg=\"Extracting file run.sh to /usr/local/tmp.f5FEZvLkHK/run.sh\""
time="2024-06-21T03:28:56Z" level=info msg="[stdout]: Stop RKE2 and remove temporary RKE2 files..."
time="2024-06-21T03:28:56Z" level=info msg="[stderr]: rm: cannot remove '/etc/rancher/rke2/rke2.yaml': No such file or directory"
time="2024-06-21T03:28:56Z" level=info msg="[stderr]: /bin/bash: line 1:  3153 Terminated              $rke2_tmp/bin/rke2 server &> /rke2.log"
time="2024-06-21T03:28:58Z" level=info msg="handle webhooks for event FAILED"
```

**Solution:**
The solution is to use the `-f` flag for the `rm` command in the respective bash script. This flag causes `rm` to exit with a successful return code if the file didn't exist in the first place, or when the file was successfully removed. Thus the script can continue on when the file it tries to remove already didn't exist anyways.

**Related Issue:**

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

