### PR TITLE
Enable longhorn storage reserved percentage conf

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -123,6 +123,8 @@ type LHDefaultSettings struct {
 	// from Longhorn v1.5.0, LH merges the above two into one
 	// the above two are not used afterwards, but Harvester keeps them for compatibility
 	GuaranteedInstanceManagerCPU *uint32 `json:"guaranteedInstanceManagerCPU,omitempty"`
+
+	StorageReservedPercentageForDefaultDisk *uint32 `json:"storageReservedPercentageForDefaultDisk,omitempty"`
 }
 
 type LonghornChartValues struct {

--- a/pkg/config/cos.go
+++ b/pkg/config/cos.go
@@ -28,12 +28,15 @@ const (
 	ifcfgGlobPattern       = networkConfigDirectory + "ifcfg-*"
 	ifrouteGlobPattern     = networkConfigDirectory + "ifroute-*"
 
-	bootstrapConfigCount                = 6
-	defaultReplicaCount                 = 3
-	defaultGuaranteedEngineManagerCPU   = 12   // means percentage 12%
-	defaultGuaranteedReplicaManagerCPU  = 12   // means percentage 12%
-	defaultGuaranteedInstanceManagerCPU = 12   // means percentage 12%
-	defaultSystemImageSize              = 3072 // size of /run/initramfs/cos-state/cOS/active.img in MB
+	bootstrapConfigCount                           = 6
+	defaultReplicaCount                            = 3
+	defaultGuaranteedEngineManagerCPU              = 12   // means percentage 12%
+	defaultGuaranteedReplicaManagerCPU             = 12   // means percentage 12%
+	defaultGuaranteedInstanceManagerCPU            = 12   // means percentage 12%
+	defaultStorageReservedPercentageForDefaultDisk = 0    // means percentage 0%
+	defaultSystemImageSize                         = 3072 // size of /run/initramfs/cos-state/cOS/active.img in MB
+
+	maxStorageReservedPercentageForDefaultDisk = 30 // means percentage 30%
 )
 
 var (
@@ -301,6 +304,15 @@ func setConfigDefaultValues(config *HarvesterConfig) {
 
 	if config.Harvester.Longhorn.DefaultSettings.GuaranteedInstanceManagerCPU != nil && *config.Harvester.Longhorn.DefaultSettings.GuaranteedInstanceManagerCPU > defaultGuaranteedInstanceManagerCPU {
 		*config.Harvester.Longhorn.DefaultSettings.GuaranteedInstanceManagerCPU = defaultGuaranteedInstanceManagerCPU
+	}
+
+	if config.Harvester.Longhorn.DefaultSettings.StorageReservedPercentageForDefaultDisk != nil {
+		if *config.Harvester.Longhorn.DefaultSettings.StorageReservedPercentageForDefaultDisk > maxStorageReservedPercentageForDefaultDisk {
+			*config.Harvester.Longhorn.DefaultSettings.StorageReservedPercentageForDefaultDisk = maxStorageReservedPercentageForDefaultDisk
+		}
+	} else {
+		config.Harvester.Longhorn.DefaultSettings.StorageReservedPercentageForDefaultDisk = new(uint32)
+		*config.Harvester.Longhorn.DefaultSettings.StorageReservedPercentageForDefaultDisk = uint32(defaultStorageReservedPercentageForDefaultDisk)
 	}
 }
 

--- a/pkg/config/templates/rancherd-10-harvester.yaml
+++ b/pkg/config/templates/rancherd-10-harvester.yaml
@@ -185,6 +185,9 @@ resources:
           {{- if .Harvester.Longhorn.DefaultSettings.GuaranteedInstanceManagerCPU }}
           guaranteedInstanceManagerCPU: {{ .Harvester.Longhorn.DefaultSettings.GuaranteedInstanceManagerCPU }}
           {{- end }}
+          {{- if .Harvester.Longhorn.DefaultSettings.StorageReservedPercentageForDefaultDisk }}
+          storageReservedPercentageForDefaultDisk: {{ .Harvester.Longhorn.DefaultSettings.StorageReservedPercentageForDefaultDisk }}
+          {{- end }}
           detachManuallyAttachedVolumesWhenCordoned: true
           nodeDrainPolicy: "allow-if-replica-is-stopped"
       harvester-network-controller:


### PR DESCRIPTION
Enabling storage-reserved-percentage-for-default-disk configuration
as part of the install.harvester.longhorn.defaultSettings

The following behaviour is enforced:
* values can range between 0% and 30%
* default value if no config passed is 0%
* max value is 30%

#### Problem:
Longhorn setting: `storage-reserved-percentage-for-default-disk` is not exposed in the harvester installation and can only be changed manually after installation.

#### Solution:
Expose the setting through configuration file

#### Related Issue(s):
https://github.com/harvester/harvester/issues/8200

#### Test plan:
Create local configuration file containing the setting (the file can be only that):
```yaml
install:
  harvester:
    longhorn:
      defaultSettings:
        storageReservedPercentageForDefaultDisk: 50
```
Served it locally through python to the harvester installation:
```
python3 -m http.server --bind 0.0.0.0 8000
```

Once ready ssh into the node and validate configuration was inside (as per description 30 not 50 since 30 is max):
```
harvester:/home/rancher # kubectl get settings.longhorn.io -n longhorn-system | grep storage-reserved-percentage-for-default-disk
storage-reserved-percentage-for-default-disk                      30                                                              true      24m
```

Default value with no configuration passed needs to be the expected one:
```
harvester:/home/rancher # kubectl get settings.longhorn.io -n longhorn-system | grep storage-reserved-percentage-for-default-disk
storage-reserved-percentage-for-default-disk                      0                                                               true      3m2s
```

So testing scenarios:
* set value above max limit of 30 - like 100, expect in env to set to 30
* install without configuration - expect value 0 - the default
* set value of a negative number - would something panic out?
* set value to custom number between 0 and 30, like 15 - expect the number to be reflected in the env

#### Additional documentation or context
N/A
