### PR TITLE
chore: add new pr-backport capability for v1.6

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -5,6 +5,7 @@ pull_request_rules:
   - check-success="Build ISO Images (arm64)"
   - check-success="Build and deploy"
   - author = renovate[bot]
+  - -conflict
   actions:
     merge:
       method: rebase
@@ -15,6 +16,7 @@ pull_request_rules:
   - check-success="Build ISO Images (arm64)"
   - check-success="Build and deploy"
   - author = mergify[bot]
+  - -conflict
   actions:
     merge:
       method: rebase
@@ -25,6 +27,7 @@ pull_request_rules:
   - check-success="Build ISO Images (arm64)"
   - check-success="Build and deploy"
   - author = renovate[bot]
+  - -conflict
   actions:
     review:
       type: APPROVE
@@ -36,6 +39,7 @@ pull_request_rules:
   - check-success="Build ISO Images (arm64)"
   - check-success="Build and deploy"
   - author = mergify[bot]
+  - -conflict
   actions:
     review:
       type: APPROVE
@@ -47,6 +51,17 @@ pull_request_rules:
   actions:
     comment:
       message: This pull request is now in conflict. Could you fix it @{{author}}? 🙏
+
+- name: Automatically open v1.6 backport PR
+  conditions:
+    - base=master
+    - label="pr-backport-to/v1.6"
+  actions:
+    backport:
+      branches:
+        - v1.6
+      assignees:
+        - "{{ author }}"
 
 - name: Automatically open v1.5 backport PR
   conditions:
@@ -67,16 +82,5 @@ pull_request_rules:
     backport:
       branches:
         - v1.4
-      assignees:
-        - "{{ author }}"
-
-- name: Automatically open v1.3 backport PR
-  conditions:
-    - base=master
-    - label="pr-backport-to/v1.3"
-  actions:
-    backport:
-      branches:
-        - v1.3
       assignees:
         - "{{ author }}"


### PR DESCRIPTION
    - Also remove the EoL v1.3 capability

<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
We need that capability because we will have the v1.6 branch for the upcoming release.

#### Solution:
Add those capability for mergify configuration

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
