### PR TITLE
ci: drop arm64 from manifest-cluster-repo-image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,7 +125,5 @@ jobs:
       if: ${{ startsWith(github.ref, 'refs/heads/') }}
       run: |
         docker pull --platform linux/amd64 rancher/harvester-cluster-repo:${{ env.branch }}-head-amd64
-        docker pull --platform linux/arm64 rancher/harvester-cluster-repo:${{ env.branch }}-head-arm64
         docker buildx imagetools create -t rancher/harvester-cluster-repo:${{ env.branch }}-head \
-          rancher/harvester-cluster-repo:${{ env.branch }}-head-amd64 \
-          rancher/harvester-cluster-repo:${{ env.branch }}-head-arm64
+          rancher/harvester-cluster-repo:${{ env.branch }}-head-amd64


### PR DESCRIPTION
**Problem:**
https://github.com/harvester/harvester-installer/actions/runs/10381016633 failed

**Solution:**
This PR

**Related Issue:**
https://github.com/harvester/harvester/issues/6296

**Test plan:**
Merge this PR and make sure an the GHA completes successfully

