### PR TITLE
external disk support enhancements - disable multipath by default

### DIFF
--- a/pkg/console/util.go
+++ b/pkg/console/util.go
@@ -50,6 +50,7 @@ You can see the full installation log by:
 
 	ElementalConfigDir  = "/tmp/elemental"
 	ElementalConfigFile = "config.yaml"
+	multipathOff        = "multipath=off"
 )
 
 func newProxyClient() http.Client {
@@ -504,6 +505,9 @@ func doInstall(g *gocui.Gui, hvstConfig *config.HarvesterConfig, webhooks Render
 		env = append(env, fmt.Sprintf("HARVESTER_DATA_DISK=%s", hvstConfig.DataDisk))
 	}
 
+	if !hvstConfig.OS.ExternalStorage.Enabled {
+		env = append(env, fmt.Sprintf("HARVESTER_ADDITIONAL_KERNEL_ARGUMENTS=%s", multipathOff))
+	}
 	if hvstConfig.OS.AdditionalKernelArguments != "" {
 		env = append(env, fmt.Sprintf("HARVESTER_ADDITIONAL_KERNEL_ARGUMENTS=%s", hvstConfig.OS.AdditionalKernelArguments))
 	}


### PR DESCRIPTION
minor change to disable multipath via kernel arguments when no exteral storage config is present. 

This ensures initrd does not load it before switching rootfs and avoids unwanted side effect of /dev/mapper devices for disks being created

**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
to enable multipathd on boot disks as part of the external disk support, multipathd has been enabled by default in initrd.

when multipath is not needed, initrd still loads multipathd, which gets shutdown during switching of rootfs

```
# journalctl --since 05:37:02|grep -i 'multipath\|switch root'
Sep 05 05:37:05 localhost systemd[1]: Starting Device-Mapper Multipath Device Controller...
Sep 05 05:37:05 localhost systemd-modules-load[306]: Inserted module 'dm_multipath'
Sep 05 05:37:05 localhost multipathd[317]: multipathd v0.9.4+117+suse.87f2634: start up
Sep 05 05:37:05 localhost multipathd[317]: reconfigure: setting up paths and maps
Sep 05 05:37:05 localhost systemd[1]: Started Device-Mapper Multipath Device Controller.
Sep 05 05:37:09 localhost multipathd[317]: sda: setting scsi timeouts is unsupported for protocol scsi:unspec
Sep 05 05:37:09 localhost multipathd[317]: 35000c50015ac3bd9: addmap [0 41943040 multipath 0 0 1 1 service-time 0 1 1 8:0 1]
Sep 05 05:37:09 localhost kernel: device-mapper: multipath service-time: version 0.3.0 loaded
Sep 05 05:37:09 localhost multipathd[317]: sda [8:0]: path added to devmap 35000c50015ac3bd9
Sep 05 05:37:09 localhost systemd[1]: Stopping Device-Mapper Multipath Device Controller...
Sep 05 05:37:09 localhost multipathd[317]: multipathd: shut down
Sep 05 05:37:09 localhost systemd[1]: multipathd.service: Deactivated successfully.
Sep 05 05:37:09 localhost systemd[1]: Stopped Device-Mapper Multipath Device Controller.
Sep 05 05:37:11 localhost systemd[1]: Starting Elemental system initramfs setup before switch root...
Sep 05 05:37:11 harvester-node-0 systemd[1]: Finished Elemental system initramfs setup before switch root.
Sep 05 05:37:11 harvester-node-0 systemd[1]: Stopped Elemental system initramfs setup before switch root.
Sep 05 05:37:11 harvester-node-0 systemd[1]: Reached target Switch Root.
Sep 05 05:37:11 harvester-node-0 systemd[1]: Starting Switch Root...
Sep 05 05:37:11 harvester-node-0 systemd[1]: Stopped Switch Root.
Sep 05 05:37:11 harvester-node-0 systemd[1]: Stopped target Switch Root.
```

As a result it can cause unintended consequences when non multipath disks get picked up and a /dev/mapper device gets setup and NDM picks up the mapper device

```
# kubectl get bds -A
NAMESPACE         NAME                               TYPE   DEVPATH     MOUNTPOINT   NODENAME           PROVISIONPHASE   AGE
longhorn-system   989754e4e66edadfd3390974a1aba3f8   disk   /dev/dm-0                harvester-node-0   Unprovisioned    15m
```

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Minor change to add default third party kernel argument of `multipath=off` when external disk support is not enabled
**Related Issue:**

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

