### PR TITLE
Allow for a Fully-Qualified Hostname

### DIFF
--- a/pkg/config/templates/rancherd-config.yaml
+++ b/pkg/config/templates/rancherd-config.yaml
@@ -4,6 +4,7 @@ role: agent
 {{- else -}}
 role: cluster-init
 {{- end }}
+nodeName: {{ .Hostname }}
 token: {{ printf "%q" .Token }}
 kubernetesVersion: {{ .RuntimeVersion }}
 rancherVersion: {{ .RancherVersion }}

--- a/pkg/console/dashboard_panels.go
+++ b/pkg/console/dashboard_panels.go
@@ -351,9 +351,7 @@ func getNodeInfo() string {
 	)
 
 	// find node hostname
-	cmd = `hostname | tr -d '\r\n'`
-	out, err = exec.Command("/bin/sh", "-c", cmd).Output()
-	hostname = string(out)
+	hostname, err = GetFullHostname()
 	if err != nil || hostname == "" {
 		logrus.Warnf("node didn't have a hostname")
 		hostname = ""
@@ -497,7 +495,7 @@ func isPodReady(namespace string, labelSelectors ...string) bool {
 }
 
 func nodeIsPresent() bool {
-	hostname, err := os.Hostname()
+	hostname, err := GetFullHostname()
 	if err != nil {
 		logrus.Errorf("failed to get hostname: %v", err)
 		return false

--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -2985,7 +2985,7 @@ func configureInstallModeDHCP(c *Console) {
 
 func checkDHCPHostname(c *config.HarvesterConfig, generate bool) {
 	if c.Hostname == "" {
-		hostname, err := os.Hostname()
+		hostname, err := GetFullHostname()
 		if err != nil {
 			logrus.Errorf("error fetching hostname from underlying OS: %v", err)
 		}

--- a/pkg/console/util.go
+++ b/pkg/console/util.go
@@ -1235,3 +1235,24 @@ func runCommand(cmd *exec.Cmd) error {
 	}
 	return err
 }
+
+// Get fully-qualified Hostname
+func GetFullHostname() (string, error) {
+	var (
+		hcmd      string
+		hostname string
+		out      []byte
+		err      error
+	)
+
+	// find node hostname
+	hcmd = `hostnamectl --static | tr -d '\r\n'`
+	out, err = exec.Command("/bin/sh", "-c", hcmd).Output()
+	if err != nil {
+		logrus.Errorf("failed to get hostname: %v", err)
+		return "", err
+	}
+
+	hostname = string(out)
+	return hostname, nil
+}


### PR DESCRIPTION
**Problem:**
When using domain names in hostnames, inform RancherD and the Dashboard that this is the proper hostname.

**Solution:**
Add hostname to rancherd node adds, and perform "hostnamectl" instead of "hostname" to pull the FQDN from the hosts.

**Related Issue:**
harvester/harvester#7312

**Test plan:**
Install Harvester with an FQDN as hostname (taylor.rancher.io) and observe that same hostname in the "hosts" and "node" fields throughout.

