### PR TITLE
bump monitoring charts shell version

### DIFF
--- a/pkg/config/templates/patch/rancher-monitoring-crd/103.0.3+up45.31.1/patch-values-shell-version.diff
+++ b/pkg/config/templates/patch/rancher-monitoring-crd/103.0.3+up45.31.1/patch-values-shell-version.diff
@@ -5,7 +5,7 @@
  image:
    repository: rancher/shell
 -  tag: v0.1.18
-+  tag: v0.1.22
++  tag: v0.1.26
  
  nodeSelector: {}
  

--- a/pkg/config/templates/patch/rancher-monitoring/103.0.3+up45.31.1/patch-values-shell-version.diff
+++ b/pkg/config/templates/patch/rancher-monitoring/103.0.3+up45.31.1/patch-values-shell-version.diff
@@ -5,7 +5,7 @@
    image:
      repository: rancher/shell
 -    tag: v0.1.19
-+    tag: v0.1.22
++    tag: v0.1.26
  
  ## Rancher Monitoring
  ##

--- a/scripts/images/rancher-images.txt
+++ b/scripts/images/rancher-images.txt
@@ -19,6 +19,7 @@ docker.io/rancher/rancher-webhook:v0.4.3
 docker.io/rancher/rancher:v2.8.3
 docker.io/rancher/shell:v0.1.22
 docker.io/rancher/shell:v0.1.23
+docker.io/rancher/shell:v0.1.26
 docker.io/rancher/system-agent:v0.3.6-suc
 docker.io/rancher/system-upgrade-controller:v0.13.1
 docker.io/rancher/mirrored-banzaicloud-fluentd:v1.14.6-alpine-5


### PR DESCRIPTION
**Problem:**
I'm on the O&B team that maintains shell and just looking to bump shell for CVE's we've addressed.
Unfamiliar with harvester stuff and this repo didn't have issues, so just made the PR myself; so something may be wrong.

Let me know if it needs changes.

If I follow correctly harvester uses Rancher 2.8.x currently, so the newest `v0.1.X` of shell should be the target; currently: https://github.com/rancher/shell/releases/tag/v0.1.26

**Solution:**
Added new tag to image list, then bumped version in patches to use newer version.

**Related Issue:**

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

