### PR TITLE
fix(dashboard_panels): change to check ready condition in managedchart

### DIFF
--- a/pkg/console/dashboard_panels.go
+++ b/pkg/console/dashboard_panels.go
@@ -453,7 +453,7 @@ func k8sIsReady() bool {
 }
 
 func chartIsInstalled() bool {
-	cmd := exec.Command("/bin/sh", "-c", `kubectl -n fleet-local get ManagedChart harvester -o jsonpath='{.status.conditions}' | jq 'map(select(.type == "Processed" and .status == "True")) | length'`)
+	cmd := exec.Command("/bin/sh", "-c", `kubectl -n fleet-local get ManagedChart harvester -o jsonpath='{.status.conditions}' | jq 'map(select(.type == "Ready" and .status == "True")) | length'`)
 	cmd.Env = os.Environ()
 	output, err := cmd.Output()
 	outStr := string(output)


### PR DESCRIPTION
**Problem:**
In Fleet v0.10.2, it changes to set Ready condition. However, we checked Processed condition.

https://github.com/rancher/fleet/blob/decbf9ae72eff096b2bee5efe05a92fdcbd5627d/internal/cmd/controller/reconciler/bundle_controller.go#L250

**Solution:**
Change command to check Ready condition.

**Related Issue:**
https://github.com/harvester/harvester/issues/6690

**Test plan:**
1. Create a Harvester cluster.
2. When Harvester is ready, check dashboard show "Ready".

<img width="958" alt="Screenshot 2024-10-07 at 10 39 25 AM" src="https://github.com/user-attachments/assets/669767d8-c3c9-4d9b-b900-bc580101fac1">
