### PR TITLE
fix: build: don't rm -rf addons source

### DIFF
--- a/scripts/package-harvester-os
+++ b/scripts/package-harvester-os
@@ -22,7 +22,6 @@ LOGGING_VERSION=${RANCHER_LOGGING_CHART_VERSION}
 echo "Rancher monitoring version: ${MONITORING_VERSION}"
 echo "Rancher logging version: ${LOGGING_VERSION}"
 echo "Harvester eventrouter image tag: ${HARVESTER_EVENTROUTER_FULL_TAG}"
-rm -rf ${addons_path}
 
 mkdir -p ${ARTIFACTS_DIR}
 


### PR DESCRIPTION
#### Problem:
If you run make from the harvester-installer repo, and have `LOCAL_ADDONS_SRC` set to a local checkout of the addons repo (to save cloning it at build time), your local checkout of the addons repo will be deleted.


#### Solution:
Don't rm -rf the addons source

#### Related Issue(s):
https://github.com/harvester/harvester/issues/8763

#### Test plan:
Build an ISO

#### Additional documentation or context
