### PR TITLE
switch to traefik as ingress controller and drop nginx helm chart config

### DIFF
--- a/pkg/config/cos.go
+++ b/pkg/config/cos.go
@@ -465,6 +465,20 @@ func initRancherdStage(config *HarvesterConfig, stage *yipSchema.Stage) error {
 		},
 	)
 
+	ingressConfig, err := render("rke2-99-traefik.yaml", config)
+	if err != nil {
+		return err
+	}
+
+	stage.Files = append(stage.Files,
+		yipSchema.File{
+			Path:        "/etc/rancher/rke2/config.yaml.d/99-traefik.yaml",
+			Content:     ingressConfig,
+			Permissions: 0600,
+			Owner:       0,
+			Group:       0,
+		},
+	)
 	return nil
 }
 

--- a/pkg/config/templates/rancherd-10-harvester.yaml
+++ b/pkg/config/templates/rancherd-10-harvester.yaml
@@ -24,23 +24,6 @@ resources:
       release: rancher-monitoring
     name: rancher-monitoring-operator
     namespace: cattle-monitoring-system
-- apiVersion: helm.cattle.io/v1
-  kind: HelmChartConfig
-  metadata:
-    name: rke2-ingress-nginx
-    namespace: kube-system
-  spec:
-    valuesContent: |-
-      controller:
-        config:
-          proxy-body-size: "0"
-          proxy-request-buffering: "off"
-        admissionWebhooks:
-          port: 8444
-        publishService:
-          pathOverride: kube-system/ingress-expose
-        extraArgs:
-          default-ssl-certificate: cattle-system/tls-rancher-internal
 - apiVersion: v1
   kind: Secret
   metadata:

--- a/pkg/config/templates/rke2-99-traefik.yaml
+++ b/pkg/config/templates/rke2-99-traefik.yaml
@@ -1,0 +1,1 @@
+ingress-controller: traefik


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
Nginx Ingress is going to be deprecated. As a result Harvester needs to switch to the inbuilt traefik ingress controller available with rke2.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
The PR introduces the following changes
* removes the `rke2-ingress-nginx` helm chart config
* adds a new 99-traefik.yaml as part of install to all nodes to define ingress to switch to `traefik`

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/10067

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
