### PR TITLE
bump kubeovn image to v1.16.2

### DIFF
--- a/scripts/images/harvester-additional-images.txt
+++ b/scripts/images/harvester-additional-images.txt
@@ -1,3 +1,3 @@
 registry.suse.com/suse/vmdp/vmdp:2.5.5
-docker.io/kubeovn/kube-ovn:v1.16.1
+docker.io/kubeovn/kube-ovn:v1.16.2
 registry.k8s.io/descheduler/descheduler:v0.33.0


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
PR updates additional images list to use kubeovn v1.16.2 image to ensure image is available in airgapped environments.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->
https://github.com/harvester/harvester/issues/8844

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
