### PR TITLE
feat: add initial iptables rules via NetworkManager dispatcher

### DIFF
--- a/package/harvester-os/Dockerfile
+++ b/package/harvester-os/Dockerfile
@@ -5,7 +5,9 @@ ARG ARCH=amd64
 RUN curl -sfL https://github.com/rancher/wharfie/releases/download/v0.6.8/wharfie-${ARCH}  -o /usr/bin/wharfie && chmod +x /usr/bin/wharfie
 
 COPY files/ /
-RUN chmod 0600 /system/oem/*
+RUN chmod 0600 /system/oem/* && \
+    chown root:root /etc/NetworkManager/dispatcher.d/99-iptables && \
+    chmod 755 /etc/NetworkManager/dispatcher.d/99-iptables
 
 COPY harvester-release.yaml /etc/
 

--- a/package/harvester-os/files/etc/NetworkManager/dispatcher.d/99-iptables
+++ b/package/harvester-os/files/etc/NetworkManager/dispatcher.d/99-iptables
@@ -2,6 +2,11 @@
 
 set -e
 
+# Log execution for debugging/verification
+if [ -x /usr/bin/logger ]; then
+    /usr/bin/logger -t "harvester-iptables" "Executing 99-iptables for interface '$1' with action '$2'"
+fi
+
 if [ "$2" != "up" ]; then
     exit 0
 fi
@@ -85,6 +90,33 @@ else
 fi
 
 # --- End HARVESTER_ESSENTIAL ---
+
+# --- Rules for HARVESTER_DYNAMIC ---
+
+check_kubeovn_enabled() {
+    KUBECONFIG=/etc/rancher/rke2/rke2.yaml
+    KUBECTL=/var/lib/rancher/rke2/bin/kubectl
+    
+    if [ ! -x "$KUBECTL" ]; then
+        KUBECTL=$(command -v kubectl || true)
+    fi
+
+    if [ -x "$KUBECTL" ] && [ -f "$KUBECONFIG" ]; then
+        STATUS=$($KUBECTL --kubeconfig "$KUBECONFIG" --request-timeout=5s get addon -n kube-system kubeovn-operator -o jsonpath='{.spec.enabled}' 2>/dev/null || true)
+        if [ "$STATUS" = "true" ]; then
+            echo "true"
+            return
+        fi
+    fi
+    
+    echo "false"
+}
+
+if [ "$(check_kubeovn_enabled)" = "true" ]; then
+    # KubeOVN Ports: 6081 (UDP), 6641/6642 (TCP)
+    iptables -A HARVESTER_DYNAMIC -p udp --dport 6081 -j ACCEPT
+    iptables -A HARVESTER_DYNAMIC -p tcp -m multiport --dports 6641,6642 -j ACCEPT
+fi
 
 # FORWARD chain rules
 add_rule FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT

--- a/package/harvester-os/files/etc/NetworkManager/dispatcher.d/99-iptables
+++ b/package/harvester-os/files/etc/NetworkManager/dispatcher.d/99-iptables
@@ -1,0 +1,94 @@
+#!/bin/sh
+
+set -e
+
+if [ "$2" != "up" ]; then
+    exit 0
+fi
+
+# Ensure custom chains exist
+ensure_chain() {
+    iptables -N "$1" 2>/dev/null || true
+    if ! iptables -L "$1" -n >/dev/null 2>&1; then
+        echo "Error: Failed to ensure chain $1 exists" >&2
+        exit 1
+    fi
+}
+
+ensure_chain HARVESTER_ESSENTIAL
+ensure_chain HARVESTER_DYNAMIC
+
+# Helper to add rule if missing
+add_rule() {
+    iptables -C "$@" 2>/dev/null || iptables -A "$@"
+}
+
+# Ensure INPUT chain jumps to our custom chains
+add_rule INPUT -j HARVESTER_ESSENTIAL
+add_rule INPUT -j HARVESTER_DYNAMIC
+
+# Set default policies to ACCEPT to prevent lockout during rule update
+iptables -P INPUT ACCEPT
+iptables -P FORWARD ACCEPT
+
+# Flush HARVESTER_ESSENTIAL to ensure clean state
+iptables -F HARVESTER_ESSENTIAL
+iptables -F HARVESTER_DYNAMIC
+
+# --- Rules for HARVESTER_ESSENTIAL ---
+
+# Allow loopback
+iptables -A HARVESTER_ESSENTIAL -i lo -j ACCEPT
+
+# Allow ICMP (Ping)
+iptables -A HARVESTER_ESSENTIAL -p icmp -j ACCEPT
+
+# Allow VRRP (Keepalived)
+iptables -A HARVESTER_ESSENTIAL -p vrrp -j ACCEPT
+
+# Allow Established/Related connections
+iptables -A HARVESTER_ESSENTIAL -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+
+# Common Rules
+# TCP 80, 443, 22
+iptables -A HARVESTER_ESSENTIAL -p tcp --dport 80 -j ACCEPT
+iptables -A HARVESTER_ESSENTIAL -p tcp --dport 443 -j ACCEPT
+iptables -A HARVESTER_ESSENTIAL -p tcp --dport 22 -j ACCEPT
+
+# UDP 8472 (VXLAN)
+iptables -A HARVESTER_ESSENTIAL -p udp --dport 8472 -j ACCEPT
+
+# K8s/RKE2 Common
+iptables -A HARVESTER_ESSENTIAL -p tcp -m multiport --dports 6443:6444 -j ACCEPT
+iptables -A HARVESTER_ESSENTIAL -p tcp -m multiport --dports 10248:10250 -j ACCEPT
+iptables -A HARVESTER_ESSENTIAL -p tcp --dport 10010 -j ACCEPT
+iptables -A HARVESTER_ESSENTIAL -p tcp --dport 9099 -j ACCEPT
+
+# Determine role and apply specific rules
+IS_SERVER=false
+if systemctl is-enabled rke2-server.service 2>/dev/null | grep -q enabled; then
+    IS_SERVER=true
+elif systemctl is-active rke2-server.service 2>/dev/null | grep -q active; then
+    IS_SERVER=true
+fi
+
+if [ "$IS_SERVER" = "true" ]; then
+    # Master/Server specific
+    iptables -A HARVESTER_ESSENTIAL -p tcp --dport 9345 -j ACCEPT
+    iptables -A HARVESTER_ESSENTIAL -p tcp -m multiport --dports 10256:10260 -j ACCEPT
+    iptables -A HARVESTER_ESSENTIAL -p tcp -m multiport --dports 2379:2382 -j ACCEPT
+    iptables -A HARVESTER_ESSENTIAL -p tcp --dport 9091 -j ACCEPT
+    iptables -A HARVESTER_ESSENTIAL -p tcp --dport 2112 -j ACCEPT
+else
+    # Worker/Agent specific
+    iptables -A HARVESTER_ESSENTIAL -p tcp --dport 10256 -j ACCEPT
+fi
+
+# --- End HARVESTER_ESSENTIAL ---
+
+# FORWARD chain rules
+add_rule FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+
+# Set default policies
+iptables -P INPUT DROP
+iptables -P FORWARD DROP

--- a/package/harvester-os/files/etc/NetworkManager/dispatcher.d/99-iptables
+++ b/package/harvester-os/files/etc/NetworkManager/dispatcher.d/99-iptables
@@ -93,29 +93,9 @@ fi
 
 # --- Rules for HARVESTER_DYNAMIC ---
 
-check_kubeovn_enabled() {
-    KUBECONFIG=/etc/rancher/rke2/rke2.yaml
-    KUBECTL=/var/lib/rancher/rke2/bin/kubectl
-    
-    if [ ! -x "$KUBECTL" ]; then
-        KUBECTL=$(command -v kubectl || true)
-    fi
-
-    if [ -x "$KUBECTL" ] && [ -f "$KUBECONFIG" ]; then
-        STATUS=$($KUBECTL --kubeconfig "$KUBECONFIG" --request-timeout=5s get addon -n kube-system kubeovn-operator -o jsonpath='{.spec.enabled}' 2>/dev/null || true)
-        if [ "$STATUS" = "true" ]; then
-            echo "true"
-            return
-        fi
-    fi
-    
-    echo "false"
-}
-
-if [ "$(check_kubeovn_enabled)" = "true" ]; then
-    # KubeOVN Ports: 6081 (UDP), 6641/6642 (TCP)
-    iptables -A HARVESTER_DYNAMIC -p udp --dport 6081 -j ACCEPT
-    iptables -A HARVESTER_DYNAMIC -p tcp -m multiport --dports 6641,6642 -j ACCEPT
+if [ -x /usr/sbin/harvester-kubeovn-monitor ]; then
+    /usr/sbin/harvester-kubeovn-monitor run-once
+    /usr/sbin/harvester-kubeovn-monitor monitor >/dev/null 2>&1 &
 fi
 
 # FORWARD chain rules

--- a/package/harvester-os/files/usr/sbin/harvester-kubeovn-monitor
+++ b/package/harvester-os/files/usr/sbin/harvester-kubeovn-monitor
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+LOG_TAG="harvester-kubeovn-monitor"
+LOCK_FILE="/var/run/harvester-kubeovn-monitor.lock"
+
+log() {
+    if [ -x /usr/bin/logger ]; then
+        /usr/bin/logger -t "$LOG_TAG" "$1"
+    else
+        echo "$1"
+    fi
+}
+
+check_kubeovn_enabled() {
+    KUBECONFIG=/etc/rancher/rke2/rke2.yaml
+    KUBECTL=/var/lib/rancher/rke2/bin/kubectl
+
+    if [ ! -x "$KUBECTL" ]; then
+        KUBECTL=$(command -v kubectl || true)
+    fi
+
+    if [ -x "$KUBECTL" ] && [ -f "$KUBECONFIG" ]; then
+        if $KUBECTL --kubeconfig "$KUBECONFIG" --request-timeout=5s get addon -n kube-system kubeovn-operator -o jsonpath='{.spec.enabled}' > /dev/null 2>&1; then
+            echo "true"
+            return
+        fi
+
+        REPLICAS=$($KUBECTL --kubeconfig "$KUBECONFIG" --request-timeout=5s get deployment -n kube-system kubeovn-operator-controller-manager -o jsonpath='{.status.availableReplicas}' 2>/dev/null || true)
+        if [ -n "$REPLICAS" ] && [ "$REPLICAS" -gt 0 ]; then
+            echo "true"
+            return
+        fi
+    fi
+
+    echo "false"
+}
+
+ensure_rules() {
+    ENABLED=$1
+
+    if [ "$ENABLED" = "true" ]; then
+        # KubeOVN Ports: 6081 (UDP), 6641/6642 (TCP)
+        iptables -C HARVESTER_DYNAMIC -p udp --dport 6081 -j ACCEPT 2>/dev/null || iptables -A HARVESTER_DYNAMIC -p udp --dport 6081 -j ACCEPT
+        iptables -C HARVESTER_DYNAMIC -p tcp -m multiport --dports 6641,6642 -j ACCEPT 2>/dev/null || iptables -A HARVESTER_DYNAMIC -p tcp -m multiport --dports 6641,6642 -j ACCEPT
+    else
+        iptables -D HARVESTER_DYNAMIC -p udp --dport 6081 -j ACCEPT 2>/dev/null || true
+        iptables -D HARVESTER_DYNAMIC -p tcp -m multiport --dports 6641,6642 -j ACCEPT 2>/dev/null || true
+    fi
+}
+
+do_monitor() {
+    log "Starting monitor..."
+    while true; do
+        ENABLED=$(check_kubeovn_enabled)
+        ensure_rules "$ENABLED"
+        sleep 5
+    done
+}
+
+CMD=${1:-monitor}
+
+if [ "$CMD" = "run-once" ]; then
+    ENABLED=$(check_kubeovn_enabled)
+    ensure_rules "$ENABLED"
+    exit 0
+fi
+
+if [ "$CMD" = "monitor" ]; then
+    exec 9>"$LOCK_FILE"
+    if ! flock -n 9; then
+        exit 0
+    fi
+    do_monitor
+fi


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
There should be a way to blacklist external network or whitelist the Harvester node network only to protection from malicious scan and access.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
This commit introduces a NetworkManager dispatcher script to apply initial iptables rules when network interfaces are brought up.

This commit introduces a NetworkManager dispatcher script to apply initial iptables rules when network interfaces are brought up. Creating two custom chains:
  - `HARVESTER_ESSENTIAL`: Contains core rules required for Harvester and RKE2 functionality (SSH, K8s API, VXLAN, etc.).
  - `HARVESTER_DYNAMIC`: A placeholder chain for users or external components


#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/5681


#### Test plan:
<!-- Describe the test plan by steps. -->
Should include all feature as follows which should be broken into details
- Core Cluster Functionalities
- Storage Network Tests
- VM Operation Tests
- External Integration Tests
  - Rancher management and other Cloud Providers
- Security Tests
  - Use checkmk or nmap scan against nodes

#### Additional documentation or context
