### PR TITLE
enhancement: use rancher/harvester-os:sl-micro-6 as base OS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,15 +87,19 @@ jobs:
         credentials_json: '${{ env.GOOGLE_AUTH }}'
 
     - name: upload-iso
-      uses: 'google-github-actions/upload-cloud-storage@v2'
-      if: ${{ startsWith(github.ref, 'refs/heads/') }}
+      uses: actions/upload-artifact@v4
       with:
-        path: dist/artifacts
-        parent: false
-        destination: releases.rancher.com/harvester/${{ env.branch }}
-        predefinedAcl: publicRead
-        headers: |-
-          cache-control: public,no-cache,proxy-revalidate
+        name: ${{ matrix.arch }}-iso-image
+        path: dist/artifacts/harvester-master-${{ matrix.arch }}.iso
+#      uses: 'google-github-actions/upload-cloud-storage@v2'
+#      if: ${{ startsWith(github.ref, 'refs/heads/') }}
+#      with:
+#        path: dist/artifacts
+#        parent: false
+#        destination: releases.rancher.com/harvester/${{ env.branch }}
+#        predefinedAcl: publicRead
+#        headers: |-
+#          cache-control: public,no-cache,proxy-revalidate
 
   manifest-cluster-repo-image:
     name: Manifest harvester-cluster-repo image

--- a/.github/workflows/vagrant-install.yaml
+++ b/.github/workflows/vagrant-install.yaml
@@ -1,8 +1,9 @@
 name: Vagrant install
 
 on:
-  pull_request:
-    types: [opened, reopened, synchronize]
+# Deployment doesn't work yet anyway, so let's not bother trying on PRs right now
+#  pull_request:
+#    types: [opened, reopened, synchronize]
   push:
     branches:
       - master

--- a/package/harvester-os/arm/grub.cfg
+++ b/package/harvester-os/arm/grub.cfg
@@ -16,17 +16,17 @@ if [ -f ${font} ];then
 fi
 menuentry "Harvester Installer ${harvester_version} (ARM64)" --class os --unrestricted {
     echo Loading kernel...
-    $linux ($root)/boot/x86_64/loader/linux cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 rd.cos.disable net.ifnames=1
+    $linux ($root)/boot/arm64/loader/linux cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=/boot/arm64/loader/rootfs.squashfs console=tty1 rd.cos.disable net.ifnames=1
     echo Loading initrd...
-    $initrd ($root)/boot/x86_64/loader/initrd
+    $initrd ($root)/boot/arm64/loader/initrd
 }
 
 menuentry "Harvester Installer ${harvester_version} (ARM64) (VGA 1024x768)" --class os --unrestricted {
     set gfxpayload=1024x768x24,1024x768
     echo Loading kernel...
-    $linux ($root)/boot/x86_64/loader/linux cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 rd.cos.disable net.ifnames=1
+    $linux ($root)/boot/arm64/loader/linux cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=/boot/arm64/loader/rootfs.squashfs console=tty1 rd.cos.disable net.ifnames=1
     echo Loading initrd...
-    $initrd ($root)/boot/x86_64/loader/initrd
+    $initrd ($root)/boot/arm64/loader/initrd
 }
 
 if [ "${grub_platform}" = "efi" ]; then

--- a/package/harvester-os/iso/boot/grub2/grub.cfg
+++ b/package/harvester-os/iso/boot/grub2/grub.cfg
@@ -22,7 +22,7 @@ if [ -f ${font} ];then
 fi
 menuentry "Harvester Installer ${harvester_version}" --class os --unrestricted {
     echo Loading kernel...
-    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 rd.cos.disable net.ifnames=1 ${extra_iso_cmdline}
+    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=/boot/x86_64/loader/rootfs.squashfs console=tty1 rd.cos.disable net.ifnames=1 ${extra_iso_cmdline}
     echo Loading initrd...
     $initrd ($root)/boot/initrd
 }
