### PR TITLE
fix: ensure passive.img is sparse after install

### DIFF
--- a/package/harvester-os/files/usr/sbin/harv-install
+++ b/package/harvester-os/files/usr/sbin/harv-install
@@ -154,6 +154,14 @@ do_mount()
     mount ${PERSISTENT} ${TARGET}/usr/local
 }
 
+sparsify_passive_img()
+{
+    # See https://github.com/harvester/harvester/issues/7518
+    echo "Ensuring passive.img is sparse..."
+    echo "  was: $(du -h ${STATEDIR}/cOS/passive.img)"
+    fallocate --dig-holes ${STATEDIR}/cOS/passive.img
+    echo "  now: $(du -h ${STATEDIR}/cOS/passive.img)"
+}
 
 preload_rke2_images()
 {
@@ -528,6 +536,7 @@ do_data_disk_format
 # Preload images
 do_detect
 do_mount
+sparsify_passive_img
 get_iso  # For PXE Boot
 save_configs
 save_wicked_state


### PR DESCRIPTION
**Problem:**
If `passive.img` is not a sparse file, it can result in too much disk space being used on the COS_STATE partition which causes problems for upgrades (see related issues).

**Solution:**
After installation, run `fallocate --dig-holes` to make `passive.img` sparse if it's not already.

**Related Issue:**
https://github.com/harvester/harvester/issues/7457
https://github.com/harvester/harvester/issues/7518

**Test plan:**
- Install Harvester
- Post-install, check disk usage of active.img and passive.img. They should be the same (about 1.7G):
  ```
  # du -sh /run/initramfs/cos-state/cOS/*
  1.7G	/run/initramfs/cos-state/cOS/active.img
  1.7G	/run/initramfs/cos-state/cOS/passive.img
  ```
- The fact that passive.img shrunk from 3.1G to 1.7G should be recorded in the install log, e.g.:
  ```
  # grep passive /oem/install/console.log | tail -n 3
  time="2025-02-11T11:59:38Z" level=info msg="[stdout]: Ensuring passive.img is sparse..."
  time="2025-02-11T11:59:38Z" level=info msg="[stdout]:   was: 3.1G\t/tmp/mnt/STATE/cOS/passive.img"
  time="2025-02-11T11:59:38Z" level=info msg="[stdout]:   now: 1.7G\t/tmp/mnt/STATE/cOS/passive.img"
  ```