### PR TITLE
fix: use same COS_* partition sizes regardless of seaparate data disk

### DIFF
--- a/pkg/config/cos.go
+++ b/pkg/config/cos.go
@@ -796,7 +796,33 @@ func calcCosPersistentPartSize(diskSizeGiB uint64, partSize string) (uint64, err
 	return util.ByteToMi(size), nil
 }
 
-func CreateRootPartitioningLayout(elementalConfig *ElementalConfig, hvstConfig *HarvesterConfig) (*ElementalConfig, error) {
+func CreateRootPartitioningLayoutSeparateDataDisk(elementalConfig *ElementalConfig) *ElementalConfig {
+	elementalConfig.Install.Partitions = &ElementalDefaultPartition{
+		OEM: &ElementalPartition{
+			FilesystemLabel: "COS_OEM",
+			Size:            DefaultCosOemSizeMiB,
+			FS:              "ext4",
+		},
+		State: &ElementalPartition{
+			FilesystemLabel: "COS_STATE",
+			Size:            DefaultCosStateSizeMiB,
+			FS:              "ext4",
+		},
+		Recovery: &ElementalPartition{
+			FilesystemLabel: "COS_RECOVERY",
+			Size:            DefaultCosRecoverySizeMiB,
+			FS:              "ext4",
+		},
+		Persistent: &ElementalPartition{
+			FilesystemLabel: "COS_PERSISTENT",
+			Size:            0,
+			FS:              "ext4",
+		},
+	}
+	return elementalConfig
+}
+
+func CreateRootPartitioningLayoutSharedDataDisk(elementalConfig *ElementalConfig, hvstConfig *HarvesterConfig) (*ElementalConfig, error) {
 	diskSizeBytes, err := util.GetDiskSizeBytes(hvstConfig.Install.Device)
 	if err != nil {
 		return nil, err

--- a/pkg/console/util.go
+++ b/pkg/console/util.go
@@ -531,10 +531,12 @@ func doInstall(g *gocui.Gui, hvstConfig *config.HarvesterConfig, webhooks Render
 
 	if hvstConfig.ShouldCreateDataPartitionOnOsDisk() {
 		// Use custom layout (which also creates Longhorn partition) when needed
-		elementalConfig, err = config.CreateRootPartitioningLayout(elementalConfig, hvstConfig)
+		elementalConfig, err = config.CreateRootPartitioningLayoutSharedDataDisk(elementalConfig, hvstConfig)
 		if err != nil {
 			return err
 		}
+	} else {
+		elementalConfig = config.CreateRootPartitioningLayoutSeparateDataDisk(elementalConfig)
 	}
 
 	if hvstConfig.DataDisk != "" {


### PR DESCRIPTION
**Problem:**
When Harvester is installed with a single disk shared between OS and data, we set the COS_STATE parittion size to 15G. When using a separate data disk, we just use the Elemental default partition layout, which only gives COS_STATE of 8G. This causes problems with upgrades due to lack of space.

**Solution:**
This commit ensures we set a 15G COS_STATE parition in both of the above cases.

**Related Issue:**
- https://github.com/harvester/harvester/issues/7457
- https://github.com/harvester/harvester/issues/7493

**Test plan:**
- Install Harvester with a shared OS/data disk. Check the COS_OEM, COS_RECOVERY and COS_STATE partition sizes:
  ```
  # lsblk -o NAME,LABEL,SIZE
  NAME    LABEL             SIZE
  [...]
  vda                       500G
  ├─vda1                      1M
  ├─vda2  COS_OEM            50M          <-- 50M is correct
  ├─vda3  COS_RECOVERY        8G          <-- 8G is correct
  ├─vda4  COS_STATE          15G          <-- 15G is correct
  ├─vda5  COS_PERSISTENT    150G
  └─vda6  HARV_LH_DEFAULT 326.9G
  [...]
  ```
- Install Harvester with a separate data disk. Check the COS_OEM, COS_RECOVERY and COS_STATE partition sizes. They should be the same as above:
  ```
  # lsblk -o NAME,LABEL,SIZE
  NAME   LABEL             SIZE
  [...]
  vda                      250G
  ├─vda1 COS_GRUB           64M
  ├─vda2 COS_OEM            50M          <-- 50M is correct
  ├─vda3 COS_RECOVERY        8G          <-- 8G is correct
  ├─vda4 COS_STATE          15G          <-- 15G is correct
  └─vda5 COS_PERSISTENT  226.9G
  vdb    HARV_LH_DEFAULT   128G
  ```
  (Ignore COS_GRUB -- in the examples above one node was installed with BIOS, the other with UEFI, sorry for any confusion)
- Prior to this fix, if you were to install Harvester with a separate data disk, COS_RECOVERY would only be 4G, and COS_STATE would be 8G.