### PR TITLE
Pass correct intf names to wicked scripts bond and bridge templates

### DIFF
--- a/pkg/config/cos.go
+++ b/pkg/config/cos.go
@@ -611,7 +611,7 @@ func updateBond(stage *yipSchema.Stage, name string, network *Network) error {
 
 	mgmtData := map[string]interface{}{
 		"VlanID":   network.VlanID,
-		"IntfName": MgmtBondInterfaceName,
+		"IntfName": MgmtInterfaceName,
 	}
 
 	postUpScript, err := render("wicked-setup-bond.sh", mgmtData)
@@ -674,7 +674,7 @@ func updateBridge(stage *yipSchema.Stage, name string, mgmtNetwork *Network) err
 
 	mgmtData := map[string]interface{}{
 		"VlanID":   mgmtNetwork.VlanID,
-		"IntfName": MgmtInterfaceName,
+		"IntfName": MgmtBondInterfaceName,
 	}
 
 	preUpScript, err := render("wicked-setup-bridge.sh", mgmtData)


### PR DESCRIPTION

#### Problem:
https://github.com/harvester/harvester/issues/7650 changed the behaviour of adding only vlans that are configured for mgmt cluster network instead of adding all 2-4094 vlans to the mgmt-br and mgmt-bo interface.
During this change, https://github.com/harvester/harvester-installer/pull/1026/files modified the interface names passed to the templates of /etc/wicked/scripts/setup_bond.sh and /etc/wicked/scripts/setup_bridge.sh due to which the behaviour added to mgmt-br and mgmt-bo is reversed.

#### Solution:
Pass correct intf names during the wicked scripts template generation

#### Related Issue(s):
https://github.com/harvester/harvester/issues/9145

#### Test plan:
1.Install Harvester with master/v1.6.1
2.Check the /etc/wicked/scripts/setup_bond.sh to reflect mgmt-br in "ip link set dev ..." during inherit mac address.
3.Check the /etc/wicked/scripts/setup_bridge.sh to reflect mgmt-bo in "bridge vlan add vid vlan-id dev mgmt-bo"

Actual:
```
cat /etc/wicked/scripts/setup_bond.sh 
#!/bin/sh

ACTION=$1
INTERFACE=$2

case $ACTION in
        post-up)
                # inherit MAC address
                ip link set dev mgmt-bo address $(ip -json link show dev $INTERFACE | jq -j '.[0]["address"]')

                #skip bridge vlan setting when no vlan id or vlan id=1 specified by user
                if [ 2021 -eq 0 ] || [ 2021 -eq 1 ]; then
                    exit 0
                fi
                #assign user configured vlan,PVID=1 by default
                bridge vlan add vid 2021 dev $INTERFACE
                ;;

esac

 cat /etc/wicked/scripts/setup_bridge.sh 

#!/bin/sh

ACTION=$1
INTERFACE=$2

case $ACTION in
        pre-up)
                # enable vlan-aware
                ip link set $INTERFACE type bridge vlan_filtering 1
                ;;

        post-up)
                #skip bridge vlan setting when no vlan id or vlan-id=1 specified by user
                if [ 2021 -eq 0 ] || [ 2021 -eq 1 ]; then
                    exit 0
                fi
                #assign user configured vlan,PVID=1 by default
                bridge vlan add vid 2021 dev $INTERFACE self
                bridge vlan add vid 2021 dev mgmt-br
                ;;
esac

```
Expected:
```
cat /etc/wicked/scripts/setup_bond.sh 
#!/bin/sh

ACTION=$1
INTERFACE=$2

case $ACTION in
        post-up)
                # inherit MAC address
                ip link set dev mgmt-br address $(ip -json link show dev $INTERFACE | jq -j '.[0]["address"]')

                #skip bridge vlan setting when no vlan id or vlan id=1 specified by user
                if [ 2021 -eq 0 ] || [ 2021 -eq 1 ]; then
                    exit 0
                fi
                #assign user configured vlan,PVID=1 by default
                bridge vlan add vid 2021 dev $INTERFACE
                ;;

esac
cat /etc/wicked/scripts/setup_bridge.sh 
#!/bin/sh

ACTION=$1
INTERFACE=$2

case $ACTION in
        pre-up)
                # enable vlan-aware
                ip link set $INTERFACE type bridge vlan_filtering 1
                ;;

        post-up)
                #skip bridge vlan setting when no vlan id or vlan-id=1 specified by user
                if [ 2021 -eq 0 ] || [ 2021 -eq 1 ]; then
                    exit 0
                fi
                #assign user configured vlan,PVID=1 by default
                bridge vlan add vid 2021 dev $INTERFACE self
                bridge vlan add vid 2021 dev mgmt-bo
                ;;
esac

```
#### Additional documentation or context