@@ -30,7 +30,7 @@ menuentry "Harvester Installer ${harvester_version}" --class os --unrestricted {
 menuentry "Harvester Installer ${harvester_version} (VGA 1024x768)" --class os --unrestricted {
     set gfxpayload=1024x768x24,1024x768
     echo Loading kernel...
-    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=rootfs.squashfs console=tty1 rd.cos.disable net.ifnames=1 ${extra_iso_cmdline}
+    $linux ($root)/boot/kernel cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.squashimg=/boot/x86_64/loader/rootfs.squashfs console=tty1 rd.cos.disable net.ifnames=1 ${extra_iso_cmdline}
     echo Loading initrd...
     $initrd ($root)/boot/initrd
 }

--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -23,7 +23,7 @@ source ${SCRIPTS_DIR}/version-monitoring
 source ${SCRIPTS_DIR}/version-logging
 source ${SCRIPTS_DIR}/lib/iso
 
-BASE_OS_IMAGE="rancher/harvester-os:sle-micro-head"
+BASE_OS_IMAGE="rancher/harvester-os:sl-micro-6-head"
 HARVESTER_OS_IMAGE=rancher/harvester-os:$VERSION
 
 cd ${PACKAGE_HARVESTER_OS_DIR}
@@ -70,23 +70,23 @@ mkdir -p /boot-files/boot
 # Copy kernel, initrd out for PXE boot
 if [ ${ARCH} == "amd64" ]
 then
-  KERNEL=$(docker run --rm ${HARVESTER_OS_IMAGE} readlink /boot/vmlinuz)
+  KERNEL=$(docker run --rm ${HARVESTER_OS_IMAGE} readlink -f /boot/vmlinuz)
 fi
 # arm images have `Image` softlink for kernel
 if [ ${ARCH} == "arm64" ]
 then
-  KERNEL=$(docker run --rm ${HARVESTER_OS_IMAGE} readlink /boot/Image)
+  KERNEL=$(docker run --rm ${HARVESTER_OS_IMAGE} readlink -f /boot/Image)
 fi
 
-INITRD=$(docker run --rm ${HARVESTER_OS_IMAGE} readlink /boot/initrd)
+INITRD=$(docker run --rm ${HARVESTER_OS_IMAGE} readlink -f /boot/initrd)
 # we need to add entrypoint or the docker create failed in newer version
 docker create --cidfile=os-img-container ${HARVESTER_OS_IMAGE} -- tail -f /dev/null
-docker cp $(<os-img-container):/boot/${KERNEL} ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-vmlinuz-${ARCH}
-docker cp $(<os-img-container):/boot/${INITRD} ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-initrd-${ARCH}
+docker cp $(<os-img-container):${KERNEL} ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-vmlinuz-${ARCH}
+docker cp $(<os-img-container):${INITRD} ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-initrd-${ARCH}
 docker cp $(<os-img-container):/usr/bin/elemental /usr/bin/elemental
 chmod +r ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-initrd-${ARCH}
-docker cp $(<os-img-container):/boot/${KERNEL} /boot-files/boot/kernel
-docker cp $(<os-img-container):/boot/${INITRD} /boot-files/boot/initrd
+docker cp $(<os-img-container):${KERNEL} /boot-files/boot/kernel
+docker cp $(<os-img-container):${INITRD} /boot-files/boot/initrd
 docker rm $(<os-img-container) && rm -f os-img-container
 
 # Make sure files under bundle dir can be read by nginx
@@ -97,7 +97,7 @@ ISO_PREFIX="${PROJECT_PREFIX}-${ARCH}"
 cp harvester-release.yaml iso
 echo "set harvester_version=${VERSION}" > iso/boot/grub2/harvester.cfg
 
-# Elemental platform expects amd64 or aarch64
+# Elemental platform expects x86_64 or aarch64
 PLATFORM=$(uname -m)
 
 CONFIG_DIR="$(pwd)"
@@ -131,7 +131,12 @@ xorriso -osirrox on -indev ${ARTIFACTS_DIR}/${ISO_PREFIX}.iso -extract / "${extr
 chmod -R a=r,u+w,a+X "${extract_dir}"
 
 # Copy squashfs image for PXE boot
-cp "${extract_dir}/rootfs.squashfs" "${ARTIFACTS_DIR}/${PROJECT_PREFIX}-rootfs-${ARCH}.squashfs"
+if [ ${ARCH} == "arm64" ]
+then
+  cp "${extract_dir}/boot/arm64/loader/rootfs.squashfs" "${ARTIFACTS_DIR}/${PROJECT_PREFIX}-rootfs-${ARCH}.squashfs"
+else
+  cp "${extract_dir}/boot/x86_64/loader/rootfs.squashfs" "${ARTIFACTS_DIR}/${PROJECT_PREFIX}-rootfs-${ARCH}.squashfs"
+fi
 
 # repackaging is only needed for amd64 builds.
 if [ "${ARCH}" == "amd64" ]
@@ -179,7 +184,7 @@ if [ "${BUILD_QCOW}" == "true" ]; then
   -serial file:harvester-installer.log  -nic none \
   -drive file=${ARTIFACTS_DIR}/${PROJECT_PREFIX}-amd64.raw,if=virtio,cache=writeback,discard=ignore,format=raw \
   -boot d -cdrom ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-amd64.iso -kernel ${ARTIFACTS_DIR}/${PROJECT_PREFIX}-vmlinuz-amd64 \
-  -append "cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.ram=1 rd.live.squashimg=rootfs.squashfs \
+  -append "cdroot root=live:CDLABEL=COS_LIVE rd.live.dir=/ rd.live.ram=1 rd.live.squashimg=/boot/x86_64/loader/rootfs.squashfs \
   console=ttyS1 rd.cos.disable net.ifnames=1 harvester.install.mode=install harvester.install.device=/dev/vda \
   harvester.install.automatic=true harvester.install.powerOff=true harvester.os.password=rancher \
   harvester.scheme_version=1 harvester.install.persistentPartitionSize=150Gi harvester.install.skipchecks=true" \


### PR DESCRIPTION
A few things seem to have changed with the newer version of elemental in SL Micro 6, notably:

- rootfs.squashfs is no longer in the root directory of the ISO, rather it's in an architecture specific subdirectory under /boot.
- The ARM initrd and kernel on the ISO moved from /boot/x86_64/loader/ to /boot/arm64/loader/ (although that begs the question - why were they under /boot/x86_64/loader previously?)
- The initrd and kernel symlinks under /boot in the baseos image may be to either other files in /boot (without extra path information), or to paths elsewhere under /usr/lib/modules/, hence the change to `readlink -f` when extracting these files.

Related issue: https://github.com/harvester/harvester/issues/7025

_NOTE: I DO NOT INTEND TO MERGE THIS, I JUST WANTED TO SEE IF THE ISO BUILD SUCCEEDS FOR BOTH ARCHITECTURES_