### PR TITLE
build: add installer commit hash to /etc/harvester-release.yaml

### DIFF
--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -33,6 +33,7 @@ PRETTY_NAME="Harvester ${VERSION}"
 cat > harvester-release.yaml <<EOF
 harvester: ${HARVESTER_VERSION}
 harvesterChart: ${HARVESTER_CHART_VERSION}
+installer: ${COMMIT}
 os: ${PRETTY_NAME}
 kubernetes: ${RKE2_VERSION}
 rancher: ${RANCHER_VERSION}


### PR DESCRIPTION
**Problem:**
It's not always obvious exactly which version of the harvester-installer code is included in a given build.

**Solution:**
Add the harvester-installer commit hash to `/etc/harvester-release.yaml`. For release builds, this should give us something like the following:

```
os: Harvester v1.3 (ff64884)
```

For local dev builds, it's a bit redundant, but I don't think there's any harm in this:

```
os: Harvester 677447c-dirty (677447c)
```

**Related Issue:**
https://github.com/harvester/harvester/issues/6285

**Test plan:**
Run `cat /etc/harvester-release` and make sure the `os` line includes the harvester-installer commit hash in parentheses.

