### PR TITLE
Bump golang to v1.22

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,6 +1,6 @@
 FROM quay.io/costoolkit/releases-teal:grub2-live-0.0.4-2 as grub2-mbr
 FROM quay.io/costoolkit/releases-teal:grub2-efi-image-live-0.0.4-2 as grub2-efi
-FROM registry.suse.com/bci/golang:1.21
+FROM registry.suse.com/bci/golang:1.22
 
 ARG http_proxy=$http_proxy
 ARG https_proxy=$https_proxy

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/harvester/harvester-installer
 
-go 1.21
+go 1.22
 
 require (
 	github.com/harvester/go-common v0.0.0-20230718010724-11313421a8f5


### PR DESCRIPTION
**Problem:**
Need to bump golang to v1.22

**Solution:**
This PR

**Related Issue:**
https://github.com/harvester/harvester/issues/6160

**Test plan:**
N/A

