### PR TITLE
Sure DHCP will work on VLAN interface if VLAN is configured

### DIFF
--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -136,6 +136,7 @@ func (c *Console) doRun() error {
 	defer c.Close()
 
 	dashboard := c.layoutInstall
+	preflightCheck := true
 
 	if hd, _ := os.LookupEnv("HARVESTER_DASHBOARD"); hd == "true" {
 		if err := c.getHarvesterConfig(); err != nil {
@@ -143,6 +144,9 @@ func (c *Console) doRun() error {
 		}
 		if c.config.Install.Mode == config.ModeCreate || c.config.Install.Mode == config.ModeJoin {
 			dashboard = c.layoutDashboard
+			// no need to do preflight check after the node is installed, it runs layoutDashboard directly
+			// preflightWarnings are used in layoutInstall
+			preflightCheck = false
 		}
 	}
 
@@ -151,9 +155,10 @@ func (c *Console) doRun() error {
 		logrus.Info("harvester already installed")
 		alreadyInstalled = true
 		c.config.Install.Mode = ""
+		preflightCheck = false
 	}
 
-	if !alreadyInstalled {
+	if preflightCheck {
 		checks := []preflight.Check{
 			preflight.CPUCheck{},
 			preflight.MemoryCheck{},

--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -1399,7 +1399,7 @@ func addNetworkPanel(c *Console) error {
 		c.config.ManagementInterface = mgmtNetwork
 
 		if mgmtNetwork.Method == config.NetworkMethodDHCP {
-			addr, err := getIPThroughDHCP(config.MgmtInterfaceName)
+			addr, err := getIPThroughDHCP(getManagementInterfaceName(c.config.ManagementInterface))
 			if err != nil {
 				return fmt.Sprintf("Requesting IP through DHCP failed: %s", err.Error()), nil
 			}
@@ -2602,14 +2602,14 @@ func configureInstallModeDHCP(c *Console) {
 		printToPanel(c.Gui, fmt.Sprintf("error applying network configuration: %s", err.Error()), installPanel)
 	}
 
-	_, err = getIPThroughDHCP(config.MgmtInterfaceName)
+	_, err = getIPThroughDHCP(getManagementInterfaceName(c.config.ManagementInterface))
 	if err != nil {
 		printToPanel(c.Gui, fmt.Sprintf("error getting DHCP address: %s", err.Error()), installPanel)
 	}
 
 	// if need vip via dhcp
 	if c.config.Install.VipMode == config.NetworkMethodDHCP {
-		vip, err := getVipThroughDHCP(config.MgmtInterfaceName)
+		vip, err := getVipThroughDHCP(getManagementInterfaceName(c.config.ManagementInterface))
 		if err != nil {
 			printToPanel(c.Gui, fmt.Sprintf("fail to get vip: %s", err), installPanel)
 			return

--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -2095,8 +2095,7 @@ func addInstallPanel(c *Console) error {
 			}
 
 			if needToGetVIPFromDHCP(c.config.VipMode, c.config.Vip, c.config.VipHwAddr) {
-				mgmtName := getManagementInterfaceName(c.config.ManagementInterface)
-				vip, err := getVipThroughDHCP(mgmtName)
+				vip, err := getVipThroughDHCP(getManagementInterfaceName(c.config.ManagementInterface))
 				if err != nil {
 					printToPanel(c.Gui, fmt.Sprintf("fail to get vip: %s", err), installPanel)
 					return
@@ -2265,8 +2264,7 @@ func addVIPPanel(c *Console) error {
 			spinner := NewSpinner(c.Gui, vipTextPanel, "Requesting IP through DHCP...")
 			spinner.Start()
 			go func(g *gocui.Gui) {
-				mgmtName := getManagementInterfaceName(c.config.ManagementInterface)
-				vip, err := getVipThroughDHCP(mgmtName)
+				vip, err := getVipThroughDHCP(getManagementInterfaceName(c.config.ManagementInterface))
 				if err != nil {
 					spinner.Stop(true, err.Error())
 					g.Update(func(_ *gocui.Gui) error {
@@ -2592,6 +2590,7 @@ func configureInstallModeDHCP(c *Console) {
 		mgmtNetwork.BondOptions = netDef.BondOptions
 	}
 	mgmtNetwork.Method = netDef.Method
+	mgmtNetwork.VlanID = netDef.VlanID
 
 	_, err := applyNetworks(
 		mgmtNetwork,


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

DHCP looks to have flaws with VLAN interfaces.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Sure the DHCP is working on VLAN interface if VLAN is configured.

This PR has 3 commits:
```
(1) Use VLAN interface if VLAN is configured to do DHCP
(2) Avoid preflight check if node goes to dashboard directly
(3) Pass VID
```

PR https://github.com/harvester/harvester-installer/pull/878 is merged to this one.

Co-authored-by: Kiefer Chang <kiefer.chang@suse.com>

**Related Issue:**

https://github.com/harvester/harvester/issues/6959
https://github.com/harvester/harvester/issues/3428

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

Per issue description


**Local test:**

Installer with this fix, the DHCP discovery frame is encaped with VLAN 100 ( and we did not set a DHCP server on VLAN 100)
![image](https://github.com/user-attachments/assets/633d4c0f-2335-469e-861a-a8b130c2623c)

Original installer without this fix, the DHCP discovery frame is NOT encaped with VLAN 100
![image](https://github.com/user-attachments/assets/3897adf2-cd2a-4267-90c6-c54aa6f6cd72)