### PR TITLE
Backport v1.5 change multipath behaviour

### DIFF
--- a/pkg/config/cos.go
+++ b/pkg/config/cos.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -179,6 +180,9 @@ func ConvertToCOS(config *HarvesterConfig) (*yipSchema.YipConfig, error) {
 	if err := setupExternalStorage(config, &initramfs); err != nil {
 		return nil, err
 	}
+
+	// disable multipath for longhorn
+	disableLonghornMultipathing(&initramfs)
 
 	// TOP
 	if cfg.Mode != ModeInstall {
@@ -891,4 +895,34 @@ func setupExternalStorage(config *HarvesterConfig, stage *yipSchema.Stage) error
 		Permissions: 0755,
 	})
 	return nil
+}
+
+// disableLonghornMultipathing tidy's up multipath configuration
+// irrespective of if multipath is needed or not, multipath module is loaded in the kernel
+// which can result in interfering with LH devices
+// to avoid this we drop in a default stage in /etc/multipath/conf.d/99-longhorn.conf
+// which contains a blacklist directive for Longhorn specific VENDOR/PRODUCT combination
+func disableLonghornMultipathing(stage *yipSchema.Stage) {
+	ignoreLonghorn := []byte(`blacklist { 
+  device { 
+    vendor "IET" 
+    product "VIRTUAL-DISK"
+  }
+}`)
+	directives := base64.StdEncoding.EncodeToString(ignoreLonghorn)
+	stage.Directories = append(stage.Directories, yipSchema.Directory{
+		Path:        "/etc/multipath/conf.d",
+		Permissions: 0644,
+		Owner:       0,
+		Group:       0,
+	})
+
+	stage.Files = append(stage.Files, yipSchema.File{
+		Path:        "/etc/multipath/conf.d/99-longhorn.conf",
+		Content:     directives,
+		Encoding:    "base64",
+		Permissions: 0644,
+		Owner:       0,
+		Group:       0,
+	})
 }

--- a/pkg/console/util.go
+++ b/pkg/console/util.go
@@ -51,7 +51,7 @@ You can see the full installation log by:
 
 	ElementalConfigDir  = "/tmp/elemental"
 	ElementalConfigFile = "config.yaml"
-	multipathOff        = "multipath=off"
+	multipathOff        = "rd.multipath=0"
 	PartitionType       = "part"
 	MpathType           = "mpath"
 	CosDiskLabelPrefix  = "COS_OEM"

--- a/pkg/console/util.go
+++ b/pkg/console/util.go
@@ -51,7 +51,7 @@ You can see the full installation log by:
 
 	ElementalConfigDir  = "/tmp/elemental"
 	ElementalConfigFile = "config.yaml"
-	multipathOff        = "rd.multipath=0"
+	multipathOff        = "multipath=off"
 	PartitionType       = "part"
 	MpathType           = "mpath"
 	CosDiskLabelPrefix  = "COS_OEM"


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
PR contains cherry-picked commits related to 
https://github.com/harvester/harvester-installer/pull/938
https://github.com/harvester/harvester-installer/pull/988

The first PR changed default multipathing behaviour to `rd.multipath=0` and disabled multipath for longhorn devices.

This seemed to have cause issues with booting on certain devices.

The second behaviour revert to `multipath=off` and changed the multipath systemd unit to start even if `multipath=off` is added to kernel arguments

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Related Issue:**
https://github.com/harvester/harvester/issues/7622
https://github.com/harvester/harvester/issues/7438

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

