### PR TITLE
Update grafana nginx proxy to sync with Rancher

### DIFF
--- a/pkg/config/templates/patch/rancher-monitoring/105.1.2+up61.3.2/nginx-config.yaml
+++ b/pkg/config/templates/patch/rancher-monitoring/105.1.2+up61.3.2/nginx-config.yaml
@@ -91,11 +91,11 @@ data:
       }
 
       map $http_referer $final_appSubUrl {
-        ~.*/k8s/clusters/(c-m-.+)/api/v1/namespaces/cattle-monitoring-system/.*      '"appSubUrl":"/k8s/clusters/$1/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy"';
-        ~.*/dashboard/c/(c-m-.+)/.*     '"appSubUrl":"/k8s/clusters/$1/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy"';
-        ~.*/dashboard/harvester/c/(c-m-.+)/harvesterhci.io.addon/cattle-monitoring-system/.* '"appSubUrl":"/k8s/clusters/$1/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy"';
-        ~.*/dashboard/harvester/c/(c-m-.+)/kubevirt.io.virtualmachine/.*/.* '"appSubUrl":"/k8s/clusters/$1/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy"';
-        ~.*/dashboard/harvester/c/(c-m-.+)/.*      '"appSubUrl":"/k8s/clusters/$1/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy"';
+        ~.*/k8s/clusters/(c-.+)/api/v1/namespaces/cattle-monitoring-system/.*      '"appSubUrl":"/k8s/clusters/$1/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy"';
+        ~.*/dashboard/c/(c-.+)/.*     '"appSubUrl":"/k8s/clusters/$1/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy"';
+        ~.*/dashboard/harvester/c/(c-.+)/harvesterhci.io.addon/cattle-monitoring-system/.* '"appSubUrl":"/k8s/clusters/$1/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy"';
+        ~.*/dashboard/harvester/c/(c-.+)/kubevirt.io.virtualmachine/.*/.* '"appSubUrl":"/k8s/clusters/$1/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy"';
+        ~.*/dashboard/harvester/c/(c-.+)/.*      '"appSubUrl":"/k8s/clusters/$1/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy"';
         ~.*/api/v1/namespaces/cattle-monitoring-system/.*    '"appSubUrl":"/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy"';
         default '"appSubUrl":"/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-grafana:80/proxy"';
       }


### PR DESCRIPTION
  Rancher names the imported cluster from `c-m-*` to `c-*`

<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

After bumping Rancher to v2.11.2, the Rancher->Harvester can't load grafana

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Update the grafana nginx proxy setting to filter the imported cluster name.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/8498

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context

Upgrade path processing will be added to `harvester` repo from another PR.