### PR TITLE
fix: don't show persistentSizeNote panel for witness nodes

### DIFF
--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -588,14 +588,24 @@ func addDiskPanel(c *Console) error {
 			return showNext(c, dataDiskPanel)
 		}
 
-		if err := c.setContentByName(diskNotePanel, persistentSizeNote); err != nil {
-			return err
+		if c.config.Install.Role != config.RoleWitness {
+			// Only show this for non-witness nodes, because:
+			// 1. witness nodes don't let you set persistent size, so the note makes no sense
+			// 2. showing the note for witness nodes, with no other fields present ends up
+			//    preventing key events and everything locks up
+			if err := c.setContentByName(diskNotePanel, persistentSizeNote); err != nil {
+				return err
+			}
 		}
 		// Show error if disk size validation fails, but allow proceeding to next field
-		if _, err := validateAllDiskSizes(); err != nil {
+		valid, err := validateAllDiskSizes()
+		if err != nil {
 			return err
 		}
 		if c.config.Install.Role == config.RoleWitness {
+			// Set diskConfirmed here to avoid having to press ENTER twice
+			// to proceed if the disk configuration is valid
+			diskConfirmed = valid
 			return isWipeDisksPanelNeeded(g, v)
 		}
 		return showNext(c, persistentSizePanel)


### PR DESCRIPTION



<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
Showing the persistent size note doesn't make sense for witness nodes, because we don't let you set the persistent size in this case.  Also it causes the installer to lock up and not take keypresses (I assume that note field somehow ends up with the focus which messes things up).

#### Solution:
Don't show the persistent size note when installing witness nodes.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
Related issue: https://github.com/harvester/harvester/issues/5457

#### Test plan:
Install a witness node with only one disk. The disk selection screen should not lock up like it did in Test 3 mentioned in https://github.com/harvester/harvester/issues/5457#issuecomment-3112973243

#### Additional documentation or context
