### PR TITLE
Ensure the harvester related managedchart has max history 10

### DIFF
--- a/pkg/config/templates/rancherd-10-harvester.yaml
+++ b/pkg/config/templates/rancherd-10-harvester.yaml
@@ -77,6 +77,7 @@ resources:
     version: {{ .HarvesterChartVersion }}
     defaultNamespace: harvester-system
     timeoutSeconds: 600
+    maxHistory: 10
     diff:
       comparePatches:
       - apiVersion: storage.k8s.io/v1
@@ -222,6 +223,7 @@ resources:
     defaultNamespace: harvester-system
     repoName: harvester-charts
     timeoutSeconds: 600
+    maxHistory: 10
     # takeOwnership will force apply this chart without checking ownership in labels and annotations.
     # https://github.com/rancher/fleet/blob/ce9c0d6c0a455d61e87c0f19df79d0ee11a89eeb/pkg/helmdeployer/deployer.go#L323
     # https://github.com/rancher/helm/blob/ee91a121e0aa301fcef2bfbc7184f96edd4b50f5/pkg/action/validate.go#L71-L76

--- a/pkg/config/templates/rancherd-11-monitoring-crd.yaml
+++ b/pkg/config/templates/rancherd-11-monitoring-crd.yaml
@@ -11,6 +11,7 @@ resources:
     defaultNamespace: cattle-monitoring-system
     repoName: harvester-charts
     timeoutSeconds: 600
+    maxHistory: 10
     targets:
     - clusterName: local
       clusterSelector:

--- a/pkg/config/templates/rancherd-14-logging-crd.yaml
+++ b/pkg/config/templates/rancherd-14-logging-crd.yaml
@@ -11,6 +11,7 @@ resources:
     defaultNamespace: cattle-logging-system
     repoName: harvester-charts
     timeoutSeconds: 600
+    maxHistory: 10
     targets:
     - clusterName: local
       clusterSelector:

--- a/pkg/config/templates/rancherd-15-kubeovn-operator-crd.yaml
+++ b/pkg/config/templates/rancherd-15-kubeovn-operator-crd.yaml
@@ -11,6 +11,7 @@ resources:
     defaultNamespace: kube-system
     repoName: harvester-charts
     timeoutSeconds: 600
+    maxHistory: 10
     targets:
     - clusterName: local
       clusterSelector:


### PR DESCRIPTION
Ensure the harvester related managedchart has max history 10 instead of default value 2

<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->

The managedchart used to keep 10 (legacy default value) history records on final helm charts; but later it was changed to 2 (new default value) by upstream.

```
helm history -n harvester-system harvester
REVISION	UPDATED                 	STATUS    	CHART                       	APP VERSION        	DESCRIPTION                                                                                                                                      
23      	Fri May 29 07:50:44 2026	superseded	harvester-1.9.0-dev-20260510	v1.9.0-dev-20260510	Upgrade complete                                                                                                                                 
38      	Fri May 29 08:09:14 2026	failed    	harvester-1.9.0-dev-20260510	v1.9.0-dev-20260510	Upgrade "harvester" failed: resource Deployment/harvester-system/harvester-webhook not ready. status: Failed, message: Progress deadline exceeded
```

It is a bit difficult when troubleshooting.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Set the expected max history value 10 on Harvester.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/10693

#### Test plan:
<!-- Describe the test plan by steps. -->

1. Edit the mangedchart `fleet-local/harvester` `timeoutSeconds: 601` field, to trigger the update on mangedchart
2. After a while, check helm history, to see it increases and there are max 10 records
`helm history -n harvester-system harvester`

```
helm history -n harvester-system harvester
REVISION	UPDATED                 	STATUS    	CHART                       	APP VERSION        	DESCRIPTION                                                                                                                                      
23      	Fri May 29 07:50:44 2026	superseded	harvester-1.9.0-dev-20260510	v1.9.0-dev-20260510	Upgrade complete                                                                                                                                 
38      	Fri May 29 08:09:14 2026	failed    	harvester-1.9.0-dev-20260510	v1.9.0-dev-20260510	Upgrade "harvester" failed: resource Deployment/harvester-system/harvester-webhook not ready. status: Failed, message: Progress deadline exceeded
39      	Fri May 29 08:18:03 2026	superseded	harvester-1.9.0-dev-20260510	v1.9.0-dev-20260510	Upgrade complete                                                                                                                                 
40      	Fri May 29 08:33:10 2026	deployed  	harvester-1.9.0-dev-20260510	v1.9.0-dev-20260510	Upgrade complete    
```

#### Additional documentation or context
