### PR TITLE
Optimize the managedchart Harvester installed status check

### DIFF
--- a/pkg/console/dashboard_panels.go
+++ b/pkg/console/dashboard_panels.go
@@ -453,7 +453,33 @@ func k8sIsReady() bool {
 	return true
 }
 
+func chartIsAnnotated() bool {
+	cmd := exec.Command("/bin/sh", "-c", `kubectl get managedchart -n fleet-local harvester -ojsonpath="{.metadata.annotations['installer\.harvesterhci\.io\/chartInstalled']}"`)
+	cmd.Env = os.Environ()
+	output, err := cmd.Output()
+
+	if err != nil {
+		// any return error means false
+		return false
+	}
+	return string(output) != ""
+}
+
+func annotateChart() {
+	cmd := exec.Command("/bin/sh", "-c", `kubectl annotate managedchart -n fleet-local harvester 'installer.harvesterhci.io/chartInstalled=true'`)
+	cmd.Env = os.Environ()
+	// skip output
+	_, _ = cmd.Output()
+}
+
 func chartIsInstalled() bool {
+	// after the managedchart installation step in done, it turns into `Ready`
+	// later if the user changes the downstream object like deployment, the managedchart might become `non-Ready`
+	// however, the `non-Ready` does not mean the chart is not `installed`
+	// use an annotation to mark the `installed` of managedchart
+	if chartIsAnnotated() {
+		return true
+	}
 	cmd := exec.Command("/bin/sh", "-c", `kubectl -n fleet-local get ManagedChart harvester -o jsonpath='{.status.conditions}' | jq 'map(select(.type == "Ready" and .status == "True")) | length'`)
 	cmd.Env = os.Environ()
 	output, err := cmd.Output()
@@ -471,7 +497,12 @@ func chartIsInstalled() bool {
 		return false
 	}
 
-	return processed >= 1
+	if processed >= 1 {
+		// installer annotates the managedchart when the installation step in done
+		annotateChart()
+		return true
+	}
+	return false
 }
 
 func isAPIReady(managementURL, path string) bool {


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
https://github.com/harvester/harvester/issues/8655

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->


#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/8655

#### Test plan:
<!-- Describe the test plan by steps. -->

1. Setup a single-node Harvester
2. When console is ready,  change harvester deployment to a new image or new memory limit, the managedchart/bundle will have complain soon
3.1 Reboot the cluster, console does not stuck on https://github.com/harvester/harvester/issues/8655#issue-3228172883
3.2 For a running cluster, if it runs into the state, run `kubectl annotate managedchart -n fleet-local harvester 'installer.harvesterhci.io/chartInstalled=true'`, the console turns into ready again

#### Additional documentation or context
