### PR TITLE
Patch Rancher shell image to v0.1.26

### DIFF
--- a/package/harvester-os/files/usr/share/rancher/rancherd/config.yaml.d/50-defaults.yaml
+++ b/package/harvester-os/files/usr/share/rancher/rancherd/config.yaml.d/50-defaults.yaml
@@ -11,4 +11,7 @@ rancherValues:
     cattle:
       psp:
         enabled: false
+  extraEnv:
+    - name: CATTLE_SHELL_IMAGE
+      value: "rancher/shell:v0.1.26"
 rancherInstallerImage: rancher/system-agent-installer-rancher:v2.8.5

--- a/scripts/images/rancher-images.txt
+++ b/scripts/images/rancher-images.txt
@@ -18,7 +18,6 @@ docker.io/rancher/mirrored-prometheus-alertmanager:v0.26.0
 docker.io/rancher/rancher-webhook:v0.4.7
 docker.io/rancher/rancher:v2.8.5
 docker.io/rancher/shell:v0.1.26
-docker.io/rancher/shell:v0.1.24
 docker.io/rancher/system-agent:v0.3.6-suc
 docker.io/rancher/system-upgrade-controller:v0.13.1
 docker.io/rancher/mirrored-banzaicloud-fluentd:v1.14.6-alpine-5


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

CVE

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Patch rancher initial shell image

**Related Issue:**

https://github.com/harvester/harvester/issues/6283

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. A newly installed cluster:

cluster is ready
![image](https://github.com/user-attachments/assets/e018dac0-2b6c-40a0-bac6-7692ccdc54e5)

2. Expected values are correct

```
$ cat /usr/share/rancher/rancherd/config.yaml.d/50-defaults.yaml
rancherValues:
  rancherImagePullPolicy: IfNotPresent
  rancherImage: rancher/rancher
  rancherImageTag: v2.8.5
  noDefaultAdmin: false
  features: multi-cluster-management=false,multi-cluster-management-agent=false
  useBundledSystemChart: true
  bootstrapPassword: admin
  hostPort: 0
  global:
    cattle:
      psp:
        enabled: false
  extraEnv:
    - name: CATTLE_SHELL_IMAGE
      value: "rancher/shell:v0.1.26"
rancherInstallerImage: rancher/system-agent-installer-rancher:v2.8.5

$ crictl image ls | grep shell
docker.io/rancher/shell                                                     v0.1.26                                     33dc949c57f81       304MB


$ cat /oem/harvester.config

...
runtimeversion: v1.28.12+rke2r1
rancherversion: v2.8.5
harvesterchartversion: 0.0.0-v1.3-ca72622e
monitoringchartversion: 103.0.3+up45.31.1
systemsettings:
    ntp-servers: '{"ntpServers":["0.suse.pool.ntp.org"]}'
loggingchartversion: 103.0.0+up3.17.10
$ kubectl get settings.management.cattle.io shell-image
NAME          VALUE
shell-image   rancher/shell:v0.1.26


harv21:/home/rancher # kubectl get settings.management.cattle.io shell-image -oyaml
apiVersion: management.cattle.io/v3
customized: false
default: rancher/shell:v0.1.24
kind: Setting
metadata:
  creationTimestamp: "2024-08-14T17:08:29Z"
  generation: 1
  name: shell-image
  resourceVersion: "1370"
  uid: e73fba98-d3f4-48b2-bf25-ed531ee69f46
source: env
value: rancher/shell:v0.1.26
```
