### PR TITLE
fix: pass hostname to rancherd and elemental config in network stage

### DIFF
--- a/pkg/config/cos.go
+++ b/pkg/config/cos.go
@@ -139,7 +139,8 @@ func ConvertToCOS(config *HarvesterConfig) (*yipSchema.YipConfig, error) {
 	}
 
 	afterNetwork := yipSchema.Stage{
-		SSHKeys: make(map[string][]string),
+		Hostname: config.OS.Hostname,
+		SSHKeys:  make(map[string][]string),
 	}
 
 	initramfs.Users[cosLoginUser] = yipSchema.User{

--- a/pkg/config/templates/rancherd-config.yaml
+++ b/pkg/config/templates/rancherd-config.yaml
@@ -4,6 +4,7 @@ role: agent
 {{- else -}}
 role: cluster-init
 {{- end }}
+nodeName: {{ .Hostname }}
 token: {{ printf "%q" .Token }}
 kubernetesVersion: {{ .RuntimeVersion }}
 rancherVersion: {{ .RancherVersion }}


### PR DESCRIPTION
**Problem:**

Follow up https://github.com/harvester/harvester-installer/pull/931. 

I found out that hostname was overwritten at some points. We've set up the hostname in live stage when installing. 

https://github.com/harvester/harvester-installer/blob/dd139f8bc7a12590edd84e64a4aada03e98487c1/pkg/console/network.go#L72-L80

> In contrast to similar projects such as Cloud Init, Yip does not keep records or caches of executed stages and steps, all stages and its associated configuration is executed at every boot.
> Reference: https://elemental.docs.rancher.com/cloud-config-reference/

It won't take any effect if the file isn't saved.  From the source codes, we can tell this live stage file is saved in `/tmp` during installation instead of `/oem` and `/system/oem` folder.

**Solution:**

When adding hostname to the stage in elemental, it will trigger [plugin to update hostname](https://github.com/rancher/yip/blob/ee4051d9ec2782989344f813bc6a0975bbd8f3fe/pkg/plugins/hostname.go#L21-L55). So, I add hostname to network stage. Then, we don't need to modify other hostname callers and add node name. The result is like this.

```sh
harvester1:/home/rancher # hostname
harvester1.dap.sys

harvester1:/home/rancher # hostnamectl
 Static hostname: harvester1.dap.sys
       Icon name: computer-vm
         Chassis: vm
      Machine ID: b7b851bd413fc2b2f2ba132b67d928ae
         Boot ID: c8bbbe8c2465477994fe5045507a2f0c
  Virtualization: kvm
Operating System: Harvester master
     CPE OS Name: cpe:/o:suse:sle-micro-rancher:5.5
          Kernel: Linux 5.14.21-150500.55.94-default
    Architecture: x86-64
 Hardware Vendor: QEMU
  Hardware Model: Standard PC _Q35 + ICH9, 2009_

harvester1:/home/rancher # cat /proc/sys/kernel/hostname
harvester1.dap.sys

harvester1:/home/rancher # cat /etc/hostname
harvester1.dap.sys

harvester1:/home/rancher # kubectl get nodes
NAME                 STATUS   ROLES                       AGE   VERSION
harvester1.dap.sys   Ready    control-plane,etcd,master   22m   v1.30.7+rke2r1
```

![image](https://github.com/user-attachments/assets/23d4ccc9-a757-4a99-83c7-45fee4dd7b44)

cc @tayterz2 

**Related Issue:**

https://github.com/harvester/harvester/issues/7312

**Test plan:**

Please install with these three ways to test it. When typing hostname, please input `harvester1.dap.sys` for main cluster and `harvester2.dap.sys` for joiners.

![image](https://github.com/user-attachments/assets/20ec77be-1579-4608-bbb0-e78b874bbf6b)

The combinations will be:

- Create a Harvester cluster. It should be equal to `harvester1.dap.sys`.
- Join a Harvester cluster. It should be equal to `harvester2.dap.sys`.
- Install Harvester binaries only, then create a Harvester cluster. It should be equal to `harvester1.dap.sys`
- Install Harvester binaries only, then join a Harvester cluster. It should be equal to `harvester2.dap.sys`.

After that, make sure the hostname is still same after rebooting in all cases.
