### PR TITLE
feat: make curl progress bar correctly shows on the gui

### DIFF
--- a/package/harvester-os/files/usr/sbin/harv-install
+++ b/package/harvester-os/files/usr/sbin/harv-install
@@ -104,21 +104,7 @@ get_url()
             attempts=5
             until [ "$n" -ge "$attempts" ]
             do
-                # Because `curl` command uses `\r` to overwrite the progress bar,
-                # so we should also consider `\r` when splitting the output.
-                # Hence, we use `startcurl` and `endcurl` to trigger replacing the progress bar.
-                # But, when we use `\r` to display, the header will be overwritten, so we need to print the header manually.
-                echo "% Total    % Received % Xferd  Average Speed   Time    Time     Time  Current"
-                echo "                               Dload  Upload   Total   Spent    Left  Speed"
-                echo "startcurl"
-                curl -o $TO -fL ${FROM} 2>&1
-                curl_result=$?
-                echo "endcurl"
-
-                if [ "$curl_result" -eq 0  ]; then
-                    break
-                fi
-
+                curl -o $TO -fL ${FROM} && break
                 n=$((n+1))
                 echo "Failed to download, retry attempt ${n} out of ${attempts}"
                 sleep 2

--- a/package/harvester-os/files/usr/sbin/harv-install
+++ b/package/harvester-os/files/usr/sbin/harv-install
@@ -104,7 +104,21 @@ get_url()
             attempts=5
             until [ "$n" -ge "$attempts" ]
             do
-                curl -o $TO -fL ${FROM} && break
+                # Because `curl` command uses `\r` to overwrite the progress bar,
+                # so we should also consider `\r` when splitting the output.
+                # Hence, we use `startcurl` and `endcurl` to trigger replacing the progress bar.
+                # But, when we use `\r` to display, the header will be overwritten, so we need to print the header manually.
+                echo "% Total    % Received % Xferd  Average Speed   Time    Time     Time  Current"
+                echo "                               Dload  Upload   Total   Spent    Left  Speed"
+                echo "startcurl"
+                curl -o $TO -fL ${FROM} 2>&1
+                curl_result=$?
+                echo "endcurl"
+
+                if [ "$curl_result" -eq 0  ]; then
+                    break
+                fi
+
                 n=$((n+1))
                 echo "Failed to download, retry attempt ${n} out of ${attempts}"
                 sleep 2


### PR DESCRIPTION
**Problem:**
When downloading ISO, the progress bar doesn't show well. The reason is that curl uses `\r` to overwrite and print the progress bar. And the console.log in `/oem/install` is not aligned.

![image](https://github.com/user-attachments/assets/807eb9a2-9ba1-4744-a55e-382c82bfcd00)

**Solution:**
We should consider the `\r` character as well when scanning. And add a tag to switch different printers to print the messages.

**Related Issue:**
https://github.com/harvester/harvester/issues/5990

**Test plan:**


Install it with PXE, and check progress bar should display correctly.


## Version 1


https://github.com/user-attachments/assets/a278cd26-d7fc-4f45-beb3-362013a74314

Console log in `/oem/install/console.log`

After

![image](https://github.com/user-attachments/assets/8ee82770-1e47-4162-8d33-4853f2afc18e)


## Version 2

Same as Version 1, but I use `"Total   Spent    Left  Speed"` as flag to trigger different printers. Then, we don't have duplicated header in `/oem/install/console.log`. But ... we still need the `endcurl` to change back to original printer.


## Version 3 (Recommended Way)

Don't use `\r` to print the curl progress bar, just use `\n`. It will look like `console.log` in Version 1. But, if user's network bandwidth is not well, the log file and console would be large.

https://github.com/user-attachments/assets/4ebb34ed-0ad4-48d4-b23a-b7ddf7adf2f9

![image](https://github.com/user-attachments/assets/f029b5e8-8850-43c5-a90c-586a4c136432)

