### PR TITLE
templates: add harvester-networkfs-manager

### DIFF
--- a/pkg/config/templates/rancherd-10-harvester.yaml
+++ b/pkg/config/templates/rancherd-10-harvester.yaml
@@ -181,6 +181,10 @@ resources:
         vipEnabled: true
         image:
           pullPolicy: "IfNotPresent"
+      harvester-networkfs-manager:
+        enabled: true
+        image:
+          pullPolicy: "IfNotPresent"
       harvester-node-disk-manager:
         enabled: true
         image:


### PR DESCRIPTION
**Problem:**
We need harvester-networkfs-manager pod enabled by default.

**Solution:**
Add corresponding config on harvester managedchart

**Related Issue:**

**Test plan:**
make sure the harvester-networkfs-manager is running by default
