### PR TITLE
Bump OS v1.5-20250416

### DIFF
--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -23,7 +23,7 @@ source ${SCRIPTS_DIR}/version-monitoring
 source ${SCRIPTS_DIR}/version-logging
 source ${SCRIPTS_DIR}/lib/iso
 
-BASE_OS_IMAGE="rancher/harvester-os:v1.5-20250409"
+BASE_OS_IMAGE="rancher/harvester-os:v1.5-20250416"
 HARVESTER_OS_IMAGE=rancher/harvester-os:$VERSION
 
 cd ${PACKAGE_HARVESTER_OS_DIR}


### PR DESCRIPTION
**Problem:**
Harvester base OS needs to update.

**Solution:**
Bump OS image to [rancher/harvester-os:v1.5-20250416](https://github.com/harvester/os2/releases/tag/v1.5-20250416).

**Related Issue:**

**Test plan:**

**More info:**
~~~

-----RPM-----

Packages found only in docker.io/rancher/harvester-os:v1.5-20250409: None

Packages found only in docker.io/rancher/harvester-os:v1.5-20250416: None

Version differences:
PACKAGE                         IMAGE1 (docker.io/rancher/harvester-os:v1.5-20250409)        IMAGE2 (docker.io/rancher/harvester-os:v1.5-20250416)
-aaa_base                       84.87+git20180409.04c9dae-150300.10.23.1, 271.1K             84.87+git20180409.04c9dae-150300.10.28.2, 271.2K
-ca-certificates-mozilla        2.74-150200.38.1, 1017.9K                                    2.74-150200.41.1, 1M
-kernel-default                 5.14.21-150500.55.97.1, 182.3M                               5.14.21-150500.55.100.1, 182.3M
-libexpat1                      2.4.4-150400.3.25.1, 250.2K                                  2.7.1-150400.3.28.1, 171.4K
-supportutils                   3.2.8-150300.7.35.33.1, 303.7K                               3.2.10-150300.7.35.36.4, 285.4K

~~~