### PR TITLE
chore: bump golang 1.26

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/golang:1.25
+FROM registry.suse.com/bci/golang:1.26
 
 ARG http_proxy=$http_proxy
 ARG https_proxy=$https_proxy
@@ -29,7 +29,7 @@ ENV YQ_SUM="YQ_SUM_${ARCH}"
 RUN curl -sfL https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${ARCH} -o /usr/bin/yq && echo "${!YQ_SUM}" /usr/bin/yq | sha256sum -c - && chmod +x /usr/bin/yq
 
 
-RUN go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
+RUN go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
 
 # only needed for raw image generation. currently skipped for arm builds
 RUN if [ "${ARCH}" == "amd64" ]; then \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/harvester/harvester-installer
 
-go 1.25
+go 1.26
 
 require (
 	github.com/dell/goiscsi v1.9.0


### PR DESCRIPTION
    - also update golangci-lint 2.12.2

<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
bump golang 1.26

#### Solution:
bump golang 1.26

#### Related Issue(s):
https://github.com/harvester/harvester/issues/10734

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
