### PR TITLE
feat: include kube-ovn v1.15.4 image in iso packaging

### DIFF
--- a/scripts/images/harvester-additional-images.txt
+++ b/scripts/images/harvester-additional-images.txt
@@ -1,3 +1,3 @@
 registry.suse.com/suse/vmdp/vmdp:2.5.5
-docker.io/kubeovn/kube-ovn:v1.14.10
+docker.io/kubeovn/kube-ovn:v1.15.4
 registry.k8s.io/descheduler/descheduler:v0.33.0


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

The Kube-OVN v1.15.4 upstream image was not included in v1.8.0 packaged ISO image we shipped. Enabling the add-on fails for air-gapped users due to missing the container image.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Add the v1.15.4 image into the packaging list.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

#### Test plan:
<!-- Describe the test plan by steps. -->

1. Build the ISO image
2. Check the built ISO image using tools such as `isoinfo`, the ISO image should include the upstream Kube-OVN v1.15.4 image

#### Additional documentation or context
