### PR TITLE
Bump eventrouter to v0.3.2 with bci 15.6

### DIFF
--- a/scripts/build-bundle
+++ b/scripts/build-bundle
@@ -48,7 +48,7 @@ update_monitoring_logging_version() {
 
   # the harvester-eventrouter image tag is first bumped on installer, then on addon, to decouple the PRs
   # if ENV includes keyword `IMAGE` then `addon generateTemplates` will strip the image and only keep version
-  local HARVESTER_EVENTROUTER_FULL_TAG="rancher/harvester-eventrouter:v0.3.1"
+  local HARVESTER_EVENTROUTER_FULL_TAG="rancher/harvester-eventrouter:v0.3.2"
   local henew="HARVESTER_EVENTROUTER_FULL_TAG=\"${HARVESTER_EVENTROUTER_FULL_TAG}\""
   local hecur=$(grep $henew $target) || echo "harvester-eventrouter image tag is not found from $target"
   if [ -z "${hecur}" ]; then


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Bump eventrouter image base from bci 15.5 to 15.6

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Bump eventrouter image base from bci 15.5 to 15.6

**Related Issue:**
https://github.com/harvester/harvester/issues/6568

container image bump: https://github.com/harvester/eventrouter/pull/12

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
1. Install new cluster
2. Enable rancher-logging addon
3. check eventrouter pod is normally running with tag v0.3.2
4.  it's pod log (`kubectl logs -n cattle-logging-system harvester-default-event-tailer-0`) has things like
>{"verb":"ADDED","event":{"metadata":{"name":"pvc-99b647d2-d7d0-46d1-998a-13a3cf3a8f02.17f64d4708a92b3c","namespace":"longhorn-system","uid":"9cc92ef2-77ac-48ac-af74-c5e576664456","resourceVersion":"287702","creationTimestamp":"2024-09-18T09:41:14Z","managedFields":[{"manager":"longhorn-manager","operation":"Update","apiVersion":"v1","time":"2024-09-18T09:41:14Z","fieldsType":"FieldsV1","fieldsV1":{"f:count":{},"f:firstTimestamp":{},"f:involvedObject":{},"f:lastTimestamp":{},"f:message":{},"f:reason":{},"f:reportingComponent":{},"f:source":{"f:component":{}},"f:type":{}}}]},"involvedObject":{"kind":"Volume","namespace":"longhorn-system","name":"pvc-99b647d2-d7d0-46d1-998a-13a3cf3a8f02","uid":"69a70ed3-ca31-4863-b64c-ed7d0359224f","apiVersion":"longhorn.io/v1beta2","resourceVersion":"287636"},"reason":"Degraded","message":"volume pvc-99b647d2-d7d0-46d1-998a-13a3cf3a8f02 became degraded","source":{"component":"longhorn-volume-controller"},"firstTimestamp":"2024-09-18T09:41:14Z","lastTimestamp":"2024-09-18T09:41:14Z","count":1,"type":"Normal","eventTime":null,"reportingComponent":"longhorn-volume-controller","reportingInstance":""}}
