### PR TITLE
fix: Installation stopped by "No default route found"

### DIFF
--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -2152,7 +2152,7 @@ func addInstallPanel(c *Console) error {
 				printToPanel(c.Gui, "Failed to check default route.", installPanel)
 				return
 			}
-			if !isDefaultRouteExist {
+			if !installModeOnly && !isDefaultRouteExist {
 				logrus.Error(ErrMsgNoDefaultRoute)
 				printToPanel(c.Gui, ErrMsgNoDefaultRoute, installPanel)
 				return


### PR DESCRIPTION
No need to check the default route if install binaries only.

**Problem:**
https://github.com/harvester/harvester/issues/6306

**Solution:**
Skip the default route check while install with method "Install Harvester binaries only".

**Related Issue:**
https://github.com/harvester/harvester/issues/6306

**Test plan:**
1. Boot from ISO
2. Select "Install Harvester binaries only"
3. Make disk settings and set password
4. Confirm installation pass w/o problem
