### PR TITLE
chore: bump bci image to 15.6

### DIFF
--- a/package/harvester-repo/Dockerfile
+++ b/package/harvester-repo/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/bci-base:15.5
+FROM registry.suse.com/bci/bci-base:15.6
 
 RUN zypper -n rm container-suseconnect && \
     zypper -n in nginx && \


### PR DESCRIPTION
**Related Issue:**
https://github.com/harvester/harvester/issues/6568