### PR TITLE
Log validateConfig, PrepareWebooks and doInstall errors

### DIFF
--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -2132,6 +2132,7 @@ func addInstallPanel(c *Console) error {
 						for _, warning := range preflightWarnings {
 							logrus.Warning(warning)
 						}
+						logrus.Info("Installation will proceed (harvester.install.skipchecks = true)")
 					} else {
 						// Checks were not explicitly skipped, fail the install
 						// (this will happen when PXE booted if checks fail and
@@ -2166,13 +2167,17 @@ func addInstallPanel(c *Console) error {
 			}
 
 			if err := validateConfig(ConfigValidator{}, c.config); err != nil {
-				printToPanel(c.Gui, err.Error(), installPanel)
+				msg := fmt.Sprintf("Invalid configuration: %s", err)
+				logrus.Error(msg)
+				printToPanel(c.Gui, msg, installPanel)
 				return
 			}
 
 			webhooks, err := PrepareWebhooks(c.config.Webhooks, getWebhookContext(c.config))
 			if err != nil {
-				printToPanel(c.Gui, fmt.Sprintf("invalid webhook: %s", err), installPanel)
+				msg := fmt.Sprintf("Invalid webhook: %s", err)
+				logrus.Error(msg)
+				printToPanel(c.Gui, msg, installPanel)
 			}
 
 			if alreadyInstalled {
@@ -2181,7 +2186,9 @@ func addInstallPanel(c *Console) error {
 				err = doInstall(c.Gui, c.config, webhooks)
 			}
 			if err != nil {
-				printToPanel(c.Gui, fmt.Sprintf("install failed: %s", err), installPanel)
+				msg := fmt.Sprintf("Install failed: %s", err)
+				logrus.Error(msg)
+				printToPanel(c.Gui, msg, installPanel)
 			}
 		}()
 		return c.setContentByName(footerPanel, "")


### PR DESCRIPTION
**Problem:**
Prior to this commit, errors returned from `validateConfig()`, `PrepareWebooks()` and `doInstall()`  would be printed to the console, but not logged.  This meant that if you weren't able to access the console for whatever reason, but _could_ access the log file, you would have no idea what went wrong if one of those function calls failed.

**Solution:**
Call `logrus.Error()` in addition to `printToPanel()`.

Bonus: call `logrus.Info("Installation will proceed (harvester.install.skipchecks = true)")` to make it explicit when preflight checks fail but are intentionally skipped.

**Related Issue:**
https://github.com/harvester/harvester/issues/6214

**Test plan:**
- Do a PXE install, but with an invalid config file (see reproducer in https://github.com/harvester/harvester/issues/6214)
- Confirm that an appropriate error message appears on the console _and_ in `/var/log/console.log`, rather than only appearing on the console.

For example, with this configuration:

```
install:
  mode: This ain't right
```

...we should see something like the following on the console:

![image](https://github.com/user-attachments/assets/bb87d0bc-75ea-4048-aad2-ff490ad37029)

...and something like this in the log:

![image](https://github.com/user-attachments/assets/48c262ce-3260-47c5-a675-515bfdc5d350)



