### PR TITLE
fix: persist /etc/nvme

### DIFF
--- a/pkg/config/templates/cos-rootfs.yaml
+++ b/pkg/config/templates/cos-rootfs.yaml
@@ -11,6 +11,7 @@ environment:
     /etc/rancher
     /etc/ssh
     /etc/iscsi
+    /etc/nvme
     /etc/cni
     /etc/pki/trust/anchors
     /home


### PR DESCRIPTION
**Problem:**
Our OS image includes `/etc/machine-id`, `/etc/iscsi/initiatorname.iscsi`, `/etc/nvme/hostid` and `/etc/nvme/hostnqn`. This means that those files will be identical on every single Harvester node installed from a given ISO image. This is wrong.

`/etc/machine-id` is meant to be unique per host, see e.g.:

https://manpages.opensuse.org/Tumbleweed/systemd/machine-id.5.en.html

Likewise, the iSCSI initiator name and NVMe hostid/hostnqn need to be unique when accessing external storage via iSCSI or NVMe over fabrics.

**Solution:**
https://github.com/harvester/os2/pull/190 ensures that those files are _not_ included in our OS image, and will be instead generated on first boot. This harvester-installer PR is also required to ensure `/etc/nvme` persists correctly.

**Related Issue:**
https://github.com/harvester/harvester/issues/6911

**Test plan:**
- With this and https://github.com/harvester/os2/pull/190 applied, install harvester on at least two nodes.
- Check the contents of `/etc/machine-id`, `/etc/iscsi/initiatorname.iscsi`, `/etc/nvme/hostid` and `/etc/nvme/hostnq` on each node. The contents of the files should be different on each node. This verifies that those files are being uniquely generated on each node on first boot.
- Reboot each node. Check the contents of those files again. Verify on each node that the contents are the same as they were before the reboot. This verifies that the files are correctly persisted and are not being re-generated on subsequent boots.

