### PR TITLE
Trivial: Fix code style: cfg.Mode -> cfg.Install.Mode

### DIFF
--- a/pkg/config/cos.go
+++ b/pkg/config/cos.go
@@ -186,7 +186,7 @@ func ConvertToCOS(config *HarvesterConfig) (*yipSchema.YipConfig, error) {
 	disableLonghornMultipathing(&initramfs)
 
 	// TOP
-	if cfg.Mode != ModeInstall {
+	if cfg.Install.Mode != ModeInstall {
 		if err := initRancherdStage(config, &initramfs); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

Not a problem, just a trivial code style confusion.

There is a place using
```
cfg.Mode
```
which actually means
```
cfg.Install.Mode
```
All other places are using `cfg.Install.Mode`.

I know that Golang correctly treat `cfg.Mode` as `cfg.Install.Mode` (struct embedding).

But this caused confusion for Golang newbies, especially when using other pure text tools to analyse the usage of `Mode`.

It would be better if unify it to the formal expression `cfg.Install.Mode`, so other tools without golang support can easily grep and analyse the usage of the Install.Mode.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Unify `cfg.Mode` to `cfg.Install.Mode`.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
