### PR TITLE
feat: add agentTLSMode to rancherValues

### DIFF
--- a/package/harvester-os/files/usr/share/rancher/rancherd/config.yaml.d/50-defaults.yaml
+++ b/package/harvester-os/files/usr/share/rancher/rancherd/config.yaml.d/50-defaults.yaml
@@ -7,6 +7,7 @@ rancherValues:
   useBundledSystemChart: true
   bootstrapPassword: admin
   hostPort: 0
+  agentTLSMode: system-store
   global:
     cattle:
       psp:


### PR DESCRIPTION
**Problem:**
Rancher added new setting `agent-tls-mode` which breaks custom CA feature.

**Solution:**
Set the setting to `system-store` to fix the error.

**Related Issue:**
https://github.com/harvester/harvester/issues/7453

**Test plan:**
1. Build with harvester-installer to create an ISO.
2. Start first node.
3. Check whether value of `agent-tls-mode` setting is `system-store`.
4. Setup `ssl-certificates` setting.
5. Create second node to join first node without error.

