### PR TITLE
Add image kubectl v1.34.0

### DIFF
--- a/scripts/images/rancher-images.txt
+++ b/scripts/images/rancher-images.txt
@@ -1,7 +1,7 @@
 docker.io/rancher/fleet-agent:v0.13.0
 docker.io/rancher/fleet:v0.13.0
-docker.io/rancher/kubectl:v1.29.2
 docker.io/rancher/kubectl:v1.33.1
+docker.io/rancher/kubectl:v1.34.0
 docker.io/rancher/mirrored-cluster-api-controller:v1.10.2
 docker.io/rancher/mirrored-fluent-fluent-bit:3.1.8
 docker.io/rancher/mirrored-kube-logging-fluentd:v1.16-4.10-full


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

<img width="3210" height="274" alt="image" src="https://github.com/user-attachments/assets/4bfd756e-8751-4e7c-b242-fa19b8ab3613" />

While testing https://github.com/harvester/harvester/pull/9203, we noticed:

PR 8996 bumped 
hookImage: rancher/kubectl: from v1.32.3 to v1.34.0, but the related kubectl image is not added to image list.


https://github.com/harvester/harvester/pull/8996
https://github.com/harvester/harvester/commit/97fb8bfce3aec7510e65362023da8887bacfcc1b#diff-96df7bc003c89a9f514e73b8a1e42d5b99e1f13a926c18a20db40a09acef807eL17

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Add new image tag.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

https://github.com/harvester/harvester/issues/8930

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
