### PR TITLE
Set default mode to Active-Backup for bond

### DIFF
--- a/pkg/config/cos.go
+++ b/pkg/config/cos.go
@@ -583,7 +583,7 @@ func updateBond(stage *yipSchema.Stage, name string, network *Network) error {
 	if network.BondOptions == nil {
 		logrus.Infof("Adding default NIC bonding options for \"%s\"", name)
 		network.BondOptions = map[string]string{
-			"mode":   BondModeBalanceTLB,
+			"mode":   BondModeActiveBackup,
 			"miimon": "100",
 		}
 	}

--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -2947,7 +2947,7 @@ func configureInstallModeDHCP(c *Console) {
 	mgmtNetwork.Interfaces = netDef.Interfaces
 	if netDef.BondOptions == nil {
 		mgmtNetwork.BondOptions = map[string]string{
-			"mode":   config.BondModeBalanceTLB,
+			"mode":   config.BondModeActiveBackup,
 			"miimon": "100",
 		}
 	} else {


### PR DESCRIPTION
Problem:
The default bond mode set during harvester installation using seeder or ipxe is balance-tlb

Expected Behavior:
The recommended or default bond mode is Active backup

Solution:
Set the default mode to Active backup in harvester-installer when no bond options are specified by user.

Note:This is not applicable to harvester installed in manual mode as install panel defaults to "Active-Backup" and the value cannot be empty

This is related to https://github.com/harvester/harvester/issues/8042