### PR TITLE
arm upgrade fix: patch harvester-release.yaml for arm iso builds

### DIFF
--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -15,6 +15,7 @@ fi
 
 mkdir -p ${ARTIFACTS_DIR}
 
+
 source ${SCRIPTS_DIR}/version
 source ${SCRIPTS_DIR}/version-rke2
 source ${SCRIPTS_DIR}/version-rancher
@@ -22,6 +23,29 @@ source ${SCRIPTS_DIR}/version-harvester ${TOP_DIR}/../harvester
 source ${SCRIPTS_DIR}/version-monitoring
 source ${SCRIPTS_DIR}/version-logging
 source ${SCRIPTS_DIR}/lib/iso
+
+# Revert harvester chart version patch to clean dirty git status
+reset_charts() {
+  pushd ${TOP_DIR}/../harvester
+  git checkout -- ./deploy/charts
+  popd
+}
+
+source ${SCRIPTS_DIR}/hack/patch-harvester-chart
+harvester_chart_path=${TOP_DIR}/../harvester/deploy/charts/harvester
+## for arm based builds we need to patch harvester chart
+## we need to temporarily copy the values.yaml for arm builds 
+## to ensure correct kubevirt version is used
+## in the function until mutli-arch image builds are available in registry.suse.com for kubevirt sles15
+if [ ${ARCH} == "arm64" ]
+then
+  patch_harvester_chart ${harvester_chart_path}
+fi
+
+# ARM builds need this version before resetting the chart
+HARVESTER_KUBEVIRT_VERSION=$(yq e '.kubevirt-operator.containers.operator.image.tag' ${harvester_chart_path}/values.yaml)
+reset_charts
+
 
 BASE_OS_IMAGE="rancher/harvester-os:sle-micro-head"
 HARVESTER_OS_IMAGE=rancher/harvester-os:$VERSION

--- a/scripts/version-harvester
+++ b/scripts/version-harvester
@@ -3,5 +3,4 @@
 HARVESTER_VERSION=$(cd $1; source ./scripts/version &> /dev/null; echo $VERSION)
 HARVESTER_APP_VERSION=$(cd $1; source ./scripts/version &> /dev/null; echo $APP_VERSION)
 HARVESTER_CHART_VERSION=$(cd $1; source ./scripts/version &> /dev/null; echo $CHART_VERSION)
-HARVESTER_KUBEVIRT_VERSION=$(yq e '.kubevirt-operator.containers.operator.image.tag' $1/deploy/charts/harvester/values.yaml)
 HARVESTER_MIN_UPGRADABLE_VERSION=$(cd $1; source ./scripts/version &> /dev/null; echo $MIN_UPGRADABLE_VERSION)


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Currently the harvester iso build includes the kubevirt version from the values.yaml file in the harvester/harvester chart.
During the ARM packaging we patch the kubevirt version to upstream version, to allow correct images to be included in the packaging.

However the changes are reverted before the OS packaging, which results in the `harvester-release.yaml` containing the values from the amd64 build. 

This causes the upgrade to fail as the upgrade helper waits for the kubevirt version to be the one defined in the `harvester-release.yaml`. This never reconciles as we end up using the amd64 kubevirt patch version which results in an upgrade being stuck.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
minor changes to allow patching of harvester-release.yaml for ARM builds. This change is needed to ensure correct kubevirt version is included in the harvester-release.yaml. This is essential to ensure the upgrade manifests script can successfully reconcile the kubevirt version with expected version as part of the upgrade process

**Related Issue:**
https://github.com/harvester/harvester/issues/6257

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
To test:
* Install Harvester v1.4.0 on ARM nodes
* Create a custom version object using the iso built from this change or harvester-master-arm64.iso once the PR is merged
* Trigger upgrade of Harvester
* Harvester Upgrade should complete successfully

