### PR TITLE
Fix Default Route check when not using DHCP

### DIFF
--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -1420,7 +1420,7 @@ func addNetworkPanel(c *Console) error {
 		if err != nil {
 			return fmt.Sprintf("Failed to check default route: %s.", err.Error()), nil
 		}
-		if !isDefaultRouteExist {
+		if !isDefaultRouteExist && mgmtNetwork.Method == config.NetworkMethodDHCP {
 			return ErrMsgNoDefaultRoute, nil
 		}
 
@@ -2404,7 +2404,7 @@ func addInstallPanel(c *Console) error {
 				printToPanel(c.Gui, "Failed to check default route.", installPanel)
 				return
 			}
-			if !installModeOnly && !isDefaultRouteExist {
+			if !installModeOnly && !isDefaultRouteExist && c.config.Install.ManagementInterface.Method == config.NetworkMethodDHCP {
 				logrus.Error(ErrMsgNoDefaultRoute)
 				printToPanel(c.Gui, ErrMsgNoDefaultRoute, installPanel)
 				return


### PR DESCRIPTION
**Problem:**
#725 introduces a bug wherein if an automated deployment (after a binaries-only installation) using user-data is initiated and does not use DHCP, the installation fails with the error "No default route found. Please check the router setting on the DHCP server" regardless of the "Gateway" settings.  This is because the check is performed before a static network is set up.

**Solution:**
Add a couple of "if" checks to determine if this is a DHCP installation.  If not, skip the default route check.

**Related Issue:**
#725 #734 

**Test plan:**
Using this user-data file on an attached CDROM or USB stick, successfully perform an automated install:

```
#cloud-config
token: token
os:
  ssh_authorized_keys:
    - ssh-rsa ...        # replace with your public key
  password: p@ssword   # replace with a your password
  ntp_servers:
    - 0.suse.pool.ntp.org
    - 1.suse.pool.ntp.org
install:
  mode: create
  automatic: true
  networks:
  management_interface:
    interfaces:
      - name: ens0
      - name: ens3
    method: static
    ip: 1.2.3.4
    gateway: 1.2.3.1
    subnet_mask: 255.255.255.0
  vipMode: static
  vip: 2.3.4.5
```