### PR TITLE
feat: reinstate rsync progress in harv-install

### DIFF
--- a/package/harvester-os/files/usr/sbin/harv-install
+++ b/package/harvester-os/files/usr/sbin/harv-install
@@ -188,10 +188,10 @@ preload_rke2_images()
     # Otherwise (PXE), use bind-mount directly to speed up the process
     if [ "$INSTALL_MODE" = "ISO" ]; then
         echo "Copying RKE2 images to the target location..."
-        rsync -ahv ${ISOMNT}/bundle/harvester/images/rke2-images.*.tar.zst $TARGET/$RKE2_IMAGES_DIR
+        rsync -ahv --progress ${ISOMNT}/bundle/harvester/images/rke2-images.*.tar.zst $TARGET/$RKE2_IMAGES_DIR
         echo "Copying remaining images temporary location..."
-        rsync -ahv ${ISOMNT}/bundle/harvester/images/ $TARGET/$TMP_IMAGES_DIR
-        rsync -ahv ${ISOMNT}/bundle/harvester/images-lists/ $TARGET/$IMAGES_LISTS_DIR
+        rsync -ahv --progress ${ISOMNT}/bundle/harvester/images/ $TARGET/$TMP_IMAGES_DIR
+        rsync -ahv --progress ${ISOMNT}/bundle/harvester/images-lists/ $TARGET/$IMAGES_LISTS_DIR
     else
         echo "Bind-mount images directory to the target location..."
         mount --bind ${ISOMNT}/bundle/harvester/images $TARGET/$RKE2_IMAGES_DIR

--- a/pkg/console/util.go
+++ b/pkg/console/util.go
@@ -412,12 +412,12 @@ func ScanLines(data []byte, atEOF bool) (advance int, token []byte, err error) {
 		return 0, nil, nil
 	}
 
-	if i := bytes.IndexByte(data, '\n'); i >= 0 {
-		// We have a full newline-terminated line.
+	if i := bytes.IndexByte(data, '\r'); i >= 0 {
+		// We have a full CR-terminated line.
 		return i + 1, dropCR(data[0:i]), nil
 	}
 
-	if i := bytes.IndexByte(data, '\r'); i >= 0 {
+	if i := bytes.IndexByte(data, '\n'); i >= 0 {
 		// We have a full newline-terminated line.
 		return i + 1, dropCR(data[0:i]), nil
 	}


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
The rsync `--progress` flag was removed in https://github.com/harvester/harvester-installer/pull/641 in order to avoid locking up when installing via extremely slow virtual media.  The original problem was that we were waiting for a '\n' character, and rsync's stdout buffer eventually got full of progress output before the '\n' was printed and the whole thing locked up.
    
Since https://github.com/harvester/harvester-installer/pull/882 was added in Harvester v1.5.0 to handle '\r' characters in command output, it's now safe to re-instate the --progress flag when running rsync, because we now split on both '\r' and '\n'.

#### Solution:
- Reinstate the `--progress` flag in rsync calls
- Search for '\r' before '\n' when splitting lines to avoid odd extra '\r' characters in the last line of rsync output

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/5095

#### Test plan:
- Install harvester from the ISO
- Watch the console during installation and ensure that you see multiple lines of rsync progress output printed in real time (one per second or so) _while_ the rsync is occurring:

https://github.com/user-attachments/assets/2a378d8b-9678-4db6-8d52-865d3471a8b7
