### PR TITLE
Use nginx user in harvester-cluster-repo image

### DIFF
--- a/package/harvester-repo/Dockerfile
+++ b/package/harvester-repo/Dockerfile
@@ -8,6 +8,12 @@ RUN zypper -n rm container-suseconnect && \
 
 COPY charts /srv/www/htdocs/charts
 
+RUN touch /run/nginx.pid && \
+    chown nginx:nginx /run/nginx.pid && \
+    chown -R nginx:nginx /srv/www/htdocs/charts
+
+USER nginx
+
 EXPOSE 80
 
 STOPSIGNAL SIGQUIT


### PR DESCRIPTION
**Problem:**
This is an enhancement, use nginx instead of root user in harvester-cluster-repo image.

**Solution:**
Use nginx user in harvester-cluster-repo

**Related Issue:**

**Test plan:**
1. `make ci` to build iso, and prepare a single node harvester cluster (easy for testing)
2. Enable addon (e.g. `pcidevices-controller`) and the addon could be successfully installed.
