### PR TITLE
chore: bump harvester-eventrouter to v1.5.1-rc4

### DIFF
--- a/scripts/patch-monitoring-logging
+++ b/scripts/patch-monitoring-logging
@@ -39,7 +39,7 @@ update_monitoring_logging_version() {
 
   # the harvester-eventrouter image tag is first bumped on installer, then on addon, to decouple the PRs
   # if ENV includes keyword `IMAGE` then `addon generateTemplates` will strip the image and only keep version
-  local HARVESTER_EVENTROUTER_FULL_TAG="rancher/harvester-eventrouter:v1.5.0-dev.0"
+  local HARVESTER_EVENTROUTER_FULL_TAG="rancher/harvester-eventrouter:v1.5.1-rc4"
   local henew="HARVESTER_EVENTROUTER_FULL_TAG=\"${HARVESTER_EVENTROUTER_FULL_TAG}\""
   local hecur=$(grep $henew $target) || echo "harvester-eventrouter image tag is not found from $target"
   if [ -z "${hecur}" ]; then


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

The harvester-eventrouter image still remains at v1.5.0-dev.0.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Manually bump it to v1.5.1-rc4.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

harvester/harvester#8503

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context

This PR supersedes #1053 for v1.5.1 releases for schedule urgency. In the long run, we'll have a unified way to manage the harvester-eventrouter's version, like what we proposed in #1053.