### PR TITLE
Skip bridge vlan add when vid less than 2

### DIFF
--- a/pkg/config/templates/wicked-setup-bond.sh
+++ b/pkg/config/templates/wicked-setup-bond.sh
@@ -8,8 +8,8 @@ case $ACTION in
                 # inherit MAC address
                 ip link set dev {{ .IntfName }} address $(ip -json link show dev $INTERFACE | jq -j '.[0]["address"]')
 
-                #skip bridge vlan setting when no custom vlan specified by user
-                if [ {{ .VlanID }} -eq 0 ]; then
+                #skip bridge vlan setting when no vlan id or vlan id=1 specified by user
+                if [ {{ .VlanID }} -eq 0 ] || [ {{ .VlanID }} -eq 1 ]; then
                     exit 0
                 fi
                 #assign user configured vlan,PVID=1 by default

--- a/pkg/config/templates/wicked-setup-bridge.sh
+++ b/pkg/config/templates/wicked-setup-bridge.sh
@@ -10,8 +10,8 @@ case $ACTION in
                 ;;
 
         post-up)
-                #skip bridge vlan setting when no custom vlan specified by user
-                if [ {{ .VlanID }} -eq 0 ]; then
+                #skip bridge vlan setting when no vlan id or vlan-id=1 specified by user
+                if [ {{ .VlanID }} -eq 0 ] || [ {{ .VlanID }} -eq 1 ]; then
                     exit 0
                 fi
                 #assign user configured vlan,PVID=1 by default


### PR DESCRIPTION

Problem:
Adding vid 1 to bridge vlan will add vid=1 as tagged vlan to mgmt interface.
This will replace the default PVID=1 behaviour on mgmt interface.

#### Solution:
When user does not configure any vlan id or configured vlan id as 1,skip configuring vid=0 or vid=1 on wicked scripts, so that the default PVID=1 is retained on the mgmt interface.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/8515

#### Test plan:
1.Install Harvester manually without any vlan id or vlan id=1
2.Check if harvester nodes are setup correctly and ready.

#### Additional documentation or context
