### PR TITLE
enable addons for arm builds

### DIFF
--- a/scripts/build-bundle
+++ b/scripts/build-bundle
@@ -108,28 +108,24 @@ patch_rancher_logging_chart ${CHARTS_DIR} ${LOGGING_VERSION} ${PKG_PATCH_LOGGING
 # make chart sanity check again after patch
 tar zxvf ${CHARTS_DIR}/rancher-logging-${LOGGING_VERSION}.tgz >/dev/null --warning=no-timestamp
 
-# skip addons for now for arm builds
-if [ ${ARCH} == "amd64" ]; then
-  # Prepare vm-import-controller-chart
-  echo "pull harvester-vm-import-controller: $VM_IMPORT_CONTROLLER_CHART_VERSION"
-  helm pull https://github.com/harvester/charts/releases/download/harvester-vm-import-controller-${VM_IMPORT_CONTROLLER_CHART_VERSION}/harvester-vm-import-controller-${VM_IMPORT_CONTROLLER_CHART_VERSION}.tgz -d ${CHARTS_DIR}
-  # make chart sanity check
-  tar zxvf ${CHARTS_DIR}/harvester-vm-import-controller-${VM_IMPORT_CONTROLLER_CHART_VERSION}.tgz >/dev/null --warning=no-timestamp
 
-  # Prepare pcidevices-chart
-  echo "pull harvester-pcidevices-controller: $PCIDEVICES_CONTROLLER_CHART_VERSION"
-  helm pull https://github.com/harvester/charts/releases/download/harvester-pcidevices-controller-${PCIDEVICES_CONTROLLER_CHART_VERSION}/harvester-pcidevices-controller-${PCIDEVICES_CONTROLLER_CHART_VERSION}.tgz -d ${CHARTS_DIR}
-  # make chart sanity check
-  tar zxvf ${CHARTS_DIR}/harvester-pcidevices-controller-${PCIDEVICES_CONTROLLER_CHART_VERSION}.tgz >/dev/null --warning=no-timestamp
+# Prepare vm-import-controller-chart
+echo "pull harvester-vm-import-controller: $VM_IMPORT_CONTROLLER_CHART_VERSION"
+helm pull https://github.com/harvester/charts/releases/download/harvester-vm-import-controller-${VM_IMPORT_CONTROLLER_CHART_VERSION}/harvester-vm-import-controller-${VM_IMPORT_CONTROLLER_CHART_VERSION}.tgz -d ${CHARTS_DIR}
+# make chart sanity check
+tar zxvf ${CHARTS_DIR}/harvester-vm-import-controller-${VM_IMPORT_CONTROLLER_CHART_VERSION}.tgz >/dev/null --warning=no-timestamp
 
-  # Prepare harvester-seeder-chart
-  echo "pull harvester-seeder: $HARVESTER_SEEDER_CHART_VERSION"
-  helm pull https://github.com/harvester/charts/releases/download/harvester-seeder-${HARVESTER_SEEDER_CHART_VERSION}/harvester-seeder-${HARVESTER_SEEDER_CHART_VERSION}.tgz -d ${CHARTS_DIR}
-  # make chart sanity check
-  tar zxvf ${CHARTS_DIR}/harvester-seeder-${HARVESTER_SEEDER_CHART_VERSION}.tgz >/dev/null --warning=no-timestamp
-else
-  echo "no harvester-vm-import-controller, harvester-pcidevices-controller, harvester-seeder charts for arm64"
-fi
+# Prepare pcidevices-chart
+echo "pull harvester-pcidevices-controller: $PCIDEVICES_CONTROLLER_CHART_VERSION"
+helm pull https://github.com/harvester/charts/releases/download/harvester-pcidevices-controller-${PCIDEVICES_CONTROLLER_CHART_VERSION}/harvester-pcidevices-controller-${PCIDEVICES_CONTROLLER_CHART_VERSION}.tgz -d ${CHARTS_DIR}
+# make chart sanity check
+tar zxvf ${CHARTS_DIR}/harvester-pcidevices-controller-${PCIDEVICES_CONTROLLER_CHART_VERSION}.tgz >/dev/null --warning=no-timestamp
+
+# Prepare harvester-seeder-chart
+echo "pull harvester-seeder: $HARVESTER_SEEDER_CHART_VERSION"
+helm pull https://github.com/harvester/charts/releases/download/harvester-seeder-${HARVESTER_SEEDER_CHART_VERSION}/harvester-seeder-${HARVESTER_SEEDER_CHART_VERSION}.tgz -d ${CHARTS_DIR}
+# make chart sanity check
+tar zxvf ${CHARTS_DIR}/harvester-seeder-${HARVESTER_SEEDER_CHART_VERSION}.tgz >/dev/null --warning=no-timestamp
 
 # Prepare nvidia-driver-toolkit chart
 helm pull https://github.com/harvester/charts/releases/download/nvidia-driver-runtime-${NVIDIA_DRIVER_RUNTIME_CHART_VERSION}/nvidia-driver-runtime-${NVIDIA_DRIVER_RUNTIME_CHART_VERSION}.tgz -d ${CHARTS_DIR}
@@ -229,16 +225,14 @@ for i in "${!repositories[@]}"; do
   echo "${repositories[$i]}:${tags[$i]}">>${image_list_file}
 done
 
-# skip addons for now for arm builds
-if [ ${ARCH} == "amd64" ]; then
-  # vm-import-controller: get images from values.yaml
-  echo ${VM_IMPORT_CONTROLLER_IMAGE} >>  ${image_list_file}
-  # pcidevices-controller images
-  echo ${PCIDEVICES_CONTROLLER_IMAGE} >> ${image_list_file}
 
-  # seeder images
-  echo ${HARVESTER_SEEDER_IMAGE} >> ${image_list_file}
-fi
+# vm-import-controller: get images from values.yaml
+echo ${VM_IMPORT_CONTROLLER_IMAGE} >>  ${image_list_file}
+# pcidevices-controller images
+echo ${PCIDEVICES_CONTROLLER_IMAGE} >> ${image_list_file}
+
+# seeder images
+echo ${HARVESTER_SEEDER_IMAGE} >> ${image_list_file}
 
 # harvester additional images, which is not in rancher images, not in harvester images or any others
 # do not add any comment line into this file, each line should be an valid image name


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
fix missing harvester addons in arm iso

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
PR removes the logic to only package harvester addons in amd64 images. This is now possible as during the move to GH actions, we enabled multi-arch builds for all the default addons.

**Related Issue:**
https://github.com/harvester/harvester/issues/6257
**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

