### PR TITLE
fix: allow non-CIDR static IP address

### DIFF
--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -1773,16 +1773,22 @@ func addNetworkPanel(c *Console) error {
 		if err = checkStaticRequiredString("address", address); err != nil {
 			return err.Error(), nil
 		}
+		userInputData.Address = address
 		ip, ipNet, err := net.ParseCIDR(address)
 		if err != nil {
-			userInputData.Address = address
-			return "", nil
+			// It's not a CIDR address, but it might be a non-CIDR address
+			ip = net.ParseIP(address)
+			if ip == nil {
+				return fmt.Sprintf("%s is not a valid IP address", address), nil
+			}
 		}
-		mask := ipNet.Mask
-		userInputData.Address = address
-		userInputData.AddrMask = ipNet.Mask.String()
+		// At this point, ip is valid (so save it) but ipNet might be nil (non-CIDR address)
 		mgmtNetwork.IP = ip.String()
-		mgmtNetwork.SubnetMask = fmt.Sprintf("%d.%d.%d.%d", mask[0], mask[1], mask[2], mask[3])
+		if ipNet != nil {
+			mask := ipNet.Mask
+			userInputData.AddrMask = ipNet.Mask.String()
+			mgmtNetwork.SubnetMask = fmt.Sprintf("%d.%d.%d.%d", mask[0], mask[1], mask[2], mask[3])
+		}
 		return "", nil
 	}
 	addressVConfirm := gotoNextPanel(c, []string{addrMaskPanel}, validateAddress)


### PR DESCRIPTION
#### Problem:
The current code relies the static IP address being in CIDR format (it calls net.ParseCIDR(), and will only save the IP address if that succeeds).

#### Solution:
This commit still allows CIDR addresses, but will fall back to allowing a regular IP address if a CIDR address is not specified.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/8809

#### Test plan:
- Run the harvester installer
- Set IPv4 method: static
- Enter a non-CIDR IP address (e.g. 192.168.122.2) and suitable netmask and gateway.
- Proceed to the next screen and verify that the network configuration is applied successfully.
- Restart the installer completely (don't just go forwards and backwards as the installer remembers previous values that were entered)
- Set IPv4 method: static
- Enter a CIDR IP address (e.g.: 192.168.122.2/24) and verify the netmask is automatically filled in with the correct value (in this example, 255.255.255.0).
- Enter a suitable gateway address and proceed to the next screen. Again, verify that the network configuration is applied successfully.

#### Additional documentation or context
