### PR TITLE
fix: do not wipe non-existent disks

### DIFF
--- a/pkg/console/util.go
+++ b/pkg/console/util.go
@@ -570,6 +570,11 @@ func doInstall(g *gocui.Gui, hvstConfig *config.HarvesterConfig, webhooks Render
 
 	// prepare to wipe disks
 	for _, disk := range hvstConfig.Install.WipeDisksList {
+		if _, err := os.Stat(disk); os.IsNotExist(err) {
+			logrus.Warnf("disk %s does not exist, skipping wipe", disk)
+			continue
+		}
+		logrus.Infof("wiping disk %s", disk)
 		if err := executeWipeDisks(ctx, disk); err != nil {
 			return fmt.Errorf("error wiping disk %s: %w", disk, err)
 		}


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
If disks in wipe_disks_list don't exist, the installation process fail.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

We should skip wiping non-existent disks.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->


https://github.com/harvester/harvester/issues/10591


#### Test plan:
<!-- Describe the test plan by steps. -->

Install Harvester with wipe_disks_lists config, make sure to include one or more non-existent disks in the list. for example:
```
install:
  wipe_disks_list:
    - /dev/sda
    - /dev/sdb
    - /dev/vda
```

Assume sdb doesn't exist, you should see the following messages in `/var/log/console.log` (during installation) or `/oem/install/console.log` (after reboot).
```
time="2026-05-20T12:49:10Z" level=warning msg="disk /dev/sdb does not exist, skipping wipe"
```

And the installation should proceed without error.

#### Additional documentation or context
