### PR TITLE
clean up calico dhcp state on reboots

### DIFF
--- a/package/harvester-os/files/system/oem/99_cni_reset.yaml
+++ b/package/harvester-os/files/system/oem/99_cni_reset.yaml
@@ -1,0 +1,5 @@
+name: "reset container dhcp leases"
+stages:
+   initramfs:
+     - command:
+       - rm -rf /var/lib/cni/networks/k8s-pod-network


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
Under certain scenarios when a harvester node is hard rebooted the canal cni can leak ip addresses 
https://docs.rke2.io/known_issues#canal-and-ip-exhaustion
Over time these may build up and result in ip address pool exhaustion for a node since.

The only option in such a scenario is to clean up un-used ip leases from `/var/lib/cni/networks/k8s-pod-network`

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
PR introduces a minor change to add directives for cni reset in base image. 
This ensures they are rolled out to existing systems as part of the upgrade cycle

**Related Issue:**
https://github.com/harvester/harvester/issues/7471

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
* Install harvester from current changes to a node
* Once harvester is running hard reboot the node
* Once harvester is up and running check the timestamp on the folder

```
/system/oem # ls -ld /var/lib/cni/networks/k8s-pod-network
drwxr-xr-x 2 root root 4096 Feb  7 02:40 /var/lib/cni/networks/k8s-pod-network
```

* the folder would have been recreated after the reboot
```
/system/oem # last reboot
reboot   system boot  5.14.21-150500.5 Fri Feb  7 02:32   still running

wtmp begins Fri Feb  7 02:32:03 2025
```