### PR TITLE
fix: really publish harvester-installer container image on tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ on:
     branches:
     - master
     - v*
+  tags:
+    - v*
   pull_request:
 env:
   # Fake up DRONE_BRANCH so it's picked up when dapper gets to


### PR DESCRIPTION
#### Problem:
https://github.com/harvester/harvester-installer/pull/1155 was missing the push tag trigger

#### Solution:
Add the push tag trigger

#### Related Issue(s):
https://github.com/harvester/harvester/issues/3418

#### Test plan:
Same as https://github.com/harvester/harvester-installer/pull/1155