### PR TITLE
Add the missing images for upgradeLog

### DIFF
--- a/scripts/images/rancher-images.txt
+++ b/scripts/images/rancher-images.txt
@@ -29,3 +29,6 @@ docker.io/rancher/mirrored-kube-logging-logging-operator:4.4.0
 docker.io/rancher/mirrored-fluent-fluent-bit:2.2.0
 docker.io/rancher/mirrored-jimmidyson-configmap-reload:v0.4.0
 docker.io/rancher/mirrored-cluster-api-controller:v1.8.3
+ghcr.io/kube-logging/fluentd:v1.15-ruby3
+ghcr.io/kube-logging/config-reloader:v0.0.5
+docker.io/fluent/fluent-bit:2.1.8


### PR DESCRIPTION
3 images are missing by default and air-gapped upgrade is affected adding them will ensure v1.4.3 to v1.5.* upgrade is smooth

<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

upgradeLog refers to some none-pre-existing images due the the bump of Rancher version, the air-gapped cluster is affected; and the fix on v1.5.0 is too big to backport

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

add the missing images on v1.4.3, to ensure v1.4.3 to v1.5.* upgrade is not blocked by the missing images on air-gapped env.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/8052

v1.4.2 has listed this as a known issue https://github.com/harvester/docs/pull/759

#### Test plan:
<!-- Describe the test plan by steps. -->

1. Install v1.4.3 cluster, single-node cluster is ok
2. Setup an air-gapped env or check the container images via `crictl image ls`, following images are on each node:
```
ghcr.io/kube-logging/fluentd:v1.15-ruby3
ghcr.io/kube-logging/config-reloader:v0.0.5
docker.io/fluent/fluent-bit:2.1.8
```
3. Upgrade to v1.5.0, air-gapped env is not blocked; none air-gapped env, check `crictl image ls`, no more `ghcr.io` or `docker.io/fluent` related container images are pulled on the fly


#### Additional documentation or context

ISO build log:
```
Pulling images...
docker.io/rancher/fleet-agent:v0.11.2
...
docker.io/rancher/mirrored-cluster-api-controller:v1.8.3
ghcr.io/kube-logging/fluentd:v1.15-ruby3
ghcr.io/kube-logging/config-reloader:v0.0.5
docker.io/fluent/fluent-bit:2.1.8
...
```