### PR TITLE
[BUG] Harvester-installer can not be run in Vagrant box because of missing iscsiadm executable

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -82,7 +82,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", inline: <<-SHELL
     zypper ar --no-gpgcheck https://download.opensuse.org/repositories/isv:/Rancher:/Harvester:/ExtraPackages:/Dev/15.4/isv:Rancher:Harvester:ExtraPackages:Dev.repo
     zypper --gpg-auto-import-keys refresh
-    zypper --non-interactive in yip dmidecode
+    zypper --non-interactive in yip dmidecode open-iscsi
     echo -e '#!/bin/sh\necho "fake $0"' > /usr/local/bin/fake
     chmod a+x /usr/local/bin/fake
     for f in /usr/sbin/harv-install /usr/sbin/cos-installer-shutdown ; do


### PR DESCRIPTION
Install missing open-iscsi package

Related to: https://github.com/harvester/harvester/issues/8258
