### PR TITLE
feat: add VIP mac address input panel

### DIFF
--- a/pkg/console/constant.go
+++ b/pkg/console/constant.go
@@ -45,6 +45,7 @@ const (
 	askVipMethodPanel           = "askVipMethodPanel"
 	vipPanel                    = "vipPanel"
 	vipHwAddrPanel              = "vipHwAddrPanel"
+	vipHwAddrNotePanel          = "vipHwAddrNotePanel"
 	vipTextPanel                = "vipTextPanel"
 	ntpServersPanel             = "ntpServersPanel"
 	askRolePanel                = "askRolePanel"
@@ -70,7 +71,7 @@ const (
 
 	vipTitle          = "Configure VIP"
 	vipLabel          = "VIP"
-	vipHwAddrLabel    = "Hardware Address"
+	vipHwAddrLabel    = "MAC Address"
 	askVipMethodLabel = "VIP Mode"
 
 	clusterTokenCreateNote = "Note: The token is used for adding nodes to the cluster"

--- a/pkg/console/constant.go
+++ b/pkg/console/constant.go
@@ -44,6 +44,7 @@ const (
 	upgradePanel                = "upgrade"
 	askVipMethodPanel           = "askVipMethodPanel"
 	vipPanel                    = "vipPanel"
+	vipHwAddrPanel              = "vipHwAddrPanel"
 	vipTextPanel                = "vipTextPanel"
 	ntpServersPanel             = "ntpServersPanel"
 	askRolePanel                = "askRolePanel"
@@ -69,6 +70,7 @@ const (
 
 	vipTitle          = "Configure VIP"
 	vipLabel          = "VIP"
+	vipHwAddrLabel    = "Hardware Address"
 	askVipMethodLabel = "VIP Mode"
 
 	clusterTokenCreateNote = "Note: The token is used for adding nodes to the cluster"

--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -1173,7 +1173,7 @@ func addTokenPanel(c *Console) error {
 			closeThisPage()
 			if c.config.Install.Mode == config.ModeCreate {
 				g.Cursor = false
-				return showNext(c, vipTextPanel, vipPanel, askVipMethodPanel)
+				return showNext(c, vipTextPanel, vipHwAddrPanel, vipPanel, askVipMethodPanel)
 			}
 			return showNext(c, serverURLPanel)
 		},
@@ -2095,7 +2095,7 @@ func addInstallPanel(c *Console) error {
 			}
 
 			if needToGetVIPFromDHCP(c.config.VipMode, c.config.Vip, c.config.VipHwAddr) {
-				vip, err := getVipThroughDHCP(getManagementInterfaceName(c.config.ManagementInterface))
+				vip, err := getVipThroughDHCP(getManagementInterfaceName(c.config.ManagementInterface), "")
 				if err != nil {
 					printToPanel(c.Gui, fmt.Sprintf("fail to get vip: %s", err), installPanel)
 					return
@@ -2233,16 +2233,20 @@ func addVIPPanel(c *Console) error {
 	if err != nil {
 		return err
 	}
+	hwAddrV, err := widgets.NewInput(c.Gui, vipHwAddrPanel, vipHwAddrLabel, false)
+	if err != nil {
+		return err
+	}
 	vipV, err := widgets.NewInput(c.Gui, vipPanel, vipLabel, false)
 	if err != nil {
 		return err
 	}
-
 	vipTextV := widgets.NewPanel(c.Gui, vipTextPanel)
 
 	closeThisPage := func() {
 		c.CloseElements(
 			askVipMethodPanel,
+			vipHwAddrPanel,
 			vipPanel,
 			vipTextPanel)
 	}
@@ -2260,11 +2264,15 @@ func addVIPPanel(c *Console) error {
 		if err != nil {
 			return err
 		}
+		hwAddr, err := hwAddrV.GetData()
+		if err != nil {
+			return err
+		}
 		if selected == config.NetworkMethodDHCP {
 			spinner := NewSpinner(c.Gui, vipTextPanel, "Requesting IP through DHCP...")
 			spinner.Start()
 			go func(g *gocui.Gui) {
-				vip, err := getVipThroughDHCP(getManagementInterfaceName(c.config.ManagementInterface))
+				vip, err := getVipThroughDHCP(getManagementInterfaceName(c.config.ManagementInterface), hwAddr)
 				if err != nil {
 					spinner.Stop(true, err.Error())
 					g.Update(func(_ *gocui.Gui) error {
@@ -2277,6 +2285,9 @@ func addVIPPanel(c *Console) error {
 				c.config.VipMode = selected
 				c.config.VipHwAddr = vip.hwAddr
 				g.Update(func(_ *gocui.Gui) error {
+					if err := hwAddrV.SetData(vip.hwAddr); err != nil {
+						return err
+					}
 					return vipV.SetData(vip.ipv4Addr)
 				})
 			}(c.Gui)
@@ -2301,6 +2312,22 @@ func addVIPPanel(c *Console) error {
 				vipTextV.SetContent("Forbid to modify the VIP obtained through DHCP")
 				return nil
 			}
+
+			// if hardware address is overridden, update the install config with
+			// the new value.
+			hwAddr, err := hwAddrV.GetData()
+			if err != nil {
+				return err
+			}
+			if hwAddr != c.config.VipHwAddr {
+				logrus.Infof("Overriding VIP hardware address. Original: %q, New: %q", c.config.VipHwAddr, hwAddr)
+				if _, err := net.ParseMAC(hwAddr); err != nil {
+					msg := fmt.Sprintf("Invalid hardware address: %s", err)
+					vipTextV.SetContent(msg)
+					return nil
+				}
+				c.config.VipHwAddr = hwAddr
+			}
 			return gotoNextPage(g, v)
 		}
 
@@ -2317,19 +2344,46 @@ func addVIPPanel(c *Console) error {
 
 		c.config.Vip = vip
 		c.config.VipHwAddr = ""
-
 		return gotoNextPage(g, v)
 	}
 	gotoAskVipMethodPanel := func(_ *gocui.Gui, _ *gocui.View) error {
 		return showNext(c, askVipMethodPanel)
 	}
+	gotoNextPanel := func(_ *gocui.Gui, _ *gocui.View) error {
+		method, err := askVipMethodV.GetData()
+		if err != nil {
+			return err
+		}
+		if method == config.NetworkMethodDHCP {
+			return showNext(c, vipHwAddrPanel)
+		}
+
+		hwAddrV.Close()
+		return showNext(c, vipPanel)
+	}
+	gotoPrevPanel := func(_ *gocui.Gui, _ *gocui.View) error {
+		method, err := askVipMethodV.GetData()
+		if err != nil {
+			return err
+		}
+		if method == config.NetworkMethodDHCP {
+			return showNext(c, vipHwAddrPanel)
+		}
+		return showNext(c, askVipMethodPanel)
+	}
 	askVipMethodV.KeyBindings = map[gocui.Key]func(*gocui.Gui, *gocui.View) error{
+		gocui.KeyArrowDown: gotoNextPanel,
+		gocui.KeyEnter:     gotoNextPanel,
+		gocui.KeyEsc:       gotoPrevPage,
+	}
+	hwAddrV.KeyBindings = map[gocui.Key]func(*gocui.Gui, *gocui.View) error{
+		gocui.KeyArrowUp:   gotoAskVipMethodPanel,
 		gocui.KeyArrowDown: gotoVipPanel,
 		gocui.KeyEnter:     gotoVipPanel,
 		gocui.KeyEsc:       gotoPrevPage,
 	}
 	vipV.KeyBindings = map[gocui.Key]func(*gocui.Gui, *gocui.View) error{
-		gocui.KeyArrowUp:   gotoAskVipMethodPanel,
+		gocui.KeyArrowUp:   gotoPrevPanel,
 		gocui.KeyArrowDown: gotoVerifyIP,
 		gocui.KeyEnter:     gotoVerifyIP,
 		gocui.KeyEsc:       gotoPrevPage,
@@ -2343,6 +2397,9 @@ func addVIPPanel(c *Console) error {
 
 	setLocation(askVipMethodV, 3)
 	c.AddElement(askVipMethodPanel, askVipMethodV)
+
+	setLocation(hwAddrV, 3)
+	c.AddElement(vipHwAddrPanel, hwAddrV)
 
 	setLocation(vipV, 3)
 	c.AddElement(vipPanel, vipV)
@@ -2497,7 +2554,7 @@ func addDNSServersPanel(c *Console) error {
 	gotoNextPage := func() error {
 		closeThisPage()
 		if c.config.Install.Mode == config.ModeCreate {
-			return showNext(c, vipTextPanel, vipPanel, askVipMethodPanel)
+			return showNext(c, vipTextPanel, vipHwAddrPanel, vipPanel, askVipMethodPanel)
 		}
 		return showNext(c, serverURLPanel)
 	}
@@ -2608,7 +2665,7 @@ func configureInstallModeDHCP(c *Console) {
 
 	// if need vip via dhcp
 	if c.config.Install.VipMode == config.NetworkMethodDHCP {
-		vip, err := getVipThroughDHCP(getManagementInterfaceName(c.config.ManagementInterface))
+		vip, err := getVipThroughDHCP(getManagementInterfaceName(c.config.ManagementInterface), "")
 		if err != nil {
 			printToPanel(c.Gui, fmt.Sprintf("fail to get vip: %s", err), installPanel)
 			return

--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -2312,22 +2312,6 @@ func addVIPPanel(c *Console) error {
 				vipTextV.SetContent("Forbid to modify the VIP obtained through DHCP")
 				return nil
 			}
-
-			// if hardware address is overridden, update the install config with
-			// the new value.
-			hwAddr, err := hwAddrV.GetData()
-			if err != nil {
-				return err
-			}
-			if hwAddr != c.config.VipHwAddr {
-				logrus.Infof("Overriding VIP hardware address. Original: %q, New: %q", c.config.VipHwAddr, hwAddr)
-				if _, err := net.ParseMAC(hwAddr); err != nil {
-					msg := fmt.Sprintf("Invalid hardware address: %s", err)
-					vipTextV.SetContent(msg)
-					return nil
-				}
-				c.config.VipHwAddr = hwAddr
-			}
 			return gotoNextPage(g, v)
 		}
 


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
There is a parity gap between the VIP configuration of the ISO installation and the automatic installation modes. In the automatic installation mode, user can specify the VIP MAC and static IP addresses over DHCP. This allows user to use a static IP address as the cluster's VIP. This option isn't available in the ISO installation mode.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
This PR updates the VIP configuration page of the installation console with a new `MAC Address` field, to allow user to specify the VIP's MAC address in DHCP mode. The installer uses this MAC address to request for the specific static IP address over DHCP. If this field is left blank, the installer falls back to the current behaviour of determining the VIP and MAC address.

On the VIP page, the subsequent input panels that will be shown are based on the method selected by the user:

![image](https://github.com/user-attachments/assets/20902155-5ff7-4dc7-99cb-ea9e3bd44b62)

Choosing `DHCP` reveals both the `MAC Address` and `VIP` input panels:

![image](https://github.com/user-attachments/assets/e2785a11-72fa-42fa-9ac2-701ce5b1de5b)

Choosing `Static` reveals only the `VIP` input panel:

![image](https://github.com/user-attachments/assets/fea4b9b8-9b86-47b2-ad25-7453a9f49c1f)

**Related Issue:**

https://github.com/harvester/harvester/issues/6960.

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

## Test Case 1 - Request For Static VIP Address Using Custom MAC Address

Follow the instructions in this [gist](https://gist.github.com/ihcsim/c33b135925ad9c8a13f12e34727be559) to add custom MAC/IP address bindings to the local kvm dnsmasq.

On the VIP page, input the custom MAC address (`32:34:1a:75:7f:64`):
  * Expect the installer to receive the pre-configured static IP (`192.168.122.39`) from the DHCP server

![image](https://github.com/user-attachments/assets/625d6b6c-72da-498c-9ab3-7a844a8f17e5)

Complete the rest of the installation setup to provision Harvester.
  * Expect the management node to be ready
    
Provision a worker node to join the cluster targeting the static VIP address.
  * Expect the worker to be successfully added to the cluster

## Test Case 2 - Let Installer Determine The VIP and MAC Address

On the VIP page, leave the MAC and VIP addresses blank.
  * Expect the installer to receive a new VIP from the DHCP server with a new random MAC address
   
Complete the rest of the installation setup to provision Harvester.
  * Expect the installation to complete successfully
 
Provision a worker node to join the cluster via the static VIP address.
  * Expect the worker to be successfully added to the cluster