### PR TITLE
Drop longhorn chart post-upgrade hook

### DIFF
--- a/scripts/build-bundle
+++ b/scripts/build-bundle
@@ -79,6 +79,7 @@ source ${SCRIPTS_DIR}/hack/patch-rancher-monitoring
 source ${SCRIPTS_DIR}/hack/patch-rancher-logging
 source ${SCRIPTS_DIR}/hack/patch-rancher-monitoring-crd
 source ${SCRIPTS_DIR}/hack/patch-harvester-chart
+source ${SCRIPTS_DIR}/hack/patch-harvester-sub-chart
 source ${addons_path}/version_info
 
 BUNDLE_DIR="${PACKAGE_HARVESTER_OS_DIR}/iso/bundle"
@@ -125,6 +126,12 @@ fi
 helm package ${harvester_chart_path} -d ${CHARTS_DIR}
 helm package ${harvester_crd_chart_path} -d ${CHARTS_DIR}
 
+# patch harvester sub chart to remove longhorn post-upgrade hook
+patch_harvester_sub_chart ${CHARTS_DIR} ${HARVESTER_CHART_VERSION}
+
+# make chart sanity check again after patch
+tar zxvf ${CHARTS_DIR}/harvester-${HARVESTER_CHART_VERSION}.tgz >/dev/null --warning=no-timestamp
+
 # Prepare monitoring chart
 helm pull https://charts.rancher.io/assets/rancher-monitoring-crd/rancher-monitoring-crd-${MONITORING_VERSION}.tgz -d ${CHARTS_DIR}
 helm pull https://charts.rancher.io/assets/rancher-monitoring/rancher-monitoring-${MONITORING_VERSION}.tgz -d ${CHARTS_DIR}
@@ -149,7 +156,7 @@ helm pull https://charts.rancher.io/assets/rancher-logging/rancher-logging-${LOG
 tar zxvf ${CHARTS_DIR}/rancher-logging-crd-${LOGGING_VERSION}.tgz >/dev/null  --warning=no-timestamp
 tar zxvf ${CHARTS_DIR}/rancher-logging-${LOGGING_VERSION}.tgz >/dev/null --warning=no-timestamp
 
-# patch rancher-logging chart to collect more logs"
+# patch rancher-logging chart to collect more logs
 PKG_PATCH_LOGGING_PATH="${TOP_DIR}/pkg/config/templates/patch/rancher-logging"
 patch_rancher_logging_chart ${CHARTS_DIR} ${LOGGING_VERSION} ${PKG_PATCH_LOGGING_PATH}
 

--- a/scripts/hack/patch-harvester-sub-chart
+++ b/scripts/hack/patch-harvester-sub-chart
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+patch_harvester_sub_chart()
+{
+  local chart_dir=$1 #${CHARTS_DIR}
+  local harvester_version=$2 # harvester chart version
+  local cwd=$(pwd)
+
+  cd ${chart_dir}
+  local chartfile=harvester-${harvester_version}.tgz
+  ls -alth ${chartfile} || (echo "not found the chart ${chartfile}" && exit 1)
+  tar zxf ${chartfile} --warning=no-timestamp
+
+  local posthook="./harvester/charts/longhorn/templates/postupgrade-job.yaml"
+  echo "patch the sub chart longhorn"
+
+  ls -alth ${posthook} || (echo "not found the to-be-removed file ${posthook}, skip patch" && rm -rf harvester && return)
+  echo "remove ${posthook}"
+  rm -r ${posthook}
+  ls -alth ./harvester/charts/longhorn/templates/
+
+  echo "remove exiting chart ${chartfile}"
+  rm -r ${chartfile}
+  # helm pack new
+  helm package harvester
+  ls -alth ${chartfile} || (echo "not found the new chart ${chartfile}, check" && exit 1)
+  rm -rf harvester
+  echo "finish patch harvester sub chart"
+  cd $cwd
+}
+

--- a/scripts/hack/patch-rancher-logging
+++ b/scripts/hack/patch-rancher-logging
@@ -45,7 +45,7 @@ patch_rancher_logging_chart()
   # helm pack new
   helm package rancher-logging
   rm -rf rancher-logging
-  echo "finish patch ranch-logging chart"
+  echo "finish patch rancher-logging chart"
   cd $cwd
 }
 

--- a/scripts/hack/patch-rancher-monitoring
+++ b/scripts/hack/patch-rancher-monitoring
@@ -53,7 +53,7 @@ patch_rancher_monitoring_chart()
   # helm pack new
   helm package rancher-monitoring
   rm -rf rancher-monitoring
-  echo "finish patch ranch-monitoring chart"
+  echo "finish patch rancher-monitoring chart"
   cd $cwd
 }
 

