### PR TITLE
fix: remove any existing COS_* labels from data disk to prevent misidentification

### DIFF
--- a/package/harvester-os/files/usr/sbin/harv-install
+++ b/package/harvester-os/files/usr/sbin/harv-install
@@ -37,15 +37,14 @@ clear_disk_label()
     # Also, while yip is partitioning the disk, if it sees the LABEL to be used exists,
     # it won't create the partition. So it's necessary to clear the label
     echo "Assessing labels on data disk $HARVESTER_DATA_DISK partitions."
-    for part in $(blkid -o device "$HARVESTER_DATA_DISK"*); do
+    for part in $(lsblk $HARVESTER_DATA_DISK -npr -oname,type | grep part | cut -d' ' -f1); do
         partition_label=$(blkid -s LABEL -o value $part)
         for label in "${CLEAR_FSLABELS[@]}"; do
             if [ "$partition_label" == "$label" ] ; then
                 echo "Removing filesystem label $label from $part"
                 # Run this tune2fs twice because sometimes the first run would show "Recovering journal"
                 # and label is not modified
-                tune2fs -L "" $part > /dev/null
-                tune2fs -L "" $part > /dev/null
+                tune2fs -L "" $part > /dev/null || tune2fs -L "" $part > /dev/null
             fi
         done
     done


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem: 
<!-- Explain the problem you aim to resolve in this PR. -->

The installation process failed if the selected data disk contains partitions with any of the `COS_*` labels. This could happen when attempting to recycle existing disks for new Harvester installation, e.g., in our lab environment. The `wipeAllDisks` option skips the selected installation and data disks. (See #885.) This caused Elemental to misidentify the disk where the new partitions should be created.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

This PR extends the list of labels to be removed from the data disk to include all the `COS_*` labels.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/8043

#### Test Case 1 - Recycle Existing Disk During Installation:
<!-- Describe the test plan by steps. -->

The key to reproduce the problem is to use a data disk containing partitions with the `COS_*` labels. An easy way to prepare the disk is to make a copy of the install disk of an existing Harvester host, and use it as the data disk for a separate Harvester installation.

These preparation steps must be repeated for every test run to ensure that data disk contains the labelled partitions.

For example, with Harvester running on my local KVM VM named `linux2024`, I can make a copy of its installation disk with:

```sh
sudo cp /var/lib/libvirt/images/linux2024.qcow2 data-disk.qcow2
```

In my next Harvester installation, I can add the `data-disk.qcow2` image as a data disk to my VM following these steps:

* Before commencing the installation, select the `Customize Configuration before install` option:

<img width="498" height="535" alt="image" src="https://github.com/user-attachments/assets/e31a078d-dda2-4067-a8c5-0ca39940bad9" />

* In the VM configuration section, add the `data-disk.qcow2` image as a new storage disk:

<img width="658" height="602" alt="image" src="https://github.com/user-attachments/assets/50f3bcaf-a438-4c1a-95f4-5811152d6266" />

* When ready, select the `Begin Installation` option to kick off the Harvester installation:

<img width="708" height="583" alt="image" src="https://github.com/user-attachments/assets/fa225c5a-fd4e-43a9-88e4-42c6cf54aa03" />

* When configuring the installation and data disks:
    * use the new disk (`/dev/vda`) as the installation disk
    * use the disk associated with the `data-disk.qcow2` image (`/dev/vdb`)  as the data disk

<img width="819" height="465" alt="image" src="https://github.com/user-attachments/assets/72c92ea9-75ab-4aae-8f2f-f97b51c7c832" />

* Proceed with the standard Harvester installation
* After the 'Configure Network' step, the host IP will be available
* Access the VM via `SSH`
* Confirm that the data disk (`/dev/vdb`) contains partitions from the previous Harvester installation:

```sh
$ rancher@rancher:~> lsblk -oNAME,LABEL
NAME   LABEL
loop0
sr0    COS_LIVE
vda
vdb
├─vdb1
├─vdb2 COS_OEM
├─vdb3 COS_RECOVERY
├─vdb4 COS_STATE
└─vdb5 COS_PERSISTENT
```

* Without the change in this PR, the installation failed with the error:

<img width="804" height="638" alt="image" src="https://github.com/user-attachments/assets/812f1a5b-1c42-4a0f-96c0-b9200d20952f" />

* Using an `.iso` built from this PR, the installation completed successfully
* The installation logs show that the previously added labels were removed:

```sh
$ sudo cat /oem/install/console.log | grep "\/dev\/vdb" 
# ...
time="2025-07-14T17:12:39Z" level=info msg="[stdout]: Assessing labels on data disk /dev/vdb partitions."
time="2025-07-14T17:12:39Z" level=info msg="[stdout]: Removing filesystem label COS_OEM from /dev/vdb2"
time="2025-07-14T17:12:40Z" level=info msg="[stdout]: Removing filesystem label COS_RECOVERY from /dev/vdb3"
time="2025-07-14T17:12:40Z" level=info msg="[stdout]: Removing filesystem label COS_STATE from /dev/vdb4"
time="2025-07-14T17:12:40Z" level=info msg="[stdout]: Removing filesystem label COS_PERSISTENT from /dev/vdb5"
time="2025-07-14T17:12:41Z" level=info msg="[stdout]: Removing filesystem label HARV_LH_DEFAULT from /dev/vdb6"
time="2025-07-14T17:13:32Z" level=info msg="[stdout]: Formatting /dev/vdb as data disk..."
```

* Access the Harvester UI via Harvester VIP. Expect the Harvester UI to be accessible.
* Create a new VM image. Expect the VM image to be created successfully.

#### Test Case 2 - Use New Data Disk (Regression Test)

* Install Harvester using a new installation and a new data disk
* Expect installation to complete successfully
* Expect the Harvester UI to be accessible
* Expect new VM image can be created successfully
