### PR TITLE
Enhancement: Small tweaks to clarify install prompts

### DIFF
--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -2232,7 +2232,7 @@ func addConfirmInstallPanel(c *Console) error {
 				Text:  "Yes",
 			}, {
 				Value: "no",
-				Text:  "No",
+				Text:  "No (Reboot)",
 			},
 		}, nil
 	}

--- a/pkg/console/util.go
+++ b/pkg/console/util.go
@@ -45,7 +45,7 @@ const (
 You can see the full installation log by:
   - Press CTRL + ALT + F2 to switch to a different TTY console.
   - Login with user "rancher" (password is "rancher").
-  - Run the command: less %s.
+  - Run the command: sudo less %s.
 `
 	https = "https://"
 


### PR DESCRIPTION
Issue documented in https://github.com/harvester/harvester/issues/8201

#### Problem:
At the conclusion of the configuration phase of installation, the user is prompted to continue the installation with a Yes/No prompt. If "No" is selected, the machine is automatically rebooted without giving the user a chance to change the configuration settings. This should be clarified so users do not incorrectly select No thinking they can change the configuration.

If the installation fails, the user is told to login as rancher/rancher and to view the console log. However, the rancher user must use sudo in order to view the log file.

#### Solution:
- Change the "No" option at the end of the configuration phase to "No (Reboot)".
- Add sudo to the command to view the log file.

#### Related Issue(s):

#### Test plan:
N/A

#### Additional documentation or context
