### PR TITLE
build: Add LOCAL_{ADDONS,HARVESTER}_SRC arguments

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -40,12 +40,17 @@ RUN mkdir /usr/tmp && \
     curl ${HELM_URL} | tar xvzf - --strip-components=1 -C /usr/tmp/ && \
     mv /usr/tmp/helm /usr/bin/helm
 
+ARG LOCAL_HARVESTER_SRC
+ENV HARVESTER_SRC_MOUNT="${LOCAL_HARVESTER_SRC:+-v $LOCAL_HARVESTER_SRC:/go/src/github.com/harvester/harvester}"
+ARG LOCAL_ADDONS_SRC
+ENV ADDONS_SRC_MOUNT="${LOCAL_ADDONS_SRC:+-v $LOCAL_ADDONS_SRC:/go/src/github.com/harvester/addons}"
+
 # You cloud defined your own rke2 url by setup `RKE2_IMAGE_REPO`
 ENV DAPPER_ENV REPO TAG DRONE_TAG DRONE_BRANCH CROSS RKE2_IMAGE_REPO USE_LOCAL_IMAGES BUILD_QCOW DRONE_BUILD_EVENT REMOTE_DEBUG
 ENV DAPPER_SOURCE /go/src/github.com/harvester/harvester-installer/
 ENV DAPPER_OUTPUT ./bin ./dist
 ENV DAPPER_DOCKER_SOCKET true
-ENV DAPPER_RUN_ARGS "-v /run/containerd/containerd.sock:/run/containerd/containerd.sock -v harvester-installer-go:/root/go -v harvester-installer-cache:/root/.cache --privileged"
+ENV DAPPER_RUN_ARGS "-v /run/containerd/containerd.sock:/run/containerd/containerd.sock -v harvester-installer-go:/root/go -v harvester-installer-cache:/root/.cache ${HARVESTER_SRC_MOUNT} ${ADDONS_SRC_MOUNT} --privileged"
 
 ENV HOME ${DAPPER_SOURCE}
 WORKDIR ${DAPPER_SOURCE}

--- a/README.md
+++ b/README.md
@@ -27,6 +27,19 @@ This will:
 
 The built ISO image is written to the `dist/artifacts` directory.
 
+During the build, the harvester source and addons will be pulled
+automatically from https://github.com/harvester/harvester.git and
+https://github.com/harvester/addons.git resectively.  If you would
+like to use an exiting local copy of either or both repositories
+instead, for example to pick up some development work in progress,
+you can do so as follows:
+
+```sh
+ $ export LOCAL_HARVESTER_SRC=/path/to/local/harvester/repo
+ $ export LOCAL_ADDONS_SRC=/path/to/local/addons/repo
+ $ make
+```
+
 ## Harvester Installation Process
 
 Harvester can be installed by either [booting the Harvester ISO](https://docs.harvesterhci.io/v1.2/install/index/),

--- a/scripts/build
+++ b/scripts/build
@@ -10,7 +10,7 @@ cd ${TOP_DIR}
 # Pull harvester source and determine harvester version
 harvester_path=../harvester
 if [ ! -d ${harvester_path} ];then
-    echo "No existed harvester source. Pulling..."
+    echo "No existing harvester source. Pulling..."
     git clone --branch master --single-branch --depth 1 https://github.com/harvester/harvester.git ../harvester
 else
     # When building against locally modified harvester source with
@@ -29,7 +29,7 @@ fi
 
 addons_path=../addons
 if [ ! -d ${addons_path} ];then
-    echo "No existed addons source. Pulling..."
+    echo "No existing addons source. Pulling..."
     git clone --branch main --single-branch --depth 1 https://github.com/harvester/addons.git ../addons
 fi
 

--- a/scripts/build-bundle
+++ b/scripts/build-bundle
@@ -11,7 +11,7 @@ cd ${TOP_DIR}
 
 addons_path=../addons
 if [ ! -d ${addons_path} ];then
-    echo "No existed harvester source. Pulling..."
+    echo "No existing addons source. Pulling..."
     git clone --branch main --single-branch --depth 1 https://github.com/harvester/addons.git ../addons
 fi
 
@@ -39,9 +39,8 @@ mkdir -p ${RANCHERD_IMAGES_DIR}
 # Prepare Harvester chart
 harvester_path=../harvester
 if [ ! -d ${harvester_path} ];then
-    echo "No existed harvester source. Pulling into /tmp/harvester"
-    git clone --branch master --single-branch --depth 1 https://github.com/harvester/harvester.git /tmp/harvester
-    harvester_path=/tmp/harvester
+    echo "No existing harvester source. Pulling..."
+    git clone --branch master --single-branch --depth 1 https://github.com/harvester/harvester.git ../harvester
 fi
 
 # Revert harvester chart version patch to clean dirty git status
@@ -52,10 +51,10 @@ reset_charts() {
 }
 
 # This must be placed after cloning `harvester/harvester`` in case `make build-bundle` is run directly.
-source ${SCRIPTS_DIR}/version-harvester ${TOP_DIR}/../harvester
+source ${SCRIPTS_DIR}/version-harvester ${harvester_path}
 
 # Replace harvester chart version
-${SCRIPTS_DIR}/patch-harvester ${TOP_DIR}/../harvester
+${SCRIPTS_DIR}/patch-harvester ${harvester_path}
 # Package harvester chart
 harvester_chart_path=${harvester_path}/deploy/charts/harvester
 harvester_crd_chart_path=${harvester_path}/deploy/charts/harvester-crd

--- a/scripts/test
+++ b/scripts/test
@@ -6,7 +6,7 @@ cd $(dirname $0)/..
 # duplicated from scripts/build, so that we can run `make test` standalone
 addons_path=../addons
 if [ ! -d ${addons_path} ];then
-    echo "No existed addons source. Pulling..."
+    echo "No existing addons source. Pulling..."
     git clone --branch main --single-branch --depth 1 https://github.com/harvester/addons.git ../addons
 fi
 cp ${addons_path}/pkg/templates/*.yaml ./pkg/config/templates


### PR DESCRIPTION
**Problem:**
It's currently annoying to build ISO images from the harvester-installer repo when you want to also include changes from a local harvester and/or addons repo. You have to manually edit `Dockerfile.dapper` and tweak `DAPPER_RUN_ARGS` to add something like `-v /path/to/local/harvester/repo:/go/src/github.com/harvester/harvester`.

**Solution:**
I've added `LOCAL_HARVESTER_SRC` and `LOCAL_ADDONS_SRC` environment variables to the build, which, if set, will automatically inject the correct `-v /path/to/local/harvester/repo` parameters, so now you can do this:

```sh
$ export LOCAL_HARVESTER_SRC=/path/to/local/harvester/repo
$ export LOCAL_ADDONS_SRC=/path/to/local/addons/repo
$ make
```

I've also done a little minor rewording and made the harvester repo cloning in `scripts/build-bundle` consistent with what's done in `scripts/build`.

**Related Issue:**
N/A

**Test plan:**
N/A

