### PR TITLE
fix: allow ipv6 on kernel/host level

### DIFF
--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -26,4 +26,8 @@ const (
 
 	DefaultPersistentPercentageNum = 0.3
 	PersistentSizeMinGiB           = 150
+
+	SysctlDisableIPv6All     = "net.ipv6.conf.all.disable_ipv6"
+	SysctlDisableIPv6Default = "net.ipv6.conf.default.disable_ipv6"
+	SysctlDisableIPv6Lo      = "net.ipv6.conf.lo.disable_ipv6"
 )

--- a/pkg/config/cos.go
+++ b/pkg/config/cos.go
@@ -204,10 +204,8 @@ func ConvertToCOS(config *HarvesterConfig) (*yipSchema.YipConfig, error) {
 	})
 	initramfs.Files = append(initramfs.Files, yipSchema.File{
 		Path: "/etc/sysctl.d/zz-harvester-enable-ipv6.conf",
-		Content: "# Written by harvester-installer: overrides /etc/sysctl.d/ipv6.conf\n" +
-			"net.ipv6.conf.all.disable_ipv6 = 0\n" +
-			"net.ipv6.conf.default.disable_ipv6 = 0\n" +
-			"net.ipv6.conf.lo.disable_ipv6 = 0\n",
+		Content: fmt.Sprintf("# Written by harvester-installer: overrides /etc/sysctl.d/ipv6.conf\n%s = 0\n%s = 0\n%s = 0\n",
+			SysctlDisableIPv6All, SysctlDisableIPv6Default, SysctlDisableIPv6Lo),
 		Permissions: 0644,
 		Owner:       0,
 		Group:       0,
@@ -215,9 +213,9 @@ func ConvertToCOS(config *HarvesterConfig) (*yipSchema.YipConfig, error) {
 	if initramfs.Sysctl == nil {
 		initramfs.Sysctl = make(map[string]string)
 	}
-	initramfs.Sysctl["net.ipv6.conf.all.disable_ipv6"] = "0"
-	initramfs.Sysctl["net.ipv6.conf.default.disable_ipv6"] = "0"
-	initramfs.Sysctl["net.ipv6.conf.lo.disable_ipv6"] = "0"
+	initramfs.Sysctl[SysctlDisableIPv6All] = "0"
+	initramfs.Sysctl[SysctlDisableIPv6Default] = "0"
+	initramfs.Sysctl[SysctlDisableIPv6Lo] = "0"
 
 	// TOP
 	if cfg.Install.Mode != ModeInstall {

--- a/pkg/config/cos.go
+++ b/pkg/config/cos.go
@@ -195,6 +195,30 @@ func ConvertToCOS(config *HarvesterConfig) (*yipSchema.YipConfig, error) {
 	// disable multipath for longhorn
 	disableLonghornMultipathing(&initramfs)
 
+	// write a persistent sysctl drop-in and apply at runtime; persists after reboot
+	initramfs.Directories = append(initramfs.Directories, yipSchema.Directory{
+		Path:        "/etc/sysctl.d",
+		Permissions: 0755,
+		Owner:       0,
+		Group:       0,
+	})
+	initramfs.Files = append(initramfs.Files, yipSchema.File{
+		Path: "/etc/sysctl.d/zz-harvester-enable-ipv6.conf",
+		Content: "# Written by harvester-installer: overrides /etc/sysctl.d/ipv6.conf\n" +
+			"net.ipv6.conf.all.disable_ipv6 = 0\n" +
+			"net.ipv6.conf.default.disable_ipv6 = 0\n" +
+			"net.ipv6.conf.lo.disable_ipv6 = 0\n",
+		Permissions: 0644,
+		Owner:       0,
+		Group:       0,
+	})
+	if initramfs.Sysctl == nil {
+		initramfs.Sysctl = make(map[string]string)
+	}
+	initramfs.Sysctl["net.ipv6.conf.all.disable_ipv6"] = "0"
+	initramfs.Sysctl["net.ipv6.conf.default.disable_ipv6"] = "0"
+	initramfs.Sysctl["net.ipv6.conf.lo.disable_ipv6"] = "0"
+
 	// TOP
 	if cfg.Install.Mode != ModeInstall {
 		if err := initRancherdStage(config, &initramfs); err != nil {

--- a/pkg/config/cos_test.go
+++ b/pkg/config/cos_test.go
@@ -265,9 +265,9 @@ func TestConvertToCOS_EnableIPv6(t *testing.T) {
 			check: func(t *testing.T, initramfs yipSchema.Stage) {
 				for _, f := range initramfs.Files {
 					if f.Path == "/etc/sysctl.d/zz-harvester-enable-ipv6.conf" {
-						assert.Contains(t, f.Content, "net.ipv6.conf.all.disable_ipv6 = 0")
-						assert.Contains(t, f.Content, "net.ipv6.conf.default.disable_ipv6 = 0")
-						assert.Contains(t, f.Content, "net.ipv6.conf.lo.disable_ipv6 = 0")
+						assert.Contains(t, f.Content, SysctlDisableIPv6All+" = 0")
+						assert.Contains(t, f.Content, SysctlDisableIPv6Default+" = 0")
+						assert.Contains(t, f.Content, SysctlDisableIPv6Lo+" = 0")
 						assert.Equal(t, uint32(0644), f.Permissions)
 						return
 					}
@@ -284,9 +284,9 @@ func TestConvertToCOS_EnableIPv6(t *testing.T) {
 		{
 			name: "sysctl map keys",
 			check: func(t *testing.T, initramfs yipSchema.Stage) {
-				assert.Equal(t, "0", initramfs.Sysctl["net.ipv6.conf.all.disable_ipv6"])
-				assert.Equal(t, "0", initramfs.Sysctl["net.ipv6.conf.default.disable_ipv6"])
-				assert.Equal(t, "0", initramfs.Sysctl["net.ipv6.conf.lo.disable_ipv6"])
+				assert.Equal(t, "0", initramfs.Sysctl[SysctlDisableIPv6All])
+				assert.Equal(t, "0", initramfs.Sysctl[SysctlDisableIPv6Default])
+				assert.Equal(t, "0", initramfs.Sysctl[SysctlDisableIPv6Lo])
 			},
 		},
 	}

--- a/pkg/config/cos_test.go
+++ b/pkg/config/cos_test.go
@@ -231,3 +231,78 @@ func containsFile(files []yipSchema.File, fileName string) bool {
 	}
 	return false
 }
+
+func containsDirectory(dirs []yipSchema.Directory, path string) bool {
+	for _, d := range dirs {
+		if d.Path == path {
+			return true
+		}
+	}
+	return false
+}
+
+func TestConvertToCOS_EnableIPv6(t *testing.T) {
+	testCases := []struct {
+		name  string
+		check func(t *testing.T, initramfs yipSchema.Stage)
+	}{
+		{
+			name: "sysctl directory present",
+			check: func(t *testing.T, initramfs yipSchema.Stage) {
+				assert.True(t, containsDirectory(initramfs.Directories, "/etc/sysctl.d"),
+					"initramfs.Directories should contain /etc/sysctl.d")
+			},
+		},
+		{
+			name: "drop-in file present",
+			check: func(t *testing.T, initramfs yipSchema.Stage) {
+				assert.True(t, containsFile(initramfs.Files, "/etc/sysctl.d/zz-harvester-enable-ipv6.conf"),
+					"initramfs.Files should contain /etc/sysctl.d/zz-harvester-enable-ipv6.conf")
+			},
+		},
+		{
+			name: "drop-in file content",
+			check: func(t *testing.T, initramfs yipSchema.Stage) {
+				for _, f := range initramfs.Files {
+					if f.Path == "/etc/sysctl.d/zz-harvester-enable-ipv6.conf" {
+						assert.Contains(t, f.Content, "net.ipv6.conf.all.disable_ipv6 = 0")
+						assert.Contains(t, f.Content, "net.ipv6.conf.default.disable_ipv6 = 0")
+						assert.Contains(t, f.Content, "net.ipv6.conf.lo.disable_ipv6 = 0")
+						assert.Equal(t, uint32(0644), f.Permissions)
+						return
+					}
+				}
+				t.Error("drop-in file not found")
+			},
+		},
+		{
+			name: "sysctl map not nil",
+			check: func(t *testing.T, initramfs yipSchema.Stage) {
+				assert.NotNil(t, initramfs.Sysctl)
+			},
+		},
+		{
+			name: "sysctl map keys",
+			check: func(t *testing.T, initramfs yipSchema.Stage) {
+				assert.Equal(t, "0", initramfs.Sysctl["net.ipv6.conf.all.disable_ipv6"])
+				assert.Equal(t, "0", initramfs.Sysctl["net.ipv6.conf.default.disable_ipv6"])
+				assert.Equal(t, "0", initramfs.Sysctl["net.ipv6.conf.lo.disable_ipv6"])
+			},
+		},
+	}
+
+	conf, err := LoadHarvesterConfig(util.LoadFixture(t, "harvester-config.yaml"))
+	assert.NoError(t, err)
+	conf.Mode = ModeInstall
+
+	yipConfig, err := ConvertToCOS(conf)
+	assert.NoError(t, err)
+
+	initramfs := yipConfig.Stages["initramfs"][0]
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.check(t, initramfs)
+		})
+	}
+}

--- a/pkg/console/network.go
+++ b/pkg/console/network.go
@@ -89,6 +89,17 @@ func applyNetworks(network config.Network, hostname string) error {
 		}
 	}
 
+	// enable IPv6 before applying NetworkManager profiles
+	for _, param := range []string{
+		"net.ipv6.conf.all.disable_ipv6=0",
+		"net.ipv6.conf.default.disable_ipv6=0",
+		"net.ipv6.conf.lo.disable_ipv6=0",
+	} {
+		if out, execErr := exec.Command("sysctl", "-w", param).CombinedOutput(); execErr != nil {
+			logrus.Warnf("Failed to enable IPv6 sysctl %s: %v (%s)", param, execErr, string(out))
+		}
+	}
+
 	err = config.UpdateManagementInterfaceConfig(network, []string{}, config.NMConnectionPath, true)
 	if err != nil {
 		return err

--- a/pkg/console/network.go
+++ b/pkg/console/network.go
@@ -91,11 +91,11 @@ func applyNetworks(network config.Network, hostname string) error {
 
 	// enable IPv6 before applying NetworkManager profiles
 	for _, param := range []string{
-		"net.ipv6.conf.all.disable_ipv6=0",
-		"net.ipv6.conf.default.disable_ipv6=0",
-		"net.ipv6.conf.lo.disable_ipv6=0",
+		config.SysctlDisableIPv6All,
+		config.SysctlDisableIPv6Default,
+		config.SysctlDisableIPv6Lo,
 	} {
-		if out, execErr := exec.Command("sysctl", "-w", param).CombinedOutput(); execErr != nil {
+		if out, execErr := exec.Command("sysctl", "-w", fmt.Sprintf("%s=0", param)).CombinedOutput(); execErr != nil {
 			logrus.Warnf("Failed to enable IPv6 sysctl %s: %v (%s)", param, execErr, string(out))
 		}
 	}


### PR DESCRIPTION
Allowing ipv6 on kernel level persisted over reboots so on subsequent PR we can create NetworkManager
configuration which can configure dual-stack which allows assignment of ipv6 addresses.

The current change layers dynamic config on top of the baseline ipv6.conf in the repo along with sysctl config allowing ipv6.

Change is safe to merge with no impact because Network Manager still disabled ipv6 on network interface level.

Added unit tests with check as part of the table for cos file. Check is part of the table as the assertion steps were different based on directory/file/content.

<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.
-->

#### Problem:
Currently we disable ipv6 on a kernel level which also prevents networkmanager from configuring network interface which supports dual stack.

#### Solution:
Allow ipv6 on kernel level, while still disabling it on network interface level. That way we can then add change which configures the network interface with dual stack along with installer UX.

#### Related Issue(s):
https://github.com/harvester/harvester/issues/10795
https://github.com/harvester/harvester/issues/10755

#### Test plan:
Added unit tests.

End to end testing:
<details>
<summary>After first boot IPv6 is allowed on kernel level</summary>

```
mdekov@localhost:~> ssh rancher@192.168.122.66
The authenticity of host '192.168.122.66 (192.168.122.66)' can't be established.
ED25519 key fingerprint is: SHA256:23J9vMktalJp39LH1KuNflQ8sLGudOLkxkxzTPENvp8
This key is not known by any other names.
Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
Warning: Permanently added '192.168.122.66' (ED25519) to the list of known hosts.
Have a lot of fun...
rancher@node-1:~> sudo su
node-1:/home/rancher # sysctl net.ipv6.conf.all.disable_ipv6
net.ipv6.conf.all.disable_ipv6 = 0
node-1:/home/rancher # cat /etc/sysctl.d/zz-harvester-enable-ipv6.conf
# Written by harvester-installer: overrides /etc/sysctl.d/ipv6.conf
net.ipv6.conf.all.disable_ipv6 = 0
net.ipv6.conf.default.disable_ipv6 = 0
net.ipv6.conf.lo.disable_ipv6 = 0
node-1:/home/rancher # sysctl net.ipv6.conf.all.disable_ipv6
net.ipv6.conf.all.disable_ipv6 = 0
node-1:/home/rancher # sysctl net.ipv6.conf.all.disable_ipv6
net.ipv6.conf.all.disable_ipv6 = 0
node-1:/home/rancher # sysctl net.ipv6.conf.default.disable_ipv6
net.ipv6.conf.default.disable_ipv6 = 0
node-1:/home/rancher # sysctl net.ipv6.conf.lo.disable_ipv6
net.ipv6.conf.lo.disable_ipv6 = 0
node-1:/home/rancher # reboot
```
</details>

<details>
<summary>NetworkManager has IPv6 disabled</summary>

```
node-1:/home/rancher # grep -r "method" /etc/NetworkManager/system-connections/
/etc/NetworkManager/system-connections/bridge-mgmt.nmconnection:method=auto
/etc/NetworkManager/system-connections/bridge-mgmt.nmconnection:method=disabled
node-1:/home/rancher # nmcli connection show
NAME               UUID                                  TYPE      DEVICE       
bridge-mgmt        713373f6-bf9d-3ee3-abb2-5f295bd18145  bridge    mgmt-br      
bond-mgmt          48589773-cb7d-38c5-b579-7dd119af73b6  bond      mgmt-bo      
bond-slave-enp1s0  97ed9ced-a5cc-306a-b37c-8a6a1e6f0ad8  ethernet  enp1s0       
lo                 1fef8cb1-e3d9-48d5-820f-0e1e01b1b437  loopback  lo           
vip-f4baf473       6ec7587c-ba1e-483b-9ecb-6631bb8b334b  macvlan   vip-f4baf473 
node-1:/home/rancher # nmcli connection show bridge-mgmt | grep IP6
IP6.GATEWAY:                            --
node-1:/home/rancher # sysctl net.ipv6.conf.mgmt-br.disable_ipv6
net.ipv6.conf.mgmt-br.disable_ipv6 = 1
node-1:/home/rancher # 
```
</details>

<details>
<summary>After reboot kernel settings persisted and NetworkManager still has IPv6 disabled</summary>

```
node-1:/home/rancher # reboot
node-1:/home/rancher # Read from remote host 192.168.122.66: Connection reset by peer
Connection to 192.168.122.66 closed.
client_loop: send disconnect: Broken pipe
mdekov@localhost:~> ssh rancher@192.168.122.66
Have a lot of fun...
rancher@node-1:~> sudo su
node-1:/home/rancher # sysctl net.ipv6.conf.all.disable_ipv6
net.ipv6.conf.all.disable_ipv6 = 0
node-1:/home/rancher # cat /etc/sysctl.d/zz-harvester-enable-ipv6.conf
# Written by harvester-installer: overrides /etc/sysctl.d/ipv6.conf
net.ipv6.conf.all.disable_ipv6 = 0
net.ipv6.conf.default.disable_ipv6 = 0
net.ipv6.conf.lo.disable_ipv6 = 0
node-1:/home/rancher # sysctl net.ipv6.conf.all.disable_ipv6
net.ipv6.conf.all.disable_ipv6 = 0
node-1:/home/rancher # 
node-1:/home/rancher # sysctl net.ipv6.conf.all.disable_ipv6
net.ipv6.conf.all.disable_ipv6 = 0
node-1:/home/rancher # sysctl net.ipv6.conf.default.disable_ipv6
net.ipv6.conf.default.disable_ipv6 = 0
node-1:/home/rancher # sysctl net.ipv6.conf.lo.disable_ipv6
net.ipv6.conf.lo.disable_ipv6 = 0
node-1:/home/rancher # grep -r "method" /etc/NetworkManager/system-connections/
/etc/NetworkManager/system-connections/bridge-mgmt.nmconnection:method=auto
/etc/NetworkManager/system-connections/bridge-mgmt.nmconnection:method=disabled
node-1:/home/rancher # nmcli connection show bridge-mgmt | grep IP6
IP6.GATEWAY:                            --
node-1:/home/rancher # sysctl net.ipv6.conf.mgmt-br.disable_ipv6
net.ipv6.conf.mgmt-br.disable_ipv6 = 1
node-1:/home/rancher # 
```
</details>

#### Additional documentation or context

[HEP](https://github.com/martindekov/harvester/blob/c7eab08d811393988c07d2ec632f1f3079c565d6/enhancements/20260528-dual-stack-ipv4-first.md)

The change is added so it won't break the existing functionality or features e.g. - log warning in case we can't enable the system ipv6 settings as of today when we only support ipv4.