### PR TITLE
fix: preserve /var/lib/NetworkManager from initramfs [DNM]

### DIFF
--- a/package/harvester-os/files/system/oem/90_network.yaml
+++ b/package/harvester-os/files/system/oem/90_network.yaml
@@ -1,5 +1,23 @@
 name: "Network configuration"
 stages:
+  rootfs:
+    - name: Preserve DHCP leases from initramfs
+      # Note: this is arugably bad, because it ends up in the immutable root
+      # filesystem of the installed system.  I seriously doubt we want that.
+      # but, it does take us from DISCOVER/OFFER/REQUEST/ACK to just
+      # REQUEST/ACK after switch root, so it _might_ fix the problem...
+      # Doing this in initramfs or boot doesn't seem to work, because we
+      # don't have access to /var/lib/NetworkManager anymore from the initrd.
+      if: cat /proc/cmdline | grep -q "harvester.install.automatic=true"
+      commands:
+      - |
+        if [ -d /var/lib/NetworkManager ]; then
+          echo "Copying /var/lib/NetworkManager from initramfs to sysroot"
+          cp /var/lib/NetworkManager/* /sysroot/var/lib/NetworkManager/
+          echo "tserong was here" > /sysroot/var/lib/NetworkManager/tserong.test
+        else
+          echo "/var/lib/NetworkManager does not exist in initramfs"
+        fi
   network:
     - name: Bring up interfaces
       commands:


### PR DESCRIPTION
This is an experiment only.  It's slighly problematic in that because it's done so early, the /var/lib/NetworkManager files copied from the initramfs actually end up in the installed system's root filesystem where strictly we really only want this in the installation environment. But, it's good enough for a test.  What I observed when doing this, while looking at the DHCP _server_ logs, is that without this change, I see:

In initramfs:

Oct 16 04:54:14 pxe-server dhcpd[4809]: DHCPDISCOVER from 02:00:00:0d:62:e2 via eth1
Oct 16 04:54:14 pxe-server dhcpd[4809]: DHCPOFFER on 192.168.0.30 to 02:00:00:0d:62:e2 via eth1
Oct 16 04:54:16 pxe-server dhcpd[4809]: DHCPREQUEST for 192.168.0.30 (192.168.0.254) from 02:00:00:0d:62:e2 via eth1
Oct 16 04:54:16 pxe-server dhcpd[4809]: DHCPACK on 192.168.0.30 to 02:00:00:0d:62:e2 via eth1

After switch root:

Oct 16 04:54:23 pxe-server dhcpd[4809]: DHCPDISCOVER from 02:00:00:0d:62:e2 via eth1
Oct 16 04:54:23 pxe-server dhcpd[4809]: DHCPOFFER on 192.168.0.30 to 02:00:00:0d:62:e2 via eth1
Oct 16 04:54:24 pxe-server dhcpd[4809]: DHCPREQUEST for 192.168.0.30 (192.168.0.254) from 02:00:00:0d:62:e2 via eth1
Oct 16 04:54:24 pxe-server dhcpd[4809]: DHCPACK on 192.168.0.30 to 02:00:00:0d:62:e2 via eth1

So there's a full DHCP discovery that happens again after the interface is restarted.

_With_ this change applied, I see the initial discovery in the initramfs:

Oct 16 07:50:20 pxe-server dhcpd[4837]: DHCPDISCOVER from 02:00:00:0d:62:e2 via eth1
Oct 16 07:50:20 pxe-server dhcpd[4837]: DHCPOFFER on 192.168.0.30 to 02:00:00:0d:62:e2 via eth1
Oct 16 07:50:21 pxe-server dhcpd[4837]: DHCPREQUEST for 192.168.0.30 (192.168.0.254) from 02:00:00:0d:62:e2 via eth1
Oct 16 07:50:21 pxe-server dhcpd[4837]: DHCPACK on 192.168.0.30 to 02:00:00:0d:62:e2 via eth1

...but then after switch root, even though the interface is still restarted, I only get this:

Oct 16 07:50:29 pxe-server dhcpd[4837]: DHCPREQUEST for 192.168.0.30 from 02:00:00:0d:62:e2 via eth1
Oct 16 07:50:29 pxe-server dhcpd[4837]: DHCPACK on 192.168.0.30 to 02:00:00:0d:62:e2 via eth1

...so it's not doing the full discovery.  I wonder if this will be enough to fix the problem?