### PR TITLE
Introduce toolchain directive to specify go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/harvester/harvester-installer
 
 go 1.23
 
+toolchain go1.23.11
+
 require (
 	github.com/dell/goiscsi v1.9.0
 	github.com/harvester/go-common v0.0.0-20230718010724-11313421a8f5


### PR DESCRIPTION
... to prevent errors like
```
$ go: downloading go1.23 (linux/amd64)
go: download go1.23 for linux/amd64: toolchain not available
```
Latest version number can be found here: https://go.dev/dl/
