### PR TITLE
Add only vlan specified by user to mgmt-br and mgmt-bo during installation

### DIFF
--- a/pkg/config/cos.go
+++ b/pkg/config/cos.go
@@ -522,6 +522,7 @@ func UpdateManagementInterfaceConfig(stage *yipSchema.Stage, mgmtInterface Netwo
 			Method:      NetworkMethodNone,
 			BondOptions: mgmtInterface.BondOptions,
 			MTU:         mgmtInterface.MTU,
+			VlanID:      mgmtInterface.VlanID,
 		}
 		if err := updateBond(stage, MgmtBondInterfaceName, &bondMgmt); err != nil {
 			return "", err
@@ -580,7 +581,12 @@ func updateBond(stage *yipSchema.Stage, name string, network *Network) error {
 		Group:       0,
 	})
 
-	postUpScript, err := render("wicked-setup-bond.sh", MgmtInterfaceName)
+	mgmtData := map[string]interface{}{
+		"VlanID":   network.VlanID,
+		"IntfName": MgmtBondInterfaceName,
+	}
+
+	postUpScript, err := render("wicked-setup-bond.sh", mgmtData)
 	if err != nil {
 		return err
 	}
@@ -641,7 +647,12 @@ func updateBridge(stage *yipSchema.Stage, name string, mgmtNetwork *Network) err
 		Group:       0,
 	})
 
-	preUpScript, err := render("wicked-setup-bridge.sh", MgmtBondInterfaceName)
+	mgmtData := map[string]interface{}{
+		"VlanID":   mgmtNetwork.VlanID,
+		"IntfName": MgmtInterfaceName,
+	}
+
+	preUpScript, err := render("wicked-setup-bridge.sh", mgmtData)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/templates/wicked-setup-bond.sh
+++ b/pkg/config/templates/wicked-setup-bond.sh
@@ -6,10 +6,10 @@ INTERFACE=$2
 case $ACTION in
 	post-up)
 		# inherit MAC address
-		ip link set dev {{ . }} address $(ip -json link show dev $INTERFACE | jq -j '.[0]["address"]')
+		ip link set dev {{ .IntfName }} address $(ip -json link show dev $INTERFACE | jq -j '.[0]["address"]')
 
 		# accept all vlan, PVID=1 by default
-		bridge vlan add vid 2-4094 dev $INTERFACE
+		bridge vlan add vid {{ .VlanID }} dev $INTERFACE
 		;;
 
 esac

--- a/pkg/config/templates/wicked-setup-bridge.sh
+++ b/pkg/config/templates/wicked-setup-bridge.sh
@@ -11,7 +11,7 @@ case $ACTION in
 
 	post-up)
 		# accept all vlan, PVID=1 by default
-		bridge vlan add vid 2-4094 dev $INTERFACE self
-		bridge vlan add vid 2-4094 dev {{ . }}
+		bridge vlan add vid {{ .VlanID }} dev $INTERFACE self
+		bridge vlan add vid {{ .VlanID }} dev {{ .IntfName }}
 		;;
 esac


### PR DESCRIPTION
**Problem:**
During Harvester installation, the system attempts to add all VLAN IDs to the management bond/bridge. With Mellanox ConnectX-6 NICs (which support 512 hardware-offloaded VLANs and have hardware VLAN offloading enabled by default), this causes boot log warnings and prevents management VLAN 2301 from being added to the hardware offloaded VLAN list.

**Solution:**
Add only configured vlans to the mgmt-br and mgmt-bo

**Related Issue:**
https://github.com/harvester/harvester/issues/7650

**Test plan:**
1.Select vlan id during harvester-installation
2.configure and proceed with installation
3.Once installed, verify "bridge vlan show"
mgmt-br and mgmt-bo should list the below for example 

bridge vlan show
port              vlan-id  
mgmt-br           1 PVID Egress Untagged
                  2021
mgmt-bo           1 PVID Egress Untagged
                  2021

where 2021 is the user configured vlan on the mgmt interface instead of all 2-4094 vlans

This PR should be merged along with https://github.com/harvester/network-controller-harvester/pull/156
