### PR TITLE
Fix incorrect unit in cpu usage dashboard

### DIFF
--- a/pkg/config/templates/rancherd-12-monitoring-dashboard.yaml
+++ b/pkg/config/templates/rancherd-12-monitoring-dashboard.yaml
@@ -124,7 +124,7 @@ resources:
             "yaxes": [
               {
                 "$$hashKey": "object:370",
-                "format": "percentunit",
+                "format": "percent",
                 "label": null,
                 "logBase": 1,
                 "max": null,
@@ -875,7 +875,7 @@ resources:
                     }
                   ]
                 },
-                "unit": "percentunit"
+                "unit": "percent"
               },
               "overrides": []
             },


### PR DESCRIPTION
**Problem:**

Prometheus VM Metrics are not accurate whatsoever where cpu usage metrics at a percentage level are exceeding 200000% within the Harvester UI VM metrics.

**Solution:**

fix incorrect cpu usage unit, upgrade path fix is here: https://github.com/harvester/harvester/pull/7250

**Related Issue:**
https://github.com/harvester/harvester/issues/7086

**Test plan:**
- Prepare a harvester cluster with this patch
- Enable rancher-monitoring addon
- Prepare some VMs (e.g. 3 VM)
- Goto Grafana UI and wait for a couple of minutes
- Check the value of cpu usage should fall in range [0, 100] in both `Harvester VM Dashboard` and `Harvester VM Info Detail` dashboards (during vm startup, the cpu usage may slightly go over 100%, after a while it should dramatically drop to a low value, like 2%)

<image src=https://github.com/user-attachments/assets/c38f68b5-2660-4c48-bafc-941f14e8d6ce width=550 />
<image src=https://github.com/user-attachments/assets/c08594b6-8305-4bc9-b48c-71cb8e3fc235 width=550 />


