### PR TITLE
fix: skip adding dummy route if a default one exists

### DIFF
--- a/package/harvester-os/files/usr/sbin/harv-dummy-iface
+++ b/package/harvester-os/files/usr/sbin/harv-dummy-iface
@@ -1,5 +1,9 @@
 #!/bin/bash -ex
 
+if ip route show | grep -q '^default'; then
+    exit 0
+fi
+
 ip link add type dummy
 ip addr add 192.168.1.100/255.255.255.0 dev dummy0
 ip link set dummy0 up


### PR DESCRIPTION
**Problem:**
<!-- Explain the problem you are aiming to resolve in this PR. -->

When installing Harvester with the install-binary-only mode, and the artifacts (including the ISO image, kernel, initrd, and rootfs) are provided through network, the installation fails in an early stage with an error message `exit status 2` on the installer dashboard.

**Solution:**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Adding a dummy default route to an already well-configured node causes the issue. A default route cannot be added if one already exists. Adding a simple default route checker to fix the issue.

**Related Issue:**

harvester/harvester#7732

**Test plan:**
<!-- Make sure tests pass on the Circle CI. -->

1. Build a Harvester ISO image with this PR included (for QAs, please use the master-head image after the PR is merged)
2. Set up a suitable environment (courtesy to @irishgordo for below steps, with some adaptation)
   - For devs, please put the built artifacts under the `/tmp` directory and then run the following script
   - For QAs, please run the following script directly

```
#! /usr/bin/bash

version=master

if ! test -f /tmp/harvester-${version}-amd64.iso; then
  echo "gonna snag the file amd64 and toss in temp /tmp/"
  wget https://releases.rancher.com/harvester/${version}/harvester-${version}-amd64.iso
fi

if ! test -f /tmp/harvester-${version}-vmlinuz-amd64; then
  echo "gonna also snag the kernel and toss in temp /tmp/"
  wget https://releases.rancher.com/harvester/${version}/harvester-${version}-vmlinuz-amd64
fi

if ! test -f /tmp/harvester-${version}-initrd-amd64; then 
  echo "gonna also snag the initrd and toss in temp /tmp/"
  wget https://releases.rancher.com/harvester/${version}/harvester-${version}-initrd-amd64
fi

if ! test -f /tmp/harvester-${version}-rootfs-amd64.squashfs; then
  echo "gonna also snag the squashfs and toss in temp /tmp/"
  wget https://releases.rancher.com/harvester/${version}/harvester-${version}-rootfs-amd64.squashfs
fi

if ! test -f /tmp/harvester-${version}.img; then
  echo "gonna hop over to tmp and build a qcow2 file"
  qemu-img create -f qcow2 /tmp/harvester-${version}.img 300G
fi

if ! test -f /tmp/other-harvester.img; then
  echo "also gonna build a secondary disk qcow2 file"
  qemu-img create -f qcow2 /tmp/other-harvester.img 20G
fi

read -p "Enter your localhost ip address: " localhostipaddr

read -p "Enter the desired temp python3 http server port: " py3tempsrvport

echo "gonna spin up python3 server remember to grep for http.server and kill this later"
cd /tmp && nohup python3 -m http.server $py3tempsrvport > server.log 2>&1 &

echo "gonna go ahead and do a virt-install with all params for repro"

virt-install \
  --name repro-7732 \
  --network default,mac=02:ca:fe:f0:0d:01,model=virtio \
  --network default,mac=02:00:00:e1:c5:a5,model=virtio \
  --network default,mac=02:00:00:8a:1e:0f,model=virtio \
  --network default,mac=02:00:00:7b:de:0a,model=virtio \
  --network default,mac=02:00:00:31:c2:93,model=e1000e \
  --network default,mac=02:00:00:01:fc:19,model=e1000e \
  --os-variant linux2022 \
  --cdrom /tmp/harvester-${version}-amd64.iso \
  --vcpus 8 \
  --ram 16548 \
  --disk /tmp/harvester-${version}.img \
  --disk /tmp/other-harvester.img \
  --boot kernel=/tmp/harvester-${version}-vmlinuz-amd64,initrd=/tmp/harvester-${version}-initrd-amd64,kernel_args="ip=dhcp net.ifnames=1 console=ttyS0 console=tty1 rd.cos.disable harvester.install.iso_url=http://${localhostipaddr}:${py3tempsrvport}/harvester-${version}-amd64.iso root=live:http://${localhostipaddr}:${py3tempsrvport}/harvester-${version}-rootfs-amd64.squashfs rd.noverifyssl harvester.install.automatic=false harvester.install.wipe_disks=true"
```

3. Choose the "Install Harvester binaries only" mode, and then proceed with the remaining installation steps
4. The installation should complete without errors