### PR TITLE
Wipe Disks Improvements

### DIFF
--- a/package/harvester-os/files/usr/sbin/harv-install
+++ b/package/harvester-os/files/usr/sbin/harv-install
@@ -26,26 +26,17 @@ clear_disk_label()
     #     }
     #   ]
     # }
-    if [ "$HARVESTER_WIPE_DISKS" == "true" ]; then
-        echo "wiping all disks"
-        for disk in $(lsblk -d -n -J -o NAME,TYPE | jq -r '.blockdevices[] | select(.type == "disk") | .name')
-        do
-            sgdisk -Z /dev/$disk
-            partprobe -s /dev/$disk
-        done
-    else
-        # Clear the label of partitions that has $DATA_DISK_FSLABEL to prevent misidentification
-        # Also, while yip is partitioning the disk, if it sees the LABEL to be used exists,
-        # it won't create the partition. So it's necessary to clear the label
-        for part in $(blkid -t LABEL="$DATA_DISK_FSLABEL" -o device); do
-            echo "Remove filesystem label from $part"
-            # Run this tune2fs twice because sometimes the first run would show "Recovering journal"
-            # and label is not modified
-            tune2fs -L "" $part > /dev/null
-            tune2fs -L "" $part > /dev/null
-        done
-        udevadm settle
-    fi
+    # Clear the label of partitions that has $DATA_DISK_FSLABEL to prevent misidentification
+    # Also, while yip is partitioning the disk, if it sees the LABEL to be used exists,
+    # it won't create the partition. So it's necessary to clear the label
+    for part in $(blkid -t LABEL="$DATA_DISK_FSLABEL" -o device); do
+        echo "Remove filesystem label from $part"
+        # Run this tune2fs twice because sometimes the first run would show "Recovering journal"
+        # and label is not modified
+        tune2fs -L "" $part > /dev/null
+        tune2fs -L "" $part > /dev/null
+    done
+    udevadm settle
 }
 
 umount_target() {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -154,19 +154,20 @@ type Install struct {
 	ClusterPodCIDR     string `json:"clusterPodCidr,omitempty"`
 	ClusterServiceCIDR string `json:"clusterServiceCidr,omitempty"`
 
-	ForceEFI      bool   `json:"forceEfi,omitempty"`
-	Device        string `json:"device,omitempty"`
-	ConfigURL     string `json:"configUrl,omitempty"`
-	Silent        bool   `json:"silent,omitempty"`
-	ISOURL        string `json:"isoUrl,omitempty"`
-	PowerOff      bool   `json:"powerOff,omitempty"`
-	NoFormat      bool   `json:"noFormat,omitempty"`
-	Debug         bool   `json:"debug,omitempty"`
-	TTY           string `json:"tty,omitempty"`
-	ForceGPT      bool   `json:"forceGpt,omitempty"`
-	Role          string `json:"role,omitempty"`
-	WithNetImages bool   `json:"withNetImages,omitempty"`
-	WipeDisks     bool   `json:"wipeDisks,omitempty"`
+	ForceEFI      bool     `json:"forceEfi,omitempty"`
+	Device        string   `json:"device,omitempty"`
+	ConfigURL     string   `json:"configUrl,omitempty"`
+	Silent        bool     `json:"silent,omitempty"`
+	ISOURL        string   `json:"isoUrl,omitempty"`
+	PowerOff      bool     `json:"powerOff,omitempty"`
+	NoFormat      bool     `json:"noFormat,omitempty"`
+	Debug         bool     `json:"debug,omitempty"`
+	TTY           string   `json:"tty,omitempty"`
+	ForceGPT      bool     `json:"forceGpt,omitempty"`
+	Role          string   `json:"role,omitempty"`
+	WithNetImages bool     `json:"withNetImages,omitempty"`
+	WipeAllDisks  bool     `json:"wipeAllDisks,omitempty"`
+	WipeDisksList []string `json:"wipeDisksList,omitempty"`
 
 	// Following options are not cOS installer flag
 	ForceMBR bool   `json:"forceMbr,omitempty"`

--- a/pkg/console/constant.go
+++ b/pkg/console/constant.go
@@ -49,6 +49,8 @@ const (
 	vipTextPanel                = "vipTextPanel"
 	ntpServersPanel             = "ntpServersPanel"
 	askRolePanel                = "askRolePanel"
+	wipeDisksPanel              = "wipeDisksPanel"
+	wipeDisksTitlePanel         = "wipeDisksTitlePanel"
 
 	hostnameTitle         = "Configure hostname for this instance"
 	networkTitle          = "Configure network"
@@ -65,6 +67,7 @@ const (
 	mtuLabel              = "MTU (optional)"
 	dnsServersLabel       = "DNS Servers"
 	ntpServersLabel       = "NTP Servers"
+	wipeDisksLabel        = "Wipe Disks"
 
 	networkMethodDHCPText   = "Automatic (DHCP)"
 	networkMethodStaticText = "Static"

--- a/pkg/console/util.go
+++ b/pkg/console/util.go
@@ -1227,8 +1227,9 @@ func executeWipeDisks(ctx context.Context, name string) error {
 }
 
 func runCommand(cmd *exec.Cmd) error {
-	if err := cmd.Start(); err != nil {
-		return err
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		logrus.Error(string(output))
 	}
-	return cmd.Wait()
+	return err
 }

--- a/pkg/console/util_test.go
+++ b/pkg/console/util_test.go
@@ -709,6 +709,383 @@ const (
       }
    ]
 }`
+
+	existingHarvesterInstalls = `{
+   "blockdevices": [
+      {
+         "name": "loop0",
+         "size": "4K",
+         "type": "loop",
+         "wwn": null,
+         "serial": null,
+         "label": null
+      },{
+         "name": "loop1",
+         "size": "175.7M",
+         "type": "loop",
+         "wwn": null,
+         "serial": null,
+         "label": null
+      },{
+         "name": "loop2",
+         "size": "89.4M",
+         "type": "loop",
+         "wwn": null,
+         "serial": null,
+         "label": null
+      },{
+         "name": "loop3",
+         "size": "55.7M",
+         "type": "loop",
+         "wwn": null,
+         "serial": null,
+         "label": null
+      },{
+         "name": "loop4",
+         "size": "55.4M",
+         "type": "loop",
+         "wwn": null,
+         "serial": null,
+         "label": null
+      },{
+         "name": "loop5",
+         "size": "64M",
+         "type": "loop",
+         "wwn": null,
+         "serial": null,
+         "label": null
+      },{
+         "name": "loop6",
+         "size": "63.7M",
+         "type": "loop",
+         "wwn": null,
+         "serial": null,
+         "label": null
+      },{
+         "name": "loop7",
+         "size": "74.2M",
+         "type": "loop",
+         "wwn": null,
+         "serial": null,
+         "label": null
+      },{
+         "name": "loop8",
+         "size": "73.9M",
+         "type": "loop",
+         "wwn": null,
+         "serial": null,
+         "label": null
+      },{
+         "name": "loop9",
+         "size": "67.8M",
+         "type": "loop",
+         "wwn": null,
+         "serial": null,
+         "label": null
+      },{
+         "name": "loop10",
+         "size": "67.8M",
+         "type": "loop",
+         "wwn": null,
+         "serial": null,
+         "label": null
+      },{
+         "name": "loop11",
+         "size": "374.7M",
+         "type": "loop",
+         "wwn": null,
+         "serial": null,
+         "label": null
+      },{
+         "name": "loop12",
+         "size": "375.1M",
+         "type": "loop",
+         "wwn": null,
+         "serial": null,
+         "label": null
+      },{
+         "name": "loop13",
+         "size": "349.7M",
+         "type": "loop",
+         "wwn": null,
+         "serial": null,
+         "label": null
+      },{
+         "name": "loop14",
+         "size": "349.7M",
+         "type": "loop",
+         "wwn": null,
+         "serial": null,
+         "label": null
+      },{
+         "name": "loop15",
+         "size": "504.2M",
+         "type": "loop",
+         "wwn": null,
+         "serial": null,
+         "label": null
+      },{
+         "name": "loop16",
+         "size": "505.1M",
+         "type": "loop",
+         "wwn": null,
+         "serial": null,
+         "label": null
+      },{
+         "name": "loop17",
+         "size": "273.6M",
+         "type": "loop",
+         "wwn": null,
+         "serial": null,
+         "label": null
+      },{
+         "name": "loop18",
+         "size": "273M",
+         "type": "loop",
+         "wwn": null,
+         "serial": null,
+         "label": null
+      },{
+         "name": "loop19",
+         "size": "91.7M",
+         "type": "loop",
+         "wwn": null,
+         "serial": null,
+         "label": null
+      },{
+         "name": "loop20",
+         "size": "44.3M",
+         "type": "loop",
+         "wwn": null,
+         "serial": null,
+         "label": null
+      },{
+         "name": "loop21",
+         "size": "87M",
+         "type": "loop",
+         "wwn": null,
+         "serial": null,
+         "label": null
+      },{
+         "name": "loop22",
+         "size": "38.8M",
+         "type": "loop",
+         "wwn": null,
+         "serial": null,
+         "label": null
+      },{
+         "name": "loop24",
+         "size": "6.8M",
+         "type": "loop",
+         "wwn": null,
+         "serial": null,
+         "label": null
+      },{
+         "name": "loop25",
+         "size": "6.8M",
+         "type": "loop",
+         "wwn": null,
+         "serial": null,
+         "label": null
+      },{
+         "name": "loop26",
+         "size": "172.3M",
+         "type": "loop",
+         "wwn": null,
+         "serial": null,
+         "label": null
+      },{
+         "name": "sda",
+         "size": "838.1G",
+         "type": "disk",
+         "wwn": "0x600508b1001cc488149adefce15584da",
+         "serial": "PDNLH0BRH7T0VY",
+         "label": null,
+         "children": [
+            {
+               "name": "sda1",
+               "size": "1G",
+               "type": "part",
+               "wwn": "0x600508b1001cc488149adefce15584da",
+               "serial": null,
+               "label": null
+            },{
+               "name": "sda2",
+               "size": "2G",
+               "type": "part",
+               "wwn": "0x600508b1001cc488149adefce15584da",
+               "serial": null,
+               "label": null
+            },{
+               "name": "sda3",
+               "size": "835G",
+               "type": "part",
+               "wwn": "0x600508b1001cc488149adefce15584da",
+               "serial": null,
+               "label": null,
+               "children": [
+                  {
+                     "name": "ubuntu--vg-ubuntu--lv",
+                     "size": "835G",
+                     "type": "lvm",
+                     "wwn": null,
+                     "serial": null,
+                     "label": null
+                  }
+               ]
+            }
+         ]
+      },{
+         "name": "sdb",
+         "size": "3.8G",
+         "type": "disk",
+         "wwn": null,
+         "serial": "General_-0:0",
+         "label": null,
+         "children": [
+            {
+               "name": "sdb1",
+               "size": "3.8G",
+               "type": "part",
+               "wwn": null,
+               "serial": null,
+               "label": null
+            }
+         ]
+      },{
+         "name": "sdc",
+         "size": "250G",
+         "type": "disk",
+         "wwn": "0x60000000000000000e00000000010001",
+         "serial": "1001",
+         "label": null,
+         "children": [
+            {
+               "name": "mpatha",
+               "size": "250G",
+               "type": "mpath",
+               "wwn": null,
+               "serial": null,
+               "label": null,
+               "children": [
+                  {
+                     "name": "mpatha-part1",
+                     "size": "64M",
+                     "type": "part",
+                     "wwn": null,
+                     "serial": null,
+                     "label": "COS_GRUB"
+                  },{
+                     "name": "mpatha-part2",
+                     "size": "50M",
+                     "type": "part",
+                     "wwn": null,
+                     "serial": null,
+                     "label": "COS_OEM"
+                  },{
+                     "name": "mpatha-part3",
+                     "size": "8G",
+                     "type": "part",
+                     "wwn": null,
+                     "serial": null,
+                     "label": "COS_RECOVERY"
+                  },{
+                     "name": "mpatha-part4",
+                     "size": "15G",
+                     "type": "part",
+                     "wwn": null,
+                     "serial": null,
+                     "label": "COS_STATE"
+                  },{
+                     "name": "mpatha-part5",
+                     "size": "150G",
+                     "type": "part",
+                     "wwn": null,
+                     "serial": null,
+                     "label": "COS_PERSISTENT"
+                  },{
+                     "name": "mpatha-part6",
+                     "size": "76.9G",
+                     "type": "part",
+                     "wwn": null,
+                     "serial": null,
+                     "label": "HARV_LH_DEFAULT"
+                  }
+               ]
+            }
+         ]
+      },{
+         "name": "sdd",
+         "size": "250G",
+         "type": "disk",
+         "wwn": "0x60000000000000000e00000000010001",
+         "serial": "1001",
+         "label": null,
+         "children": [
+            {
+               "name": "mpatha",
+               "size": "250G",
+               "type": "mpath",
+               "wwn": null,
+               "serial": null,
+               "label": null,
+               "children": [
+                  {
+                     "name": "mpatha-part1",
+                     "size": "64M",
+                     "type": "part",
+                     "wwn": null,
+                     "serial": null,
+                     "label": "COS_GRUB"
+                  },{
+                     "name": "mpatha-part2",
+                     "size": "50M",
+                     "type": "part",
+                     "wwn": null,
+                     "serial": null,
+                     "label": "COS_OEM"
+                  },{
+                     "name": "mpatha-part3",
+                     "size": "8G",
+                     "type": "part",
+                     "wwn": null,
+                     "serial": null,
+                     "label": "COS_RECOVERY"
+                  },{
+                     "name": "mpatha-part4",
+                     "size": "15G",
+                     "type": "part",
+                     "wwn": null,
+                     "serial": null,
+                     "label": "COS_STATE"
+                  },{
+                     "name": "mpatha-part5",
+                     "size": "150G",
+                     "type": "part",
+                     "wwn": null,
+                     "serial": null,
+                     "label": "COS_PERSISTENT"
+                  },{
+                     "name": "mpatha-part6",
+                     "size": "76.9G",
+                     "type": "part",
+                     "wwn": null,
+                     "serial": null,
+                     "label": "HARV_LH_DEFAULT"
+                  }
+               ]
+            }
+         ]
+      },{
+         "name": "nvme0n1",
+         "size": "1.8T",
+         "type": "disk",
+         "wwn": "eui.0025385c2140432c",
+         "serial": "S6S2NS0TC11162K",
+         "label": null
+      }
+   ]
+}`
 )
 
 func Test_identifyUniqueDisksWithSerialNumber(t *testing.T) {
@@ -737,4 +1114,11 @@ func Test_identifyUniqueDisks(t *testing.T) {
 	out, err := identifyUniqueDisks([]byte(raidDisks))
 	assert.NoError(err, "expected no error while parsing disk data")
 	t.Log(out)
+}
+
+func Test_identifyUniqueDisksWithHarvesterInstall(t *testing.T) {
+	assert := require.New(t)
+	results, err := filterHarvesterInstallDisks([]byte(existingHarvesterInstalls))
+	assert.NoError(err, "expected no error while parsing disk data")
+	assert.Len(results, 1, "expected to find 1 disk from sample data")
 }

--- a/pkg/widgets/dropdown.go
+++ b/pkg/widgets/dropdown.go
@@ -201,3 +201,8 @@ func (d *DropDown) SetData(data string) error {
 	}
 	return nil
 }
+
+func (d *DropDown) Reset() {
+	d.Select.selectedIndexes = []bool{}
+	d.Value = ""
+}


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
We introduced a field in Harvester config named `wipeDisks` which when set ran a script in the installer to iterate over all disk devices visible to the host and wipe them.

This ended up being too aggressive, not to mention not all disks may contain old Harvester installations.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
PR introduces two new fields in the harvester config wipeDisksList and wipeAllDisks and drops the old wipeDisks introduced in v1.3

There is an extra panel in disk configuration page. The extra panel contains a drop down menu which gets rendered and populated if installer finds additional disks with existing elemental based installations which are not already used in install device or additional data device.

The extra `Wipe Disks` panels will only be available when there are additional disks visible to the host which have a partition with `COS_OEM` label and such disk is not already being used in `Install Device` or `Install Data Device`.

![image](https://github.com/user-attachments/assets/5b0d9b1e-9649-4cf5-96f2-d1d9d79d4c5a)

User can also pass these fields via ipxe using the following two new fields

```
install:
  wipeAllDisks: true
```

or 

```
install:
  wipeDisksList: 
     - device1
     - device2
```

`wipeAllDisks` uses the same logic as the installers `Wipe Disks Panel` where it will identify additional disks with `COS_OEM` partition which are not already being used as `Install Device` or `Install Data Device`.

**Related Issue:**
https://github.com/harvester/harvester/issues/6304
https://github.com/harvester/harvester/issues/6533

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