--- a/scripts/hack/patch-rancher-monitoring-crd
+++ b/scripts/hack/patch-rancher-monitoring-crd
@@ -36,7 +36,7 @@ patch_rancher_monitoring_crd_chart()
   # helm pack new
   helm package rancher-monitoring-crd
   rm -rf rancher-monitoring-crd
-  echo "finish patch ranch-monitoring-crd chart"
+  echo "finish patch rancher-monitoring-crd chart"
   cd $cwd
 }
 


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

Harvester managedchart report post-upgrade hooks (longhorn-post-upgrade) failed: context deadline exceeded

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Before upstream (fleet/helm) fix the bug, Harvester temporarily drops the LH post-upgrade hook.

NOTE: 
(1) PR https://github.com/harvester/harvester-installer/pull/929 also mentioned this case and the related workaround.
(2) ManagedChart has no option to `disable post-upgrade hook`
(3) Another Hook policy is tested, which can't fix the bug

https://github.com/longhorn/longhorn/blob/bad420bce26a190656fbace414cb8cad22a472c0/chart/templates/postupgrade-job.yaml#L5
```
    "helm.sh/hook": post-upgrade
    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
```
is changed to Hlem suggested default value

```
    "helm.sh/hook": post-upgrade
    "helm.sh/hook-delete-policy": before-hook-creation
```
The `post-hook` JOB is left after managedchart is upgraded and removed in next round upgrade.


build log:

```
...
Successfully packaged chart and saved it to: /go/src/github.com/harvester/harvester-installer/package/harvester-repo/charts/harvester-0.0.0-master-51edf948.tgz
Successfully packaged chart and saved it to: /go/src/github.com/harvester/harvester-installer/package/harvester-repo/charts/harvester-crd-0.0.0-master-51edf948.tgz
-rw-r--r-- 1 root root 218K Jan 23 13:35 harvester-0.0.0-master-51edf948.tgz
patch the sub chart longhorn
-rw-r--r-- 1 root root 2.4K Jan 23 13:35 ./harvester/charts/longhorn/templates/postupgrade-job.yaml
remove ./harvester/charts/longhorn/templates/postupgrade-job.yaml
total 272K
drwxr-xr-x 3 root root 4.0K Jan 23 13:35 .
drwxr-xr-x 3 root root 4.0K Jan 23 13:35 ..
drwxr-xr-x 2 root root 4.0K Jan 23 13:35 network-policies
-rw-r--r-- 1 root root  234 Jan 23 13:35 NOTES.txt
-rw-r--r-- 1 root root 2.0K Jan 23 13:35 _helpers.tpl
-rw-r--r-- 1 root root 3.3K Jan 23 13:35 clusterrole.yaml
-rw-r--r-- 1 root root 1.4K Jan 23 13:35 clusterrolebinding.yaml
-rw-r--r-- 1 root root 154K Jan 23 13:35 crds.yaml
-rw-r--r-- 1 root root 6.6K Jan 23 13:35 daemonset-sa.yaml
-rw-r--r-- 1 root root  16K Jan 23 13:35 default-setting.yaml
-rw-r--r-- 1 root root 6.3K Jan 23 13:35 deployment-driver.yaml
-rw-r--r-- 1 root root 6.5K Jan 23 13:35 deployment-ui.yaml
-rw-r--r-- 1 root root 1.1K Jan 23 13:35 ingress.yaml
-rw-r--r-- 1 root root 2.6K Jan 23 13:35 preupgrade-job.yaml
-rw-r--r-- 1 root root  371 Jan 23 13:35 priorityclass.yaml
-rw-r--r-- 1 root root 1.4K Jan 23 13:35 psp.yaml
-rw-r--r-- 1 root root  404 Jan 23 13:35 registry-secret.yaml
-rw-r--r-- 1 root root 1.3K Jan 23 13:35 serviceaccount.yaml
-rw-r--r-- 1 root root 1.2K Jan 23 13:35 servicemonitor.yaml
-rw-r--r-- 1 root root 1.2K Jan 23 13:35 services.yaml
-rw-r--r-- 1 root root 2.6K Jan 23 13:35 storageclass.yaml
-rw-r--r-- 1 root root  379 Jan 23 13:35 tls-secrets.yaml
-rw-r--r-- 1 root root 2.5K Jan 23 13:35 uninstall-job.yaml
-rw-r--r-- 1 root root  367 Jan 23 13:35 validate-psp-install.yaml
remove exiting chart harvester-0.0.0-master-51edf948.tgz
Successfully packaged chart and saved it to: /go/src/github.com/harvester/harvester-installer/package/harvester-repo/charts/harvester-0.0.0-master-51edf948.tgz
-rw-r--r-- 1 root root 218K Jan 23 13:35 harvester-0.0.0-master-51edf948.tgz
finish patch harvester sub chart
...
```



**Related Issue:**

https://github.com/harvester/harvester/issues/7441

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

Per issue description
