### PR TITLE
Bump golang to v1.23 plus some additional cleanup

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,6 +1,6 @@
 FROM quay.io/costoolkit/releases-teal:grub2-live-0.0.4-2 AS grub2-mbr
 FROM quay.io/costoolkit/releases-teal:grub2-efi-image-live-0.0.4-2 AS grub2-efi
-FROM registry.suse.com/bci/golang:1.22
+FROM registry.suse.com/bci/golang:1.23
 
 ARG http_proxy=$http_proxy
 ARG https_proxy=$https_proxy

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -19,7 +19,7 @@ ENV ARCH $DAPPER_HOST_ARCH
 RUN zypper -n rm container-suseconnect && \
     zypper -n install git curl docker gzip tar wget zstd squashfs xorriso awk jq mtools dosfstools unzip rsync patch
 RUN curl -sfL https://github.com/mikefarah/yq/releases/download/v4.21.1/yq_linux_${ARCH} -o /usr/bin/yq && chmod +x /usr/bin/yq
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.57.1
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.63.4
 
 # only needed for raw image generation. currently skipped for arm builds
 RUN if [ "${ARCH}" == "amd64" ]; then \

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,5 +1,5 @@
-FROM quay.io/costoolkit/releases-teal:grub2-live-0.0.4-2 as grub2-mbr
-FROM quay.io/costoolkit/releases-teal:grub2-efi-image-live-0.0.4-2 as grub2-efi
+FROM quay.io/costoolkit/releases-teal:grub2-live-0.0.4-2 AS grub2-mbr
+FROM quay.io/costoolkit/releases-teal:grub2-efi-image-live-0.0.4-2 AS grub2-efi
 FROM registry.suse.com/bci/golang:1.22
 
 ARG http_proxy=$http_proxy

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ If you are using VS Code, create a remote debug configuration in
 ```
 
 ## License
-Copyright (c) 2024 [Rancher Labs, Inc.](http://rancher.com)
+Copyright (c) 2025 [Rancher Labs, Inc.](http://rancher.com)
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/harvester/harvester-installer
 
-go 1.22.5
+go 1.23
 
 require (
 	github.com/dell/goiscsi v1.9.0

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,10 +32,10 @@ const (
 )
 
 const (
-	SingleDiskMinSizeGiB   = 250
-	MultipleDiskMinSizeGiB = 180
-	HardMinDataDiskSizeGiB = 50
-	MaxPods                = 200
+	SingleDiskMinSizeGiB   uint64 = 250
+	MultipleDiskMinSizeGiB uint64 = 180
+	HardMinDataDiskSizeGiB uint64 = 50
+	MaxPods                       = 200
 )
 
 // refer: https://github.com/harvester/harvester/blob/master/pkg/settings/settings.go

--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -34,7 +34,7 @@ func initLogs() error {
 		logFilePath = defaultLogFilePath
 	}
 
-	f, err := os.OpenFile(logFilePath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0755) //0600)
+	f, err := os.OpenFile(logFilePath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
 	if err != nil {
 		return err
 	}

--- a/pkg/console/spinner.go
+++ b/pkg/console/spinner.go
@@ -79,7 +79,7 @@ func (s *Spinner) Stop(err bool, message string) {
 	<-s.stopped
 }
 
-func (s *Spinner) writePanel(message string, clear bool, fgColor gocui.Attribute) {
+func (s *Spinner) writePanel(message string, clearView bool, fgColor gocui.Attribute) {
 	// g.Update spawns a goroutine to notify gocui to update.
 	// wait until cui consumes the notification to make sure any remaining
 	// writePanel calls don't go first
@@ -100,7 +100,7 @@ func (s *Spinner) writePanel(message string, clear bool, fgColor gocui.Attribute
 		if s.focus {
 			g.SetCurrentView(s.panel)
 		}
-		if clear {
+		if clearView {
 			v.Clear()
 		}
 		v.FgColor = fgColor

--- a/pkg/console/util.go
+++ b/pkg/console/util.go
@@ -451,7 +451,7 @@ func saveElementalConfig(obj interface{}) (string, string, error) {
 	}
 
 	elementalConfigFile := filepath.Join(ElementalConfigDir, ElementalConfigFile)
-	err = ioutil.WriteFile(elementalConfigFile, bytes, os.ModePerm)
+	err = ioutil.WriteFile(elementalConfigFile, bytes, 0600)
 	if err != nil {
 		return "", "", err
 	}
@@ -703,7 +703,7 @@ func validateDiskSize(devPath string, single bool) error {
 	if !single {
 		limit = config.MultipleDiskMinSizeGiB
 	}
-	if util.ByteToGi(diskSizeBytes) < uint64(limit) {
+	if util.ByteToGi(diskSizeBytes) < limit {
 		return fmt.Errorf("Installation disk size is too small. Minimum %dGi is required", limit)
 	}
 
@@ -1047,7 +1047,7 @@ const (
 // identifyUniqueDisks parses the json output of lsblk and identifies
 // unique disks by comparing their serial number info and wwn details
 func identifyUniqueDisks(output []byte) ([]string, error) {
-	var returnDisks []string
+	returnDisks := []string{}
 	disks := &BlockDevices{}
 	err := json.Unmarshal(output, disks)
 	if err != nil {

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -31,12 +31,12 @@ func DupStrings(src []string) []string {
 	return s
 }
 
-func ByteToGi(byte uint64) uint64 {
-	return byte >> 30
+func ByteToGi(b uint64) uint64 {
+	return b >> 30
 }
 
-func ByteToMi(byte uint64) uint64 {
-	return byte >> 20
+func ByteToMi(b uint64) uint64 {
+	return b >> 20
 }
 
 func GiToByte(gi uint64) uint64 {


### PR DESCRIPTION
**Problem:**
Need to bump golang to v1.23. While doing that I found a couple of other little things to clean up which I have also included in this PR as separate commits.

**Solution:**
This PR

**Related Issue:**
https://github.com/harvester/harvester/issues/7336

**Test plan:**
N/A