### PR TITLE
added `standalone` config option for `automatic` installations

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -142,6 +142,7 @@ type HarvesterChartValues struct {
 
 type Install struct {
 	Automatic           bool    `json:"automatic,omitempty"`
+	Standalone          bool    `json:"standalone,omitempty"`
 	SkipChecks          bool    `json:"skipchecks,omitempty"`
 	Mode                string  `json:"mode,omitempty"`
 	ManagementInterface Network `json:"managementInterface,omitempty"`

--- a/pkg/console/validator.go
+++ b/pkg/console/validator.go
@@ -420,7 +420,7 @@ func commonCheck(cfg *config.HarvesterConfig) error {
 		return prettyError(ErrMsgModeUnknown, mode)
 	}
 
-	if !alreadyInstalled && cfg.Install.Mode != config.ModeInstall && cfg.Install.Automatic && cfg.Install.ISOURL == "" {
+	if !alreadyInstalled && cfg.Install.Mode != config.ModeInstall && cfg.Install.Automatic && !cfg.Install.Standalone && cfg.Install.ISOURL == "" {
 		return errors.New(ErrMsgISOURLNotSpecified)
 	}
 


### PR DESCRIPTION
**Problem:**
- **Use Case:** is being able to install and deploy `harvester` without any existing infrastructure and no users with the technical ability to do it manually or troubleshoot. 
- **TLDR:** server arrives and user plugs in `USB` with `harvester` on it.
- **Technical Problem:** Unable to complete an `harvester.install.automatic=true` install of `harvester` using the `ISO` due to `harvester.install.automatic=true` requiring the `harvester.install.isoUrl=<isoUrl>` which starts a process follow in `harv-install` geared towards `PXE` installs.


**Solution:**
- Added an additional configuration option of `harvester.install.standalone=true`, which is defaulted `false` for backwards compatibility, to include an additional check to bypass the `harvester.install.isoUrl=<isoUrl>` requirement when using `harvester.install.automatic=true`.
- Happy to modify the configuration option name of `standalone` to something else... we debated something like `harvester.install.automatic.mode=PXE/CD` or something similar...


**Related Issue:**
- https://github.com/harvester/harvester-installer/blob/master/package/harvester-os/files/usr/sbin/harv-install
- https://github.com/harvester/harvester-installer/blob/f8a05d73c1d54bf1b6aa9654798d8a8fb45a2068/pkg/console/validator.go#L423


**Test Plan:**
- Create bootable `CD` or `USB` with `harvester`
- Add the following kernel arguments and wait for `harvester` to boot up...
- `$linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 rd.cos.disable net.ifnames=1 ${extra_iso_cmdline} ip=<ip>::<gateway>:<subnet>:<hostname>:<interface>:none harvester.scheme_version=1 harvester.install.automatic=true harvester.install.standalone=true harvester.install.skipchecks=true harvester.install.mode=create harvester.install.management_interface.method=static harvester.install.management_interface.interfaces='name:<interface>' harvester.install.management_interface.ip=<ip> harvester.install.management_interface.subnetMask=<subnet> harvester.install.management_interface.gateway=<gateway> harvester.install.management_interface.default_route=true harvester.token=Pa22word harvester.os.hostname=<hostname> harvester.os.password=Pa22word harvester.os.ntpServers=<ntp> harvester.os.ntpServers=<ntp> harvester.os.dnsNameservers=<dns> harvester.os.dnsNameservers=<dns> harvester.install.device=/dev/<disk> harvester.install.vip=<vip ip> harvester.install.vipMode=static
`



