### PR TITLE
leverage generateTemplates capability of harvester/addons

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -69,7 +69,10 @@ if [ "$(uname)" = "Linux" ]; then
 fi
 
 # render template files
-cp ${addons_path}/pkg/templates/*.yaml ./pkg/config/templates
+cd ${addons_path}
+go run . -generateTemplates -path ${TOP_DIR}/pkg/config/templates
+
+cd ${TOP_DIR}
 
 CGO_ENABLED=0 go build -gcflags "${OTHER_COMPILERFLAGS}" -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/harvester-installer .
 

--- a/scripts/build-bundle
+++ b/scripts/build-bundle
@@ -15,6 +15,11 @@ if [ ! -d ${addons_path} ];then
     git clone --branch main --single-branch --depth 1 https://github.com/harvester/addons.git ../addons
 fi
 
+# will generate template file in ${addons_path}, and this is used for subsequent checks
+cd ${addons_path}
+go run . -generateTemplates 
+cd ${TOP_DIR}
+
 source ${SCRIPTS_DIR}/version
 source ${SCRIPTS_DIR}/version-rke2
 source ${SCRIPTS_DIR}/version-rancher
@@ -140,9 +145,9 @@ check_addon_chart_version_matching() {
   ls -alht ${CHARTS_DIR}
 
   echo "addon template files"
-  ls -alht ${addons_path}/pkg/templates
+  ls -alht ${addons_path}
 
-  for filename in ${addons_path}/pkg/templates/*.yaml; do
+  for filename in ${addons_path}/*.yaml; do
     local tmpfile=/tmp/$(basename ${filename})
     grep -v "{{" ${filename} > ${tmpfile}
     local cnt=$(yq '.resources | length' ${tmpfile})


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
PR introduces minor changes to installer to leverage the new `generateTemplate` capability added to `harvester/addons`

Prior to this change the addon updates were being managed by updates to version_info file, and also updating the version details in the rancher-22-addons.yaml template file.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
This has been simplified to use the chart versions in version_info file and allow ability to generate template file dynamically. This ensures that chart and image version change is only ever kept in one single location.

addons PR: https://github.com/harvester/addons/pull/4

**Related Issue:**
https://github.com/harvester/harvester/issues/4937
**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

