### PR TITLE
add /lib/firmware to list of RW filesystems

### DIFF
--- a/pkg/config/templates/cos-rootfs.yaml
+++ b/pkg/config/templates/cos-rootfs.yaml
@@ -5,7 +5,7 @@ environment_file: /run/cos/cos-layout.env
 environment:
   VOLUMES: "LABEL=COS_OEM:/oem LABEL=COS_PERSISTENT:/usr/local{{ if .ShouldMountDataPartition }} LABEL=HARV_LH_DEFAULT:/var/lib/harvester/defaultdisk{{ end }}"
   OVERLAY: "tmpfs:25%"
-  RW_PATHS: "/var /etc /srv /boot"
+  RW_PATHS: "/var /etc /srv /boot /lib/firmware"
   PERSISTENT_STATE_PATHS: >-
     /etc/systemd
     /etc/rancher


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Currently /lib is mounted directly from the image file, and is readonly filesystem.

For certain driver packages, such as nvidia, a firmware file is needed which needs to be written to /lib/firmware for the driver and GPU to perform correctly. This currently fails, and attempts to leverage https://www.kernel.org/doc/html/v4.18/driver-api/firmware/fw_search_path.html does not seem to result in the correct behaviour.

The PR makes `/lib/firmware` to be remounted as an overlay fs, allowing temporary changes to be stored for drivers to function correctly.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Related Issue:**
https://github.com/harvester/harvester/issues/6487

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

