### PR TITLE
[v1.3]Bump eventrouter to v0.3.2 with BCI 15.6

### DIFF
--- a/pkg/config/templates/rancherd-22-addons.yaml
+++ b/pkg/config/templates/rancherd-22-addons.yaml
@@ -91,7 +91,7 @@ resources:
           controlNamespace: cattle-logging-system
           workloadOverrides:
             containers:
-            - image: rancher/harvester-eventrouter:v0.2.0
+            - image: rancher/harvester-eventrouter:v0.3.2
               name: event-tailer
               resources:
                 limits:


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
BCI 15.5 is EOL in the end of the year, related images need to be bumped to BCI 15.6.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

This is a munual backport to v1.3 of PR https://github.com/harvester/harvester-installer/pull/839.

The addon source code and image version organizations are changed on v1.4.

**Related Issue:**
https://github.com/harvester/harvester/issues/6568

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

per https://github.com/harvester/harvester-installer/pull/839