### PR TITLE
fine tune logic to filter disks

### DIFF
--- a/pkg/console/util.go
+++ b/pkg/console/util.go
@@ -1039,9 +1039,11 @@ func identifyUniqueDisks(output []byte) ([]string, error) {
 				if !ok {
 					dedupMap[disk.Serial] = disk
 				}
-				continue
 			}
 
+			// disks may have same serial number but different wwn when used with a raid array
+			// as evident in test data from a host with a raid array
+			// in this case if serial number is same, we still check for unique wwn
 			if disk.WWN != "" {
 				_, ok := dedupMap[disk.WWN]
 				if !ok {

--- a/pkg/console/util_test.go
+++ b/pkg/console/util_test.go
@@ -587,6 +587,128 @@ const (
    ]
 }
 `
+	raidDisks = `{
+   "blockdevices": [
+      {
+         "name": "loop0",
+         "size": "780.5M",
+         "type": "loop",
+         "wwn": null,
+         "serial": null
+      },{
+         "name": "sda",
+         "size": "447.1G",
+         "type": "disk",
+         "wwn": "0x600508b1001cec28a12a38168f7bb195",
+         "serial": "PDNMF0ARH1614W",
+         "children": [
+            {
+               "name": "3600508b1001cec28a12a38168f7bb195",
+               "size": "447.1G",
+               "type": "mpath",
+               "wwn": null,
+               "serial": null
+            }
+         ]
+      },{
+         "name": "sdb",
+         "size": "447.1G",
+         "type": "disk",
+         "wwn": "0x600508b1001c3e956986e526698cd830",
+         "serial": "PDNMF0ARH1614W",
+         "children": [
+            {
+               "name": "sdb1",
+               "size": "1M",
+               "type": "part",
+               "wwn": "0x600508b1001c3e956986e526698cd830",
+               "serial": null
+            },{
+               "name": "sdb2",
+               "size": "50M",
+               "type": "part",
+               "wwn": "0x600508b1001c3e956986e526698cd830",
+               "serial": null
+            },{
+               "name": "sdb3",
+               "size": "8G",
+               "type": "part",
+               "wwn": "0x600508b1001c3e956986e526698cd830",
+               "serial": null
+            },{
+               "name": "sdb4",
+               "size": "15G",
+               "type": "part",
+               "wwn": "0x600508b1001c3e956986e526698cd830",
+               "serial": null
+            },{
+               "name": "sdb5",
+               "size": "170G",
+               "type": "part",
+               "wwn": "0x600508b1001c3e956986e526698cd830",
+               "serial": null
+            },{
+               "name": "sdb6",
+               "size": "254G",
+               "type": "part",
+               "wwn": "0x600508b1001c3e956986e526698cd830",
+               "serial": null
+            },{
+               "name": "3600508b1001c3e956986e526698cd830",
+               "size": "447.1G",
+               "type": "mpath",
+               "wwn": null,
+               "serial": null,
+               "children": [
+                  {
+                     "name": "3600508b1001c3e956986e526698cd830-part1",
+                     "size": "1M",
+                     "type": "part",
+                     "wwn": null,
+                     "serial": null
+                  },{
+                     "name": "3600508b1001c3e956986e526698cd830-part2",
+                     "size": "50M",
+                     "type": "part",
+                     "wwn": null,
+                     "serial": null
+                  },{
+                     "name": "3600508b1001c3e956986e526698cd830-part3",
+                     "size": "8G",
+                     "type": "part",
+                     "wwn": null,
+                     "serial": null
+                  },{
+                     "name": "3600508b1001c3e956986e526698cd830-part4",
+                     "size": "15G",
+                     "type": "part",
+                     "wwn": null,
+                     "serial": null
+                  },{
+                     "name": "3600508b1001c3e956986e526698cd830-part5",
+                     "size": "170G",
+                     "type": "part",
+                     "wwn": null,
+                     "serial": null
+                  },{
+                     "name": "3600508b1001c3e956986e526698cd830-part6",
+                     "size": "254G",
+                     "type": "part",
+                     "wwn": null,
+                     "serial": null
+                  }
+               ]
+            }
+         ]
+      },{
+         "name": "sr0",
+         "size": "1024M",
+         "type": "rom",
+         "wwn": null,
+         "serial": "475652914613"
+      }
+   ]
+}`
 )
 
 func Test_identifyUniqueDisksWithSerialNumber(t *testing.T) {
@@ -608,4 +730,11 @@ func Test_identifyUniqueDisksOnExistingInstalls(t *testing.T) {
 	result, err := identifyUniqueDisks([]byte(preInstalledMultiPath))
 	assert.NoError(err, "expected no error while parsing disk data")
 	assert.Len(result, 1, "expected to find 1 disk only")
+}
+
+func Test_identifyUniqueDisks(t *testing.T) {
+	assert := require.New(t)
+	out, err := identifyUniqueDisks([]byte(raidDisks))
+	assert.NoError(err, "expected no error while parsing disk data")
+	t.Log(out)
 }


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Logic disks managed by the raid controller will have the same serial number. This results in disks being deduplicated and ignored.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
From the sample data available the wwn is unique despite the serial number being the same. 

The PR adds a minor tweak to continue comparing disks even if serial number is same and check for wwn uniqueness.

**Related Issue:**
https://github.com/harvester/harvester/issues/6694
**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

