### PR TITLE
feat: add sans to HarvesterConfig

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -233,9 +233,10 @@ type SSHDConfig struct {
 
 type HarvesterConfig struct {
 	// Harvester will use scheme version to determine current version and migrate config to new scheme version
-	SchemeVersion          uint32 `json:"schemeVersion,omitempty"`
-	ServerURL              string `json:"serverUrl,omitempty"`
-	Token                  string `json:"token,omitempty"`
+	SchemeVersion          uint32   `json:"schemeVersion,omitempty"`
+	ServerURL              string   `json:"serverUrl,omitempty"`
+	Token                  string   `json:"token,omitempty"`
+	SANS                   []string `json:"sans,omitempty"`
 	OS                     `json:"os,omitempty"`
 	Install                `json:"install,omitempty"`
 	RuntimeVersion         string            `json:"runtimeVersion,omitempty"`

--- a/pkg/config/templates/rke2-90-harvester-server.yaml
+++ b/pkg/config/templates/rke2-90-harvester-server.yaml
@@ -4,6 +4,11 @@ service-cidr: {{ or .ClusterServiceCIDR "10.53.0.0/16" }}
 cluster-dns: {{ or .ClusterDNS "10.53.0.10" }}
 tls-san:
   - {{ .Vip }}
+{{if .SANS -}}
+{{- range .SANS }}
+  - {{ . }}
+{{- end }}
+{{- end }}
 {{- with $args :=  .GetKubeletArgs }}
 kubelet-arg:
 {{- range $arg := $args }}


### PR DESCRIPTION
**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Allow users to add other endpoints to `tls-san`.

**Related Issue:**
https://github.com/harvester/harvester/issues/7716

**Test plan:**
1. Clone https://github.com/harvester/ipxe-examples.
2. Modify `ansible/roles/harvester/templates/config-create.yaml.j2` to add `sans` like
```yaml
# ...
sans:
  - example.com
# ...
```
3. Create a harvester cluster with ISO from this branch.
4. After first node is ready, check there is `example.com` and VIP in the certificate.
```
> openssl x509 -in /var/lib/rancher/rke2/server/tls/serving-kube-apiserver.crt -text -noout
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number: 927360019122894648 (0xcdea50626b83738)
        Signature Algorithm: ecdsa-with-SHA256
        Issuer: CN = rke2-server-ca@1740650146
        Validity
            Not Before: Feb 27 09:55:46 2025 GMT
            Not After : Feb 27 09:55:46 2026 GMT
        Subject: CN = kube-apiserver
        Subject Public Key Info:
            Public Key Algorithm: id-ecPublicKey
                Public-Key: (256 bit)
                pub:
                    04:23:6a:e5:22:52:d0:82:3b:48:64:e4:1c:72:11:
                    c9:b4:96:b5:ae:de:82:a3:e3:a5:fe:e5:b3:21:04:
                    43:32:f6:f2:7e:54:73:99:e9:65:80:07:82:54:fb:
                    33:45:b7:e1:4a:1e:30:4f:be:7f:b8:60:cc:86:54:
                    f6:39:0c:7d:94
                ASN1 OID: prime256v1
                NIST CURVE: P-256
        X509v3 extensions:
            X509v3 Key Usage: critical
                Digital Signature, Key Encipherment
            X509v3 Extended Key Usage:
                TLS Web Server Authentication
            X509v3 Authority Key Identifier:
                keyid:02:33:86:86:97:C3:32:3C:16:E0:C6:66:19:59:0B:93:C9:A0:5B:B5

            X509v3 Subject Alternative Name:
                DNS:kubernetes, DNS:kubernetes.default, DNS:kubernetes.default.svc, DNS:kubernetes.default.svc.cluster.local, DNS:example.com, DNS:localhost, DNS:harvester-node-0, IP Address:192.168.3.131, IP Address:127.0.0.1, IP Address:0:0:0:0:0:0:0:1, IP Address:192.168.3.30, IP Address:10.53.0.1
    Signature Algorithm: ecdsa-with-SHA256
         30:46:02:21:00:af:b7:81:97:f4:d1:fe:bb:62:a1:46:48:30:
         ab:e8:02:ae:32:44:d8:cb:96:87:e5:85:33:ce:7c:83:cb:c7:
         48:02:21:00:ac:93:b4:62:f6:65:0a:42:8b:9c:69:51:54:47:
         6a:1d:12:96:4a:bd:e9:5e:4e:eb:a4:55:a2:39:bd:b3:48:80
```
