### PR TITLE
fix: propagate /etc/udev/rules.d/80-ifname.rules to sysroot

### DIFF
--- a/package/harvester-os/files/system/oem/90_network.yaml
+++ b/package/harvester-os/files/system/oem/90_network.yaml
@@ -1,5 +1,23 @@
 name: "Network configuration"
 stages:
+  rootfs:
+    - name: Preserve ifname= settings from initramfs (1)
+      # We can't write directly to /sysroot as it's RO at this point so have to stage in /run
+      commands:
+      - |
+        if [ -e /etc/udev/rules.d/80-ifname.rules ]; then
+          echo "Copying /etc/udev/rules.d/80-ifname.rules from initramfs to /run"
+          cp /etc/udev/rules.d/80-ifname.rules /run/
+        fi
+  initramfs:
+    - name: Preserve ifname= settings from initramfs (2)
+      commands:
+      # /run from rootfs makes it through to initramfs, where /etc is writable
+      - |
+        if [ -e /run/80-ifname.rules ]; then
+          echo "Moving /run/80-ifname.rules to /etc/udev/rules.d/"
+          mv /run/80-ifname.rules /etc/udev/rules.d/
+        fi
   network:
     - name: Bring up interfaces
       commands:


### PR DESCRIPTION

#### Problem:
It's possible for NICs to not be renamed in time, while the initrd is still active.  If they come up later in the real root, and the necessary udev rules aren't in place, no renaming will occur.

#### Solution:
We can fix this by propagating `/etc/udev/rules.d/80-ifname.rules` through to the real root by first copying the file to `/run` in the `rootfs` stage, then moving it from there to `/etc/udev/rules.d/` in the `initramfs` stage.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/10783

#### Test plan:
Quick smoke test:
- Install Harvester
- As root, run `grub2-editenv /oem/grubenv set third_party_kernel_args="multipath=off ifname=fake-interface:00:11:22:33:44:55"` to create an `ifname=` rule. It doesn't matter what the MAC address is, or if the interface exists.
- Reboot
- Check that the `/etc/udev/rules.d/80-ifname.rules` file exists and has the correct content:
  ```
  # cat /etc/udev/rules.d/80-ifname.rules 
  SUBSYSTEM=="net", ACTION=="add", DRIVERS=="?*", ATTR{address}=="00:11:22:33:44:55", ATTR{type}=="1", NAME="fake-interface"
  ```

Test to prove that interface renaming actually works properly:
- Follow the steps under "To Reproduce" in https://github.com/harvester/harvester/issues/10783.
- With this fix applied, after unloading and reloading the NIC driver, the interface should keep its new name, and not revert back to the old name.

#### Additional documentation or context
