### PR TITLE
ci: Publish ISO images on branch push (v1.4)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,8 +112,8 @@ jobs:
       uses: rancher-eio/read-vault-secrets@main
       with:
         secrets: |
-          secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
-          secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_PASSWORD ;
+          secret/data/github/repo/${{ github.repository }}/dockerhub/harvester/credentials username | DOCKER_USERNAME ;
+          secret/data/github/repo/${{ github.repository }}/dockerhub/harvester/credentials password | DOCKER_PASSWORD ;
 
     - name: Login to Docker Hub
       uses: docker/login-action@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ env:
   # so wet just set it to master in this case.
   DRONE_BRANCH: ${{ endsWith(github.ref_name, '/merge') && 'master' || github.ref_name }}
 jobs:
-  build-iso-images:
+  build-iso:
     name: Build ISO Images
     strategy:
       matrix:
@@ -31,3 +31,104 @@ jobs:
     # Build ISO
     - name: Run make ci
       run: make ci
+
+    # Below is essentially duplicated from the main Harvester repo's
+    # .github/workflows/build.yml, except we're only publishing branches,
+    # not tags.
+
+    - name: Declare branch
+      run: |
+        echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> "$GITHUB_ENV"
+        if [ "${{ matrix.arch }}" == "x64" ]; then
+          echo "arch=amd64" >> "$GITHUB_ENV"
+        else
+          echo "arch=arm64" >> "$GITHUB_ENV"
+        fi
+
+    - name: Read Secrets
+      if: ${{ startsWith(github.ref, 'refs/heads/') }}
+      uses: rancher-eio/read-vault-secrets@main
+      with:
+        secrets: |
+          secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
+          secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_PASSWORD ;
+          secret/data/github/repo/${{ github.repository }}/google-auth/harvester/credentials token | GOOGLE_AUTH ;
+
+    - name: Login to Docker Hub
+      if: ${{ startsWith(github.ref, 'refs/heads/') }}
+      uses: docker/login-action@v3
+      with:
+        username: ${{ env.DOCKER_USERNAME }}
+        password: ${{ env.DOCKER_PASSWORD }}
+
+    # rancher/harvester-cluster-repo image
+    - name: docker-publish-harvester-cluster-repo
+      if: ${{ startsWith(github.ref, 'refs/heads/') }}
+      uses: docker/build-push-action@v5
+      with:
+        context: dist/harvester-cluster-repo
+        push: true
+        platforms: linux/${{ env.arch }}
+        tags: rancher/harvester-cluster-repo:${{ env.branch }}-head-${{ env.arch }}
+        file: dist/harvester-cluster-repo/Dockerfile
+
+    - name: Login to Google Cloud
+      if: ${{ startsWith(github.ref, 'refs/heads/') }}
+      uses: 'google-github-actions/auth@v2'
+      with:
+        credentials_json: '${{ env.GOOGLE_AUTH }}'
+
+    - name: upload-iso
+      uses: 'google-github-actions/upload-cloud-storage@v2'
+      if: ${{ startsWith(github.ref, 'refs/heads/') }}
+      with:
+        path: dist/artifacts
+        parent: false
+        destination: releases.rancher.com/harvester/${{ env.branch }}
+        predefinedAcl: publicRead
+        headers: |-
+          cache-control: public,no-cache,proxy-revalidate
+
+  manifest-cluster-repo-image:
+    name: Manifest harvester-cluster-repo image
+    runs-on: runs-on,runner=4cpu-linux-x64,run-id=${{ github.run_id }}
+    needs: build-iso
+    if: ${{ startsWith(github.ref, 'refs/heads/') }}
+    permissions:
+      contents: read
+      id-token: write # for reading credential https://github.com/rancher-eio/read-vault-secrets
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Declare branch
+      run: |
+        echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> "$GITHUB_ENV"
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Read Secrets
+      uses: rancher-eio/read-vault-secrets@main
+      with:
+        secrets: |
+          secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
+          secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_PASSWORD ;
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ env.DOCKER_USERNAME }}
+        password: ${{ env.DOCKER_PASSWORD }}
+
+    # rancher/harvester-cluster-repo image
+    - name: docker-pull-harvester-cluster-repo
+      if: ${{ startsWith(github.ref, 'refs/heads/') }}
+      run: |
+        docker pull --platform linux/amd64 rancher/harvester-cluster-repo:${{ env.branch }}-head-amd64
+        docker pull --platform linux/arm64 rancher/harvester-cluster-repo:${{ env.branch }}-head-arm64
+        docker buildx imagetools create -t rancher/harvester-cluster-repo:${{ env.branch }}-head \
+          rancher/harvester-cluster-repo:${{ env.branch }}-head-amd64 \
+          rancher/harvester-cluster-repo:${{ env.branch }}-head-arm64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,8 +53,8 @@ jobs:
       uses: rancher-eio/read-vault-secrets@main
       with:
         secrets: |
