### PR TITLE
[Backport v1.5] fix kernel command line for management interface

### DIFF
--- a/pkg/util/cmdline_test.go
+++ b/pkg/util/cmdline_test.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/rancher/mapper/values"
@@ -37,27 +38,55 @@ func Test_parseCmdLineWithoutPrefix(t *testing.T) {
 }
 
 func Test_parseCmdLineWithNetworkInterface(t *testing.T) {
-
-	cmdline := `harvester.os.sshAuthorizedKeys=a  harvester.install.management_interface.method=dhcp harvester.install.management_interface.bond_options.mode=balance-tlb harvester.install.management_interface.bond_options.miimon=100 harvester.os.sshAuthorizedKeys=b harvester.install.mode=create harvester.install.management_interface.interfaces="hwAddr: ab:cd:ef:gh:ij:kl" harvester.install.management_interface.interfaces="hwAddr:   de:fg:hi:jk:lm:no" harvester.install.management_interface.interfaces="ens3" harvester.install.management_interface.interfaces="name:ens5"`
-
-	m, err := parseCmdLine(cmdline, "harvester")
-	if err != nil {
-		t.Fatal(err)
+	type testcase struct {
+		cmdline       string
+		expectation   []interface{}
+		expectedError error
 	}
 
-	want := []interface{}{
-		map[string]interface{}{"hwAddr": "ab:cd:ef:gh:ij:kl"},
-		map[string]interface{}{"hwAddr": "de:fg:hi:jk:lm:no"},
-		map[string]interface{}{"name": "ens3"},
-		map[string]interface{}{"name": "ens5"},
+	testcases := []testcase{
+		{
+			cmdline: `harvester.os.sshAuthorizedKeys=a  harvester.install.management_interface.method=dhcp harvester.install.management_interface.bond_options.mode=balance-tlb harvester.install.management_interface.bond_options.miimon=100 harvester.os.sshAuthorizedKeys=b harvester.install.mode=create harvester.install.management_interface.interfaces="hwAddr: ab:cd:ef:gh:ij:kl" harvester.install.management_interface.interfaces="hwAddr:   de:fg:hi:jk:lm:no" harvester.install.management_interface.interfaces="ens3" harvester.install.management_interface.interfaces="name:ens5"`,
+			expectation: []interface{}{
+				map[string]interface{}{"hwAddr": "ab:cd:ef:gh:ij:kl"},
+				map[string]interface{}{"hwAddr": "de:fg:hi:jk:lm:no"},
+				map[string]interface{}{"name": "ens3"},
+				map[string]interface{}{"name": "ens5"},
+			},
+			expectedError: nil,
+		},
+		{
+			cmdline: `harvester.install.management_interface.interfaces="ens3"`,
+			expectation: []interface{}{
+				map[string]interface{}{"name": "ens3"},
+			},
+			expectedError: nil,
+		},
+		{
+			cmdline:       `harvester.os.sshAuthorizedKeys=a  harvester.install.management_interface.method=dhcp harvester.install.management_interface.bond_options.mode=balance-tlb harvester.install.management_interface.bond_options.miimon=100 harvester.os.sshAuthorizedKeys=b harvester.install.mode=create harvester.install.management_interface.interfaces="foo:bar:foobar"`,
+			expectation:   []interface{}{},
+			expectedError: fmt.Errorf("could not parse interface details"),
+		},
 	}
 
-	have, ok := values.GetValue(m, "install", "management_interface", "interfaces")
-	if !ok {
-		t.Fatal(fmt.Errorf("no network interfaces found"))
-	}
+	for _, tc := range testcases {
+		m, err := parseCmdLine(tc.cmdline, "harvester")
+		if err != nil {
+			if tc.expectedError != nil {
+				assert.True(t, strings.Contains(err.Error(), tc.expectedError.Error()), "unexpected error")
+			} else {
+				t.Fatal(err)
+			}
+		} else {
+			want := tc.expectation
+			have, ok := values.GetValue(m, "install", "management_interface", "interfaces")
+			if !ok {
+				t.Fatal(fmt.Errorf("no network interfaces found"))
+			}
 
-	assert.Equal(t, want, have)
+			assert.Equal(t, want, have)
+		}
+	}
 }
 
 func Test_parseCmdLineWithSchemeVersion(t *testing.T) {

--- a/pkg/util/cmdline_test.go
+++ b/pkg/util/cmdline_test.go
@@ -38,7 +38,7 @@ func Test_parseCmdLineWithoutPrefix(t *testing.T) {
 
 func Test_parseCmdLineWithNetworkInterface(t *testing.T) {
 
-	cmdline := `harvester.os.sshAuthorizedKeys=a  harvester.install.management_interface.method=dhcp harvester.install.management_interface.bond_options.mode=balance-tlb harvester.install.management_interface.bond_options.miimon=100 harvester.os.sshAuthorizedKeys=b harvester.install.mode=create harvester.install.management_interface.interfaces="hwAddr: ab:cd:ef:gh" harvester.install.management_interface.interfaces="hwAddr:   de:fg:hi:jk"`
+	cmdline := `harvester.os.sshAuthorizedKeys=a  harvester.install.management_interface.method=dhcp harvester.install.management_interface.bond_options.mode=balance-tlb harvester.install.management_interface.bond_options.miimon=100 harvester.os.sshAuthorizedKeys=b harvester.install.mode=create harvester.install.management_interface.interfaces="hwAddr: ab:cd:ef:gh:ij:kl" harvester.install.management_interface.interfaces="hwAddr:   de:fg:hi:jk:lm:no" harvester.install.management_interface.interfaces="ens3" harvester.install.management_interface.interfaces="name:ens5"`
 
 	m, err := parseCmdLine(cmdline, "harvester")
 	if err != nil {
@@ -46,12 +46,10 @@ func Test_parseCmdLineWithNetworkInterface(t *testing.T) {
 	}
 
 	want := []interface{}{
-		map[string]interface{}{
-			"hwAddr": "ab:cd:ef:gh",
-		},
-		map[string]interface{}{
-			"hwAddr": "de:fg:hi:jk",
-		},
+		map[string]interface{}{"hwAddr": "ab:cd:ef:gh:ij:kl"},
+		map[string]interface{}{"hwAddr": "de:fg:hi:jk:lm:no"},
+		map[string]interface{}{"name": "ens3"},
+		map[string]interface{}{"name": "ens5"},
 	}
 
 	have, ok := values.GetValue(m, "install", "management_interface", "interfaces")
@@ -63,7 +61,7 @@ func Test_parseCmdLineWithNetworkInterface(t *testing.T) {
 }
 
 func Test_parseCmdLineWithSchemeVersion(t *testing.T) {
-	cmdline := `harvester.os.sshAuthorizedKeys=a  harvester.install.management_interface.method=dhcp harvester.install.management_interface.bond_options.mode=balance-tlb harvester.install.management_interface.bond_options.miimon=100 harvester.os.sshAuthorizedKeys=b harvester.install.mode=create harvester.install.management_interface.interfaces="hwAddr: ab:cd:ef:gh" harvester.install.management_interface.interfaces="hwAddr:   de:fg:hi:jk" harvester.scheme_version=1`
+	cmdline := `harvester.os.sshAuthorizedKeys=a  harvester.install.management_interface.method=dhcp harvester.install.management_interface.bond_options.mode=balance-tlb harvester.install.management_interface.bond_options.miimon=100 harvester.os.sshAuthorizedKeys=b harvester.install.mode=create harvester.install.management_interface.interfaces="hwAddr: ab:cd:ef:gh:ij:kl" harvester.install.management_interface.interfaces="hwAddr:   de:fg:hi:jk:lm:no" harvester.scheme_version=1`
 
 	m, err := parseCmdLine(cmdline, "harvester")
 	assert.NoError(t, err, "expected no error while parsing arguments")


### PR DESCRIPTION
This is a backport of [PR #942](https://github.com/harvester/harvester-installer/pull/942) to v1.5 branch.

Fix parsing management interface configuration from the kernel command line.
The parser now accepts more different specifications for the management interface, including just the systemd name for the device. Additionally, should the configuration not be parseable (e.g. due to a typo), the installer doesn't crash anymore, but rather produces a human readable error.

related-to: https://github.com/harvester/harvester/issues/7470