### PR TITLE
Fix cni pod network cache reset

### DIFF
--- a/package/harvester-os/files/system/oem/99_cni_reset.yaml
+++ b/package/harvester-os/files/system/oem/99_cni_reset.yaml
@@ -1,5 +1,6 @@
 name: "reset container dhcp leases"
 stages:
-   initramfs:
-     - command:
-       - rm -rf /var/lib/cni/networks/k8s-pod-network
+  initramfs:
+    - name: "reset container dhcp leases"
+      commands:
+      - rm -rf /var/lib/cni/networks/k8s-pod-network


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

`/var/lib/cni/networks/k8s-pod-network/` is not fully cleandup when node/cluster reboots.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Fix stage file definition.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/8150

#### Test plan:
<!-- Describe the test plan by steps. -->

1. Restart node/cluser
2. Check node/nodes, the `/var/lib/cni/networks/k8s-pod-network` path is not existing or only has files with timestamp after node/cluster rebooting.

It is validated on both v1.5.0 and v1.4.2 cluster.

#### Additional documentation or context
