### PR TITLE
ci: Use correct dockerhub credential path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,8 +53,8 @@ jobs:
       uses: rancher-eio/read-vault-secrets@main
       with:
         secrets: |
-          secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
-          secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_PASSWORD ;
+          secret/data/github/repo/${{ github.repository }}/dockerhub/harvester/credentials username | DOCKER_USERNAME ;
+          secret/data/github/repo/${{ github.repository }}/dockerhub/harvester/credentials password | DOCKER_PASSWORD ;
           secret/data/github/repo/${{ github.repository }}/google-auth/harvester/credentials token | GOOGLE_AUTH ;
 
     - name: Login to Docker Hub


### PR DESCRIPTION
**Problem:**
https://github.com/harvester/harvester-installer/actions/runs/10316766319 failed.

**Solution:**
This PR, I hope.

**Related Issue:**
https://github.com/harvester/harvester/issues/6296

**Test plan:**
Merge this PR and make sure an ISO is published to releases.rancher.com.

