### PR TITLE
fix: DHCP fails with a VLAN ID

### DIFF
--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -1399,7 +1399,7 @@ func addNetworkPanel(c *Console) error {
 		c.config.ManagementInterface = mgmtNetwork
 
 		if mgmtNetwork.Method == config.NetworkMethodDHCP {
-			addr, err := getIPThroughDHCP(config.MgmtInterfaceName)
+			addr, err := getIPThroughDHCP(getManagementInterfaceName(mgmtNetwork))
 			if err != nil {
 				return fmt.Sprintf("Requesting IP through DHCP failed: %s", err.Error()), nil
 			}
@@ -2602,14 +2602,14 @@ func configureInstallModeDHCP(c *Console) {
 		printToPanel(c.Gui, fmt.Sprintf("error applying network configuration: %s", err.Error()), installPanel)
 	}
 
-	_, err = getIPThroughDHCP(config.MgmtInterfaceName)
+	_, err = getIPThroughDHCP(getManagementInterfaceName(mgmtNetwork))
 	if err != nil {
 		printToPanel(c.Gui, fmt.Sprintf("error getting DHCP address: %s", err.Error()), installPanel)
 	}
 
 	// if need vip via dhcp
 	if c.config.Install.VipMode == config.NetworkMethodDHCP {
-		vip, err := getVipThroughDHCP(config.MgmtInterfaceName)
+		vip, err := getVipThroughDHCP(getManagementInterfaceName(mgmtNetwork))
 		if err != nil {
 			printToPanel(c.Gui, fmt.Sprintf("fail to get vip: %s", err), installPanel)
 			return

--- a/pkg/console/vip.go
+++ b/pkg/console/vip.go
@@ -80,6 +80,7 @@ func getVipThroughDHCP(iface string) (*vipAddr, error) {
 }
 
 func getIPThroughDHCP(iface string) (net.IP, error) {
+	logrus.Infof("Get IP through DHCP via interface %s", iface)
 	broadcast, err := nclient4.New(iface)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Management interface with a VLAN ID fails to do DHCP configuration in the interactive installation. The testing traffic is sent without a VLAN ID.


**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
We should send the traffic via the `mgmt-br.<vlan_id>` interface.

**Related Issue:**

- https://github.com/harvester/harvester/issues/6959
- https://github.com/harvester/harvester/issues/3428

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

- Boot ISO
- make sure not DHCPD in vlan1 or non-vlan network.
- When configuring the management interface, select a VLAN ID and use DHCP protocol.
