### PR TITLE
feat: don't require a data disk for witness nodes

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -330,12 +330,20 @@ func (c *HarvesterConfig) GetKubeReserved() string {
 }
 
 func (c HarvesterConfig) ShouldCreateDataPartitionOnOsDisk() bool {
+	// Witness nodes don't need a data partition
+	if c.Install.Role == RoleWitness {
+		return false
+	}
 	// DataDisk is empty means only using the OS disk, and most of the time we should create data
 	// partition on OS disk, unless when ForceMBR=true then we should not create data partition.
 	return c.DataDisk == "" && !c.ForceMBR
 }
 
 func (c HarvesterConfig) ShouldMountDataPartition() bool {
+	// Witness nodes don't need a data partition
+	if c.Install.Role == RoleWitness {
+		return false
+	}
 	// With ForceMBR=true and no DataDisk assigned (Using the OS disk), no data partition/disk will
 	// be created, so no need to mount the data disk/partition
 	if c.ForceMBR && c.DataDisk == "" {

--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -1352,50 +1352,50 @@ func addHostnamePanel(c *Console) error {
 // If s is not a valid textual representation of an IP mask,
 // ParseMask returns an error describing why the parsing failed.
 func ParseMask(mask string) (IPMask, error) {
-    // Split the mask string by dots
-    parts := strings.Split(mask, ".")
+	// Split the mask string by dots
+	parts := strings.Split(mask, ".")
 
-    // Validate number of parts
-    if len(parts) != 4 {
-           return nil, &ParseError{Type: "mask format must be x.x.x.x, instead of", Text: mask}
-    }
+	// Validate number of parts
+	if len(parts) != 4 {
+		return nil, &ParseError{Type: "mask format must be x.x.x.x, instead of", Text: mask}
+	}
 
-    result := make(IPMask, 4)
+	result := make(IPMask, 4)
 
-    // Parse and validate each octet
-    for i, part := range parts {
-        // Convert string to integer
-        num, err := strconv.Atoi(part)
-        if err != nil {
-               return nil, &ParseError{Type: fmt.Sprintf("unknown number in position %d: %s", i+1, part), Text: mask}
-        }
-        // Validate range (0-255)
-        if num < 0 || num > 255 {
-               return nil, &ParseError{Type: fmt.Sprintf("number out of range in position %d: %d", i+1, num), Text: mask}
-        }
+	// Parse and validate each octet
+	for i, part := range parts {
+		// Convert string to integer
+		num, err := strconv.Atoi(part)
+		if err != nil {
+			return nil, &ParseError{Type: fmt.Sprintf("unknown number in position %d: %s", i+1, part), Text: mask}
+		}
+		// Validate range (0-255)
+		if num < 0 || num > 255 {
+			return nil, &ParseError{Type: fmt.Sprintf("number out of range in position %d: %d", i+1, num), Text: mask}
+		}
 
-        result[i] = byte(num)
-    }
+		result[i] = byte(num)
+	}
 
-    // Validate mask format (must be continuous 1s followed by continuous 0s)
-    if !isValidMaskFormat(result) {
-           return nil, &ParseError{Type: "invalid subnet mask: not continuous", Text: mask}
-    }
+	// Validate mask format (must be continuous 1s followed by continuous 0s)
+	if !isValidMaskFormat(result) {
+		return nil, &ParseError{Type: "invalid subnet mask: not continuous", Text: mask}
+	}
 
 	return result, nil
 }
 
 // Helper function to validate mask format
 func isValidMaskFormat(mask IPMask) bool {
-    valid := false
-    outMask := net.IPv4Mask(mask[0], mask[1], mask[2], mask[3])
-    if outMask != nil {
-        ones, _ := outMask.Size()
-        cidrMask := net.CIDRMask(int(ones), 32)
-        valid = outMask.String() == cidrMask.String()
-    }
+	valid := false
+	outMask := net.IPv4Mask(mask[0], mask[1], mask[2], mask[3])
+	if outMask != nil {
+		ones, _ := outMask.Size()
+		cidrMask := net.CIDRMask(int(ones), 32)
+		valid = outMask.String() == cidrMask.String()
+	}
 
-    return valid
+	return valid
 }
 
 func addNetworkPanel(c *Console) error {

--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -521,6 +521,33 @@ func addDiskPanel(c *Console) error {
 		return showNetworkPage(c)
 	}
 
+	// isWipeDisksNeeded is a helper function to render the wipeDisksPanel if needed
+	// if there are no additional disks to wipe then it checks if MBR needs to be enabled
+	// else will move on to the next apge
+	isWipeDisksNeeded := func(g *gocui.Gui, v *gocui.View) error {
+		options, err := getWipeDisksOptions(c.config)
+		if err != nil {
+			return err
+		}
+		if len(options) != 0 {
+			if slices.Contains(c.config.WipeDisksList, c.config.Device) || slices.Contains(c.config.WipeDisksList, c.config.DataDisk) {
+				c.config.WipeDisksList = []string{}
+				wipeDisksV.Reset()
+			}
+			return showNext(c, wipeDisksTitlePanel, wipeDisksPanel)
+		}
+		// no disks left to wipe, so close the wipeDisksTitlePanel and wipeDisksPanel
+		c.CloseElements(wipeDisksTitlePanel, wipeDisksPanel)
+
+		if systemIsBIOS() {
+			if err := c.setContentByName(diskNotePanel, forceMBRNote); err != nil {
+				return err
+			}
+			return showNext(c, askForceMBRPanel)
+		}
+		return gotoNextPage(g, v)
+	}
+
 	diskConfirm := func(_ *gocui.Gui, _ *gocui.View) error {
 		device, err := diskV.GetData()
 		if err != nil {
@@ -555,33 +582,6 @@ func addDiskPanel(c *Console) error {
 			return err
 		}
 		return showNext(c, persistentSizePanel)
-	}
-
-	// isWipeDisksNeeded is a helper function to render the wipeDisksPanel if needed
-	// if there are no additional disks to wipe then it checks if MBR needs to be enabled
-	// else will move on to the next apge
-	isWipeDisksNeeded := func(g *gocui.Gui, v *gocui.View) error {
-		options, err := getWipeDisksOptions(c.config)
-		if err != nil {
-			return err
-		}
-		if len(options) != 0 {
-			if slices.Contains(c.config.WipeDisksList, c.config.Device) || slices.Contains(c.config.WipeDisksList, c.config.DataDisk) {
-				c.config.WipeDisksList = []string{}
-				wipeDisksV.Reset()
-			}
-			return showNext(c, wipeDisksTitlePanel, wipeDisksPanel)
-		}
-		// no disks left to wipe, so close the wipeDisksTitlePanel and wipeDisksPanel
-		c.CloseElements(wipeDisksTitlePanel, wipeDisksPanel)
-
-		if systemIsBIOS() {
-			if err := c.setContentByName(diskNotePanel, forceMBRNote); err != nil {
-				return err
-			}
-			return showNext(c, askForceMBRPanel)
-		}
-		return gotoNextPage(g, v)
 	}
 
 	// Keybindings

--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -234,12 +234,14 @@ func showDiskPage(c *Console) error {
 	}
 
 	showPersistentSizeOption := false
-	if len(diskOptions) == 1 || c.config.Install.DataDisk == c.config.Install.Device {
+	if c.config.Install.Role != config.RoleWitness &&
+		(len(diskOptions) == 1 || c.config.Install.DataDisk == c.config.Install.Device) {
 		showPersistentSizeOption = true
 	}
 
 	nextComponents := []string{diskPanel}
-	if len(diskOptions) > 1 {
+	if c.config.Install.Role != config.RoleWitness &&
+		len(diskOptions) > 1 {
 		nextComponents = append([]string{dataDiskPanel}, nextComponents...)
 	}
 
@@ -446,7 +448,11 @@ func addDiskPanel(c *Console) error {
 		installDisk := c.config.Install.Device
 		dataDisk := c.config.Install.DataDisk
 
-		if dataDisk == "" || installDisk == dataDisk {
+		if c.config.Install.Role == config.RoleWitness {
+			if err := validateDiskSize(installDisk, false); err != nil {
+				return false, updateValidatorMessage(err.Error())
+			}
+		} else if dataDisk == "" || installDisk == dataDisk {
 			if err := validateDiskSize(installDisk, true); err != nil {
 				return false, updateValidatorMessage(err.Error())
 			}
@@ -501,10 +507,12 @@ func addDiskPanel(c *Console) error {
 			return err
 		}
 
-		// Make sure the persistent partition size is in the correct size.
-		// Do NOT allow proceeding to next field.
-		if valid, err := validatePersistentPartitionSize(c.config.Install.PersistentPartitionSize); !valid || err != nil {
-			return err
+		if c.config.Install.Role != config.RoleWitness {
+			// Make sure the persistent partition size is in the correct size.
+			// Do NOT allow proceeding to next field.
+			if valid, err := validatePersistentPartitionSize(c.config.Install.PersistentPartitionSize); !valid || err != nil {
+				return err
+			}
 		}
 
 		if !diskConfirmed {
@@ -548,7 +556,7 @@ func addDiskPanel(c *Console) error {
 		return gotoNextPage(g, v)
 	}
 
-	diskConfirm := func(_ *gocui.Gui, _ *gocui.View) error {
+	diskConfirm := func(g *gocui.Gui, v *gocui.View) error {
 		device, err := diskV.GetData()
 		if err != nil {
 			return err
@@ -568,6 +576,9 @@ func addDiskPanel(c *Console) error {
 			if _, err := validateAllDiskSizes(); err != nil {
 				return err
 			}
+			if c.config.Install.Role == config.RoleWitness {
+				return isWipeDisksNeeded(g, v)
+			}
 			if device == dataDisk {
 				return showNext(c, persistentSizePanel, dataDiskPanel)
 			}
@@ -580,6 +591,9 @@ func addDiskPanel(c *Console) error {
 		// Show error if disk size validation fails, but allow proceeding to next field
 		if _, err := validateAllDiskSizes(); err != nil {
 			return err
+		}
+		if c.config.Install.Role == config.RoleWitness {
+			return isWipeDisksNeeded(g, v)
 		}
 		return showNext(c, persistentSizePanel)
 	}
@@ -720,6 +734,9 @@ func addDiskPanel(c *Console) error {
 				return err
 			}
 
+			if c.config.Install.Role == config.RoleWitness {
+				return showNext(c, diskPanel)
+			}
 			if len(diskOpts) > 1 && disk != dataDisk {
 				return showNext(c, dataDiskPanel)
 			}
@@ -767,6 +784,9 @@ func addDiskPanel(c *Console) error {
 				return err
 			}
 
+			if c.config.Install.Role == config.RoleWitness {
+				return showNext(c, diskPanel)
+			}
 			if len(diskOpts) > 1 && disk != dataDisk {
 				return showNext(c, dataDiskPanel)
 			}

--- a/pkg/console/validator.go
+++ b/pkg/console/validator.go
@@ -138,7 +138,11 @@ func checkDevice(cfg *config.HarvesterConfig) error {
 		return prettyError(ErrMsgDeviceNotFound, installDisk)
 	}
 
-	if dataDisk == installDisk || dataDisk == "" {
+	if cfg.Install.Role == config.RoleWitness {
+		if err := validateDiskSize(installDisk, false); err != nil {
+			return prettyError(ErrMsgDeviceTooSmall, installDisk)
+		}
+	} else if dataDisk == installDisk || dataDisk == "" {
 		if err := validateDiskSize(installDisk, true); err != nil {
 			return prettyError(ErrMsgDeviceTooSmall, installDisk)
 		}

--- a/pkg/util/cmdline.go
+++ b/pkg/util/cmdline.go
@@ -105,7 +105,7 @@ func toNetworkInterfaces(data map[string]interface{}) error {
 // "name: ens3"
 func parseIfDetails(details string) (*map[string]interface{}, error) {
 	var (
-		parts []string
+		parts = make([]string, 0, 7)
 		data  string
 	)
 


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
 The witness node only runs a minimal workload, so we don't need a data disk/partition.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
When adding a witness node:
- The data disk and persistent size fields are removed from the interactive installer.
- No data partition will be created on the installation disk.
- Minimum installation disk size becomes 180GiB (the same as is used for other nodes when there's a separate data disk).

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/5457

#### Test plan:
TBD

#### Additional documentation or context
This PR includes a tiny bit of unrelated code reformatting and a lint error fix. If you want to ignore those when reviewing, view commit by commit.

I still need to build an ISO and do a test install to make sure this all works properly. Stay tuned...