### PR TITLE
config: add rke2 config to improve the device permission

### DIFF
--- a/pkg/config/cos.go
+++ b/pkg/config/cos.go
@@ -363,6 +363,21 @@ func initRancherdStage(config *HarvesterConfig, stage *yipSchema.Stage) error {
 		)
 	}
 
+	// RKE2 settings of device permissions (device_ownership_from_security_context)
+	rke2DeviceOwnershipConfig, err := render("rke2-91-harvester-cdi.yaml", config)
+	if err != nil {
+		return err
+	}
+	stage.Files = append(stage.Files,
+		yipSchema.File{
+			Path:        "/etc/rancher/rke2/config.yaml.d/91-harvester-cdi.yaml",
+			Content:     rke2DeviceOwnershipConfig,
+			Permissions: 0600,
+			Owner:       0,
+			Group:       0,
+		},
+	)
+
 	// RKE2 settings of kube-audit
 	rke2KubeAuditConfig, err := render("rke2-92-harvester-kube-audit-policy.yaml", config)
 	if err != nil {

--- a/pkg/config/templates/rke2-91-harvester-cdi.yaml
+++ b/pkg/config/templates/rke2-91-harvester-cdi.yaml
@@ -1,0 +1,2 @@
+# handle the permission issue of Longhorn for CDI
+"nonroot-devices": true


### PR DESCRIPTION
**Problem:**
We encounter the permission issue when using Longhorn v2 volume with CDI

**Solution:**
Set `device_ownership_from_security_context` to true for better permission handling.

**Related Issue:**
https://github.com/harvester/harvester/issues/1199

**Test plan:**
Please see the test plan on https://github.com/harvester/harvester/pull/7640

