### PR TITLE
Change LH default settings to fix maintenance mode issues

### DIFF
--- a/pkg/config/templates/rancherd-10-harvester.yaml
+++ b/pkg/config/templates/rancherd-10-harvester.yaml
@@ -174,6 +174,8 @@ resources:
           {{- if .Harvester.Longhorn.DefaultSettings.GuaranteedInstanceManagerCPU }}
           guaranteedInstanceManagerCPU: {{ .Harvester.Longhorn.DefaultSettings.GuaranteedInstanceManagerCPU }}
           {{- end }}
+          detachManuallyAttachedVolumesWhenCordoned: true
+          nodeDrainPolicy: "allow-if-replica-is-stopped"
       harvester-network-controller:
         enabled: true
         vipEnabled: true


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
The Harvester maintenance mode is blocked by manually attached volumes and single-replica volumes.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Change LH default setting to allow node drain on such scenarios.

Refer:

https://github.com/longhorn/charts/blob/v1.6.x/charts/longhorn/values.yaml#L248

https://github.com/longhorn/charts/blob/ad73dc01239b7eeb25ff510ce8358578433d85a5/charts/longhorn/values.yaml#L250

**Related Issue:**
https://github.com/harvester/harvester/issues/6264
https://github.com/harvester/harvester/issues/6266

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
Per issue steps.

After a new installation, get such LH default settings:

```
default-data-path                                                 /var/lib/harvester/defaultdisk                    true      7m19s
...
detach-manually-attached-volumes-when-cordoned                    true                                              true      7m19s
...
node-drain-policy                                                 allow-if-replica-is-stopped                       true      7m19s
```


Following PRs:

- [ ] Upgrade https://github.com/harvester/harvester/pull/6276
- [ ] Document https://github.com/harvester/docs/pull/619

