### PR TITLE
Be able to change console_params in <OEM>/grubenv

### DIFF
--- a/package/harvester-os/files/etc/cos/bootargs.cfg
+++ b/package/harvester-os/files/etc/cos/bootargs.cfg
@@ -1,4 +1,3 @@
-set console_params="console=tty1"
 set kernel=/boot/vmlinuz
 set crash_kernel_params="crashkernel=219M,high crashkernel=72M,low"
 if [ "${img}" == "/cOS/recovery.img" ]; then

--- a/package/harvester-os/files/usr/sbin/harv-install
+++ b/package/harvester-os/files/usr/sbin/harv-install
@@ -390,10 +390,6 @@ update_grub_settings()
         TTY=$HARVESTER_TTY
     fi
 
-    if [ -e "/dev/${TTY%,*}" ] && [ "$TTY" != tty1 ] && [ "$TTY" != console ] && [ -n "$TTY" ]; then
-        sed -i "s/console_params=\"console=tty1\"/console_params=\"console=${TTY} console=tty1\"/g" ${TARGET}/etc/cos/bootargs.cfg
-    fi
-
     PLATFORM=$(uname -m)
     if [ "${PLATFORM}" == "aarch64" ]
     then
@@ -441,6 +437,10 @@ update_grub_settings()
     TARGET_FILE="${oem_dir}/grubenv"
     if [ -n "${HARVESTER_ADDITIONAL_KERNEL_ARGUMENTS}" ]; then
         grub2-editenv ${TARGET_FILE} set third_party_kernel_args="${HARVESTER_ADDITIONAL_KERNEL_ARGUMENTS}"
+    fi
+
+    if [ -e "/dev/${TTY%,*}" ] && [ "$TTY" != tty1 ] && [ "$TTY" != console ] && [ -n "$TTY" ]; then
+        grub2-editenv ${TARGET_FILE} set "console_params=console=${TTY} console=tty1"
     fi
 
     add_debug_grub_entry

--- a/package/harvester-os/files/usr/sbin/stream-disk
+++ b/package/harvester-os/files/usr/sbin/stream-disk
@@ -15,7 +15,14 @@ update_boot_args()
       fi
 
       if [ -e "/dev/${TTY%,*}" ] && [ "$TTY" != tty1 ] && [ "$TTY" != console ] && [ -n "$TTY" ]; then
-          sed -i "1s/.*/console_params=\"console=${TTY} console=tty1\"/g" ${TARGET}/etc/cos/bootargs.cfg
+          oem_partition=$(blkid -L COS_OEM)
+          mount ${oem_partition} /oem
+          TARGET_FILE=/oem/grubenv
+          if ! [ -f ${TARGET_FILE} ]; then
+              grub2-editenv ${TARGET_FILE} create
+          fi
+          grub2-editenv ${TARGET_FILE} set "console_params=console=${TTY} console=tty1"
+          umount /oem
       fi
 }
 


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

No way to override kernel boot arg console=tty... due to the immutable /etc/cos/bootargs.cfg took precedence.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

move the console_params definition from `/etc/cos/bootargs.cfg` (in the immutable rootfs) to <OEM>/grubenv
```
console_params=console=ttyS... console=tty...
```

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Issue https://github.com/harvester/harvester/issues/8650

#### Test plan:
<!-- Describe the test plan by steps. -->
https://github.com/jjqq2013/harvester-os-raw-disk-image-builder
Use the `test` branch.

#### Additional documentation or context
