### PR TITLE
chore: Configure Mergify to open backport PRs by labels [skip ci]

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -25,3 +25,36 @@ pull_request_rules:
   actions:
     comment:
       message: This pull request is now in conflict. Could you fix it @{{author}}? 🙏
+
+- name: Automatically open v1.4 backport PR
+  conditions:
+    - base=master
+    - label="backport-to/v1.4"
+  actions:
+    backport:
+      branches:
+        - v1.4
+      assignees:
+        - "{{ author }}"
+
+- name: Automatically open v1.3 backport PR
+  conditions:
+    - base=master
+    - label="backport-to/v1.3"
+  actions:
+    backport:
+      branches:
+        - v1.3
+      assignees:
+        - "{{ author }}"
+
+- name: Automatically open v1.2 backport PR
+  conditions:
+    - base=master
+    - label="backport-to/v1.2"
+  actions:
+    backport:
+      branches:
+        - v1.2
+      assignees:
+        - "{{ author }}"


### PR DESCRIPTION
Use Mergify to automatically create backport PRs according to `backport-to/<branch>` labels.

