### PR TITLE
change multipath default behaviour

### DIFF
--- a/pkg/config/cos.go
+++ b/pkg/config/cos.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -179,6 +180,9 @@ func ConvertToCOS(config *HarvesterConfig) (*yipSchema.YipConfig, error) {
 	if err := setupExternalStorage(config, &initramfs); err != nil {
 		return nil, err
 	}
+
+	// disable multipath for longhorn
+	disableLonghornMultipathing(&initramfs)
 
 	// TOP
 	if cfg.Mode != ModeInstall {
@@ -865,4 +869,34 @@ func setupExternalStorage(config *HarvesterConfig, stage *yipSchema.Stage) error
 		Permissions: 0755,
 	})
 	return nil
+}
+
+// disableLonghornMultipathing tidy's up multipath configuration
+// irrespective of if multipath is needed or not, multipath module is loaded in the kernel
+// which can result in interfering with LH devices
+// to avoid this we drop in a default stage in /etc/multipath/conf.d/99-longhorn.conf
+// which contains a blacklist directive for Longhorn specific VENDOR/PRODUCT combination
+func disableLonghornMultipathing(stage *yipSchema.Stage) {
+	ignoreLonghorn := []byte(`blacklist { 
+  device { 
+    vendor "IET" 
+    product "VIRTUAL-DISK"
+  }
+}`)
+	directives := base64.StdEncoding.EncodeToString(ignoreLonghorn)
+	stage.Directories = append(stage.Directories, yipSchema.Directory{
+		Path:        "/etc/multipath/conf.d",
+		Permissions: 0644,
+		Owner:       0,
+		Group:       0,
+	})
+
+	stage.Files = append(stage.Files, yipSchema.File{
+		Path:        "/etc/multipath/conf.d/99-longhorn.conf",
+		Content:     directives,
+		Encoding:    "base64",
+		Permissions: 0644,
+		Owner:       0,
+		Group:       0,
+	})
 }

--- a/pkg/console/util.go
+++ b/pkg/console/util.go
@@ -51,7 +51,7 @@ You can see the full installation log by:
 
 	ElementalConfigDir  = "/tmp/elemental"
 	ElementalConfigFile = "config.yaml"
-	multipathOff        = "multipath=off"
+	multipathOff        = "rd.multipath=0"
 	PartitionType       = "part"
 	MpathType           = "mpath"
 	CosDiskLabelPrefix  = "COS_OEM"


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Currently when externalDisk support is not enabled, the installer adds a default kernel argument `multipath=off` via `third_party_kernel_arguments`.

This works fine, however it breaks CSI's needing multipath since it cannot be enabled due to the kernel argument.

Disabling `multipath=off` from `third_party_kernel_args` breaks the boot, when OS has been installed to nvme, as multipath attempts to create multiple paths for nvme disks.
**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
To fix this a minor change has been made to default kernel argument being passed when multipath is not needed. This allows dracut to still boot with nvme disks as it ignores multipath module packaged in dracut, while allowing multipathd to be enable subsequently

In addition a default multipath config is added to ignore longhorn based volumes from multipath

**Related Issue:**
https://github.com/harvester/harvester/issues/7438

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
Failure case:
* Install v1.4.0 to a host with nvme disks, with the nvme disk being used as the install disk
* After installation is completed, ssh into the node and attempt to enable multipathd
```
systemctl enable multipathd
systemctl start multipathd
```
This will fail as can be checked via `journalctl -fu multipathd`
* remove the `multipath=off` kernel argument by removing it from /oem/grubenv
`grub2-editenv /oem/grubenv set third_party_kernel_args=""`
* reboot node

Expect node boot to fail

Success case:
* Install build with this change to a host with nvme disks, with the nvme disk being used as the install disk
* After installation is completed, ssh into the node and attempt to enable multipathd
```
systemctl enable multipathd
systemctl start multipathd
```
* create a VM using any image
* once VM is running shell into the node and check `multipath -ll`
* No longhorn volumes should be reported

This will be successful
