### PR TITLE
Add test upon addon templated files

### DIFF
--- a/pkg/config/testdata/rancherd-22-fake-addons.yaml
+++ b/pkg/config/testdata/rancherd-22-fake-addons.yaml
@@ -1,0 +1,20 @@
+resources:
+  - apiVersion: harvesterhci.io/v1beta1
+    kind: Addon
+    metadata:
+      name: vm-import-controller
+      namespace: harvester-system
+    spec:
+      repo: http://harvester-cluster-repo.cattle-system.svc/charts
+      version: "1.5.1-rc4"
+      chart: harvester-vm-import-controller
+      # invalid file content
+      {{- if and .Addons .Addons.harvester_vm_import_controller 
+      enabled: {{ .Addons.harvester_vm_import_controller.Enabled }}
+      {{- else }}
+      enabled: false
+      {{- end }}
+      valuesContent: |
+        image:
+          tag: "rancher/harvester-vm-import-controller:v1.5.1-rc4"
+        fullnameOverride: harvester-vm-import-controller

--- a/pkg/config/testdata/rancherd-22-good-addons.yaml
+++ b/pkg/config/testdata/rancherd-22-good-addons.yaml
@@ -1,0 +1,19 @@
+resources:
+  - apiVersion: harvesterhci.io/v1beta1
+    kind: Addon
+    metadata:
+      name: vm-import-controller
+      namespace: harvester-system
+    spec:
+      repo: http://harvester-cluster-repo.cattle-system.svc/charts
+      version: "1.5.1-rc4"
+      chart: harvester-vm-import-controller
+      {{- if and .Addons .Addons.harvester_vm_import_controller }}
+      enabled: {{ .Addons.harvester_vm_import_controller.Enabled }}
+      {{- else }}
+      enabled: false
+      {{- end }}
+      valuesContent: |
+        image:
+          tag: "rancher/harvester-vm-import-controller:v1.5.1-rc4"
+        fullnameOverride: harvester-vm-import-controller

--- a/pkg/config/testdata/rancherd-22-not-templated-addons.yaml
+++ b/pkg/config/testdata/rancherd-22-not-templated-addons.yaml
@@ -1,0 +1,20 @@
+resources:
+  - apiVersion: harvesterhci.io/v1beta1
+    kind: Addon
+    metadata:
+      name: vm-import-controller
+      namespace: harvester-system
+    spec:
+      repo: http://harvester-cluster-repo.cattle-system.svc/charts
+      # version is not templated
+      version: << .VM_IMPORT_CONTROLLER_CHART_VERSION >>
+      chart: harvester-vm-import-controller
+      {{- if and .Addons .Addons.harvester_vm_import_controller }}
+      enabled: {{ .Addons.harvester_vm_import_controller.Enabled }}
+      {{- else }}
+      enabled: false
+      {{- end }}
+      valuesContent: |
+        image:
+          tag: "rancher/harvester-vm-import-controller:v1.5.1-rc4"
+        fullnameOverride: harvester-vm-import-controller

--- a/scripts/test
+++ b/scripts/test
@@ -1,15 +1,25 @@
 #!/bin/bash
 set -e
 
-cd $(dirname $0)/..
+TOP_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
+cd ${TOP_DIR}
 
-# duplicated from scripts/build, so that we can run `make test` standalone
-addons_path=../addons
-if [ ! -d ${addons_path} ];then
-    echo "No existing addons source. Pulling..."
-    git clone --branch main --single-branch --depth 1 https://github.com/harvester/addons.git ../addons
-fi
-cp ${addons_path}/pkg/templates/*.yaml ./pkg/config/templates
+SCRIPTS_DIR="${TOP_DIR}/scripts"
+source ${SCRIPTS_DIR}/lib/addon
 
-echo Running tests
+addons_path=${TOP_DIR}/../addons
+load_and_source_addon ${addons_path} https://github.com/harvester/addons.git main
+
+generate_addon ${addons_path}
+# copy the generated addon yamls to installer
+cp ${addons_path}/*.yaml ./pkg/config/templates
+
+echo "All existing template files"
+ls -alth ./pkg/config/templates
+echo "The templated rancherd-22-addons.yaml file"
+cat ./pkg/config/templates/rancherd-22-addons.yaml
+
+cd ${TOP_DIR}
+
+echo "Running tests"
 go test -cover -tags=test ./pkg/...


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

The addon repo fetching and processing are unified now, update the test related part.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

1. Unify `make test`
2. Add test code upon addon tempate file, if some fields are note well templated, report error

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/6289


#### Test plan:
<!-- Describe the test plan by steps. -->
Both `make` and `make test` can run smoothly

#### Additional documentation or context

To avoid future backport conflicts, this PR is still backported to v1.6, but need to update the add on repo branch in `script/test` 