-          secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
-          secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_PASSWORD ;
+          secret/data/github/repo/${{ github.repository }}/dockerhub/harvester/credentials username | DOCKER_USERNAME ;
+          secret/data/github/repo/${{ github.repository }}/dockerhub/harvester/credentials password | DOCKER_PASSWORD ;
           secret/data/github/repo/${{ github.repository }}/google-auth/harvester/credentials token | GOOGLE_AUTH ;
 
     - name: Login to Docker Hub

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,11 +42,6 @@ jobs:
     - name: Declare branch
       run: |
         echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> "$GITHUB_ENV"
-        if [ "${{ matrix.arch }}" == "x64" ]; then
-          echo "arch=amd64" >> "$GITHUB_ENV"
-        else
-          echo "arch=arm64" >> "$GITHUB_ENV"
-        fi
 
     - name: Read Secrets
       if: ${{ startsWith(github.ref, 'refs/heads/') }}
@@ -71,8 +66,8 @@ jobs:
       with:
         context: dist/harvester-cluster-repo
         push: true
-        platforms: linux/${{ env.arch }}
-        tags: rancher/harvester-cluster-repo:${{ env.branch }}-head-${{ env.arch }}
+        platforms: linux/${{ matrix.arch }}
+        tags: rancher/harvester-cluster-repo:${{ env.branch }}-head-${{ matrix.arch }}
         file: dist/harvester-cluster-repo/Dockerfile
 
     - name: Login to Google Cloud

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,9 @@ jobs:
     # 77G disk, which is sufficient for ISO builds.
     # The VM runners are named "x64", not "amd64" like other docker things.
     runs-on: runs-on,runner=4cpu-linux-${{ matrix.arch == 'amd64' && 'x64' || matrix.arch }},hdd=50,run-id=${{ github.run_id }}
+    permissions:
+      contents: read
+      id-token: write # for reading credential https://github.com/rancher-eio/read-vault-secrets
     steps:
     - name: Checkout code
       uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
         secrets: |
           secret/data/github/repo/${{ github.repository }}/dockerhub/harvester/credentials username | DOCKER_USERNAME ;
           secret/data/github/repo/${{ github.repository }}/dockerhub/harvester/credentials password | DOCKER_PASSWORD ;
-          secret/data/github/repo/${{ github.repository }}/google-auth/harvester/credentials token | GOOGLE_AUTH ;
+          secret/data/github/repo/${{ github.repository }}/google-auth-key/credentials credential | GOOGLE_AUTH ;
 
     - name: Login to Docker Hub
       if: ${{ startsWith(github.ref, 'refs/heads/') }}


### PR DESCRIPTION
**Problem:**
ISOs are only published on pushes to the main harvester repo. Sometimes we need an ISO built when there's only been a change in harvester-installer, for example when doing testing of the head of one of the stable branches, or of master.

**Solution:**
Duplicate the relevant ISO publishing bits from https://github.com/harvester/harvester/blob/master/.github/workflows/build.yml

**Related Issue:**
https://github.com/harvester/harvester/issues/6296

**Test plan:**
Merge this PR and make sure an ISO is published to releases.rancher.com.