### PR TITLE
Fix rancher-monitoring missing images

### DIFF
--- a/scripts/images/rancher-images.txt
+++ b/scripts/images/rancher-images.txt
@@ -13,8 +13,8 @@ docker.io/rancher/mirrored-prometheus-adapter-prometheus-adapter:v0.10.0
 docker.io/rancher/mirrored-prometheus-node-exporter:v1.3.1
 docker.io/rancher/mirrored-prometheus-operator-prometheus-config-reloader:v0.65.1
 docker.io/rancher/mirrored-prometheus-operator-prometheus-operator:v0.65.1
-docker.io/rancher/mirrored-prometheus-prometheus:v2.45.0
-docker.io/rancher/mirrored-prometheus-alertmanager:v0.26.0
+docker.io/rancher/mirrored-prometheus-prometheus:v2.42.0
+docker.io/rancher/mirrored-prometheus-alertmanager:v0.25.0
 docker.io/rancher/rancher-webhook:v0.4.7
 docker.io/rancher/rancher:v2.8.5
 docker.io/rancher/shell:v0.1.26


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

v1.3-rc2 air-gapped ENV encountered such issue:

![image](https://github.com/user-attachments/assets/90fc00a4-f6ec-4968-a809-225551ef8155)


missing images:
```
rancher/mirrored-prometheus-alertmanager:v0.25.0
mirrored-prometheus-prometheus:v2.42.0
```
**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

PR https://github.com/harvester/harvester-installer/pull/793 happend to update following images, they are related to `rancher-monitoring` stack not `Rancher`.
```
docker.io/rancher/mirrored-prometheus-prometheus:v2.45.0
docker.io/rancher/mirrored-prometheus-alertmanager:v0.26.0
```

Revert them.

**Related Issue:**

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

`Rancher-monitoring` addon can be enabled successfully on air-gapped env.