### PR TITLE
fix installer not initialising on arm hosts in equinix metal

### DIFF
--- a/package/harvester-os/files/usr/bin/setup-installer.sh
+++ b/package/harvester-os/files/usr/bin/setup-installer.sh
@@ -44,12 +44,17 @@ echo "Remove the serial-getty service..."
 rm -rf "/etc/systemd/system/serial-getty*"
 
 # reverse the ttys to start from the last one
-for TTY in $(cat /sys/class/tty/console/active); do
+read -r -a tty_list < /sys/class/tty/console/active
+
+for TTY in "${tty_list[@]}"; do
   tty_num=${TTY#tty}
 
  #for arm64 the terminals are named /dev/ttyAMA*
+ #skip /dev/ttyAMA* if an additional tty is present
+ #on equinix metal /dev/ttyAMA is the only terminal available
+ #so needs to be used as default option
   PLATFORM=$(uname -m)
-  if [ $PLATFORM == "aarch64" ]
+  if [[ $PLATFORM == "aarch64" && ${#tty_list[@]} > 1 ]]
   then
     if  [[ $tty_num =~ ^AMA[0-9]+$ ]]; then
       continue


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Currently harvester installer does not initialise on arm instances on equinix metal.

The original arm implementation skipped the serial console /dev/ttyAMA0 in favour of non serial terminals exposed such as /dev/tty1 exposed on the ampere hosts.

Arm hosts in equinix metal only expose /dev/ttyAMA0 via serial-over-ssh. Since there is no alternate terminal exposed the installer does not start.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
The PR introduces a minor change to setup-installer script to favour non /dev/ttyAMA0 terminals if one is present such as on Ampere hosts, and failover to /dev/ttyAMA0 if that is the only option.

**Related Issue:**

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

