### PR TITLE
fix: use CloseElement to avoid crash on VIP screen

### DIFF
--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -2862,12 +2862,9 @@ func addVIPPanel(c *Console) error {
 			return showNext(c, vipPanel, vipHwAddrNotePanel, vipHwAddrPanel)
 		}
 
-		if err = hwAddrV.Close(); err != nil {
-			return err
-		}
-		if err = hwAddrNoteV.Close(); err != nil {
-			return err
-		}
+		c.CloseElement(vipHwAddrPanel)
+		c.CloseElement(vipHwAddrNotePanel)
+
 		return showNext(c, vipPanel)
 	}
 	gotoVipParentPanel := func(_ *gocui.Gui, _ *gocui.View) error {


### PR DESCRIPTION
#### Problem:
https://github.com/harvester/harvester-installer/pull/1118 updated the code to pass the latest lint checks, which includes better checking of error returns.  Unfortunately, a couple of the calls to close elements _do_ return errors (ErrUnknownView) if those elements aren't visible yet, which means the installer will crash on the VIP screen if you try to select "Static IP".

#### Solution:
This commit calls the CloseElement function instead, which safely ignores that error if the element is not visible.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/8749

#### Test plan:
Go through the installer. Try to select Static VIP. The installer should not crash.

#### Additional documentation or context
