### PR TITLE
re-add harvester chart patching for harvester v1.4.x builds

### DIFF
--- a/scripts/build-bundle
+++ b/scripts/build-bundle
@@ -78,6 +78,7 @@ source ${SCRIPTS_DIR}/lib/image
 source ${SCRIPTS_DIR}/hack/patch-rancher-monitoring
 source ${SCRIPTS_DIR}/hack/patch-rancher-logging
 source ${SCRIPTS_DIR}/hack/patch-rancher-monitoring-crd
+source ${SCRIPTS_DIR}/hack/patch-harvester-chart
 source ${addons_path}/version_info
 
 BUNDLE_DIR="${PACKAGE_HARVESTER_OS_DIR}/iso/bundle"
@@ -112,6 +113,14 @@ ${SCRIPTS_DIR}/patch-harvester ${TOP_DIR}/../harvester
 # Package harvester chart
 harvester_chart_path=${harvester_path}/deploy/charts/harvester
 harvester_crd_chart_path=${harvester_path}/deploy/charts/harvester-crd
+
+## for arm based builds we need to patch harvester chart
+## we also patch the version to v1.1.1 for now and this needs to be manually updated
+## in the function until mutli-arch image builds are available in registry.suse.com for kubevirt sles15
+if [ ${ARCH} == "arm64" ]
+then
+  patch_harvester_chart ${harvester_chart_path}
+fi
 
 helm package ${harvester_chart_path} -d ${CHARTS_DIR}
 helm package ${harvester_crd_chart_path} -d ${CHARTS_DIR}

--- a/scripts/hack/patch-harvester-chart
+++ b/scripts/hack/patch-harvester-chart
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+patch_harvester_chart(){
+    local kubevirt_arm_version="v1.3.1"
+    local kubevirt_arm_registry="quay.io\/kubevirt"
+    local kubevirt_amd_registry="registry.suse.com\/suse\/sles\/15.6"
+    local harvester_chart_dir=$1
+    local values_file="${harvester_chart_dir}/values.yaml"
+    sed -ie "s/${kubevirt_amd_registry}/${kubevirt_arm_registry}/g" ${values_file}
+    # drop emulatedMachines from harvester chart
+    yq -i 'del(.kubevirt.spec.configuration.emulatedMachines)' ${values_file}
+    version=${kubevirt_arm_version} yq -i '.kubevirt-operator.containers.operator.image.tag = env(version)' ${values_file}
+}


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->
pr rolls back the changes dropped in backport PR https://github.com/harvester/harvester-installer/pull/965 as these are still needed for v1.4.x. This rollback is needed to ensure we can keep using upstream kubevirt v1.3 images for harvester v1.4.x. In addition to the rollback, the PR also updates patch-harvester-chart to use kubevirt v1.3.1 images and tweak replacement logic to match harvester v1.4.2 chart requirements

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Related Issue:**
https://github.com/harvester/harvester/issues/7735

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->
* Install harvester v1.4-head to an arm node
* post install verify virt-operator is using upstream kubevirt v1.3.1 images
* basic tests like vm creation should be successful
