### PR TITLE
fix: Skip wipe of live usb device.

### DIFF
--- a/package/harvester-os/files/usr/sbin/harv-install
+++ b/package/harvester-os/files/usr/sbin/harv-install
@@ -30,6 +30,9 @@ clear_disk_label()
         echo "wiping all disks"
         for disk in $(lsblk -d -n -J -o NAME,TYPE | jq -r '.blockdevices[] | select(.type == "disk") | .name')
         do
+            if [ "/dev/$disk" == "$(grep '/run/initramfs/live' /proc/mounts | sed -n 's/[0-9].*//p')" ]; then
+                continue
+            fi
             sgdisk -Z /dev/$disk
             partprobe -s /dev/$disk
         done

--- a/package/harvester-os/files/usr/sbin/harv-install
+++ b/package/harvester-os/files/usr/sbin/harv-install
@@ -30,7 +30,7 @@ clear_disk_label()
         echo "wiping all disks"
         for disk in $(lsblk -d -n -J -o NAME,TYPE | jq -r '.blockdevices[] | select(.type == "disk") | .name')
         do
-            if [ "/dev/$disk" == "$(grep '/run/initramfs/live' /proc/mounts | sed -n 's/[0-9].*//p')" ]; then
+            if [ "/dev/$disk" == "$(grep $ISOMNT /proc/mounts | sed -n 's/[0-9].*//p')" ]; then
                 continue
             fi
             sgdisk -Z /dev/$disk


### PR DESCRIPTION
**Problem:**
The option harvester.install.wipe_disks=true should skip the live usb device.

**Solution:**
Skip the live usb device mounted as the root rfs.

**Related Issue:**
https://github.com/harvester/harvester/issues/6533