### PR TITLE
fix: stringify longhorn numeric defaultValues

### DIFF
--- a/pkg/config/templates/rancherd-10-harvester.yaml
+++ b/pkg/config/templates/rancherd-10-harvester.yaml
@@ -186,7 +186,7 @@ resources:
           guaranteedInstanceManagerCPU: {{ .Harvester.Longhorn.DefaultSettings.GuaranteedInstanceManagerCPU }}
           {{- end }}
           {{- if .Harvester.Longhorn.DefaultSettings.StorageReservedPercentageForDefaultDisk }}
-          storageReservedPercentageForDefaultDisk: {{ .Harvester.Longhorn.DefaultSettings.StorageReservedPercentageForDefaultDisk }}
+          storageReservedPercentageForDefaultDisk: "{{ .Harvester.Longhorn.DefaultSettings.StorageReservedPercentageForDefaultDisk }}"
           {{- end }}
           detachManuallyAttachedVolumesWhenCordoned: true
           nodeDrainPolicy: "allow-if-replica-is-stopped"


### PR DESCRIPTION
#### Problem:
Since https://github.com/longhorn/longhorn/commit/d41740d1, longhorn's defaultValues must be strings.

#### Solution:
Quote the numeric values.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/9223

#### Test plan:
Deploy harvester, make sure there are no errors as in the description of the related issue

