### PR TITLE
Treat local ISO paths as ISO installs

### DIFF
--- a/package/harvester-os/files/usr/sbin/harv-install
+++ b/package/harvester-os/files/usr/sbin/harv-install
@@ -183,11 +183,15 @@ preload_rke2_images()
     fi
 
     # Use HARVESTER_ISO_URL to determine if this is an ISO-based installation
-    if [ -n "$HARVESTER_ISO_URL" ]; then
-        INSTALL_MODE="PXE"
-    else
-        INSTALL_MODE="ISO"
-    fi
+    # Only remote URL sources use the PXE bind-mount path.
+    case "${HARVESTER_ISO_URL:-}" in
+        ftp*|http*|tftp*)
+            INSTALL_MODE="PXE"
+            ;;
+        *)
+            INSTALL_MODE="ISO"
+            ;;
+    esac
 
     readonly RKE2_IMAGES_DIR="/var/lib/rancher/rke2/agent/images"
     readonly TMP_IMAGES_DIR="/var/lib/rancher/tmp/images"


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
Helps with airgapped, non-interactive installs discussed in
https://github.com/harvester/harvester/issues/10460.

`harv-install` currently overloads `HARVESTER_ISO_URL`: if it is non-empty, the preload logic treats the install as PXE mode (`INSTALL_MODE="PXE"`), even when the value is a local filesystem path to an ISO rather than an HTTP/TFTP source.

That distinction appears to matter on v1.8.0. In our environment, using a local file path in `HARVESTER_ISO_URL` caused the PXE-style preload path to leave at least one required first-boot image unavailable locally:
`docker.io/rancher/mirrored-calico-operator:v1.40.3`.

The resulting behavior was:

- early bootstrap attempted to start Tigera/Calico
- `tigera-operator` was not available locally
- once the bind-mounted preload source was gone, bootstrap fell back to pulling from `docker.io`
- in an airgapped/static-first-boot environment, bootstrap stalled

The core issue is that a local ISO path should not force PXE preload semantics. A local-file `HARVESTER_ISO_URL` still wants ISO-style preload/copy behavior, not PXE-style bind-mount behavior.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Distinguish local ISO paths from remote PXE sources in preload handling:

- treat `HARVESTER_ISO_URL` as PXE only for real remote URLs (`http`, `https`, `tftp`, `ftp`)
- treat local filesystem paths as ISO-mode preload


#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

Issue harvester/harvester#10460

#### Test plan:
<!-- Describe the test plan by steps. -->

- use a local filesystem path in `HARVESTER_ISO_URL`
- verify preload follows ISO-mode behavior instead of PXE-mode behavior
- verify required first-boot images are available locally after install
- verify bootstrap does not fall back to pulling `tigera-operator` from `docker.io`
- verify remote URL sources still follow PXE-mode behavior

#### Additional documentation or context

This issue was reproduced while trying to support non-interactive, airgapped installs using a local Harvester ISO.