### PR TITLE
fix: check number of disks on disk page and report error gracefully when there is none

### DIFF
--- a/pkg/console/constant.go
+++ b/pkg/console/constant.go
@@ -4,6 +4,7 @@ const (
 	titlePanel                  = "title"
 	debugPanel                  = "debug"
 	diskPanel                   = "disk"
+	diskFatalPanel              = "diskFatal"
 	persistentSizePanel         = "persistentSize"
 	dataPersistentSizePanel     = "dataPersistentSize"
 	dataPersistentSizeNotePanel = "dataPersistentSizeNote"


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
When running the Harvester installer on a host without an accessible disk, the installer will terminate with panic.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
Check number of disks on disk page

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/7863

#### Test plan:
<!-- Describe the test plan by steps. -->

Path 1: Install on a machine without a disk

https://github.com/user-attachments/assets/9c0256dc-fd3e-49bc-a623-d76fbf3723c0

Path 2: Hotplug: Install on a machine without a disk and attach one later

https://github.com/user-attachments/assets/433e94ae-4d4a-4bab-b9c2-f47d46a70153

Path 3: Hotplug: Install on a machine with a disk and detach it later

https://github.com/user-attachments/assets/1a349ef9-e2d0-4a56-a100-fdb7071e5cdd


#### Additional documentation or context

https://github.com/harvester/harvester-installer/pull/1132 is another way to tackle the same problem.
