### PR TITLE
doc: Adjust README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ perform system installation when the ISO is booted.
 
 ## Building
 
+### Prerequisite
+- [Docker](https://docs.docker.com/engine/install/)
+- Git
+- Go (see `go.mod` for version)
+- Helm
+
 To build an ISO image, run:
 
 `make`


### PR DESCRIPTION
* adjusting the README to call out the deep Docker dependency

Resolves: doc/adj-readme

#### Problem:
We don't address a deep dependency to Docker.
Other tools like `nerdctl` aren't compliant enough to work with Harvester.

#### Solution:
Call out in the README the prerequisite.

#### Related Issue(s):
N/A

#### Test plan:
N/A

#### Additional documentation or context
N/A