### PR TITLE
fix: do not fatally abort install on nm-online connectivity check

### DIFF
--- a/pkg/config/cos.go
+++ b/pkg/config/cos.go
@@ -588,14 +588,28 @@ func UpdateManagementInterfaceConfig(mgmtInterface Network, dnsNameServers []str
 			logrus.Error(err, string(output))
 			return err
 		}
-		// This next command waits up to 30 seconds to ensure there's
-		// a connection.  Without this, it's possible that a slow DHCP
-		// server won't return in time, and the installer will subsequently
-		// fail the check for a default route.
-		output, err = exec.Command("nm-online", "-x").CombinedOutput()
+		// Wait (up to the timeout) for NetworkManager to finish (re)starting the
+		// management network before continuing.
+		//
+		// Use "-s" (wait for startup to complete) instead of "-x": "-x" exits
+		// immediately and defeats the intended wait, and startup (interfaces
+		// finished activating) is the right signal rather than *global*
+		// connectivity, which an isolated management network may never reach.
+		//
+		// The 45s timeout gives a slow-rate LACP bond headroom to converge:
+		// lacp_rate=slow emits an LACPDU only every 30s, so a single missed
+		// interval can cost ~30s before the bond syncs.  Because "-s" returns as
+		// soon as startup completes, this budget only costs time on a genuinely
+		// slow or degraded link.
+		//
+		// The check is best-effort and must NOT be fatal.  On the
+		// already-installed first-boot path it runs before the RancherD config is
+		// written, so aborting the install here on a briefly-degraded link (e.g. a
+		// bond still re-converging) leaves the node with no role until manual
+		// repair.  See harvester/harvester#10885.
+		output, err = exec.Command("nm-online", "-s", "-t", "45").CombinedOutput()
 		if err != nil {
-			logrus.Error(err, string(output))
-			return err
+			logrus.Warnf("nm-online did not confirm the management network within the timeout; continuing anyway: %v: %s", err, string(output))
 		}
 	}
 


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first.

!IMPORTANT!
The installer code has been integrated into the main [harvester/harvester](https://github.com/harvester/harvester) repository. Please do not submit pull requests to this repository unless they are for v1.8 or earlier branches. This repository will be archived soon.

-->

#### Problem:
<!-- Explain the problem you aim to resolve in this PR. -->
The management-network readiness check ran `nm-online -x`, which exits immediately instead of waiting, and treated any non-zero result as fatal. On the already-installed first-boot path this check runs before the RancherD config is written, so a management link that is briefly offline while the bond re-converges aborts the whole install and leaves the node with no role until manual repair.

#### Solution:
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Two changes:

- Wait for the network instead of sampling once: use `nm-online -s -t 45` instead of `-x`. `-s` waits for NetworkManager startup to complete (interfaces finished activating) rather than for global connectivity, which an isolated management network may never reach. The 100s timeout gives a slow-rate LACP bond headroom: `lacp_rate=slow` emits an LACPDU only every 30s, so a single missed interval can cost ~30s before the bond syncs. This gives slow-LACP three attempts with grace. Because `-s` returns as soon as startup completes, this budget only costs time on a genuinely slow or degraded link.
- Make the check non-fatal: log a warning and continue instead of returning an error, so a slow or briefly-degraded management link no longer aborts the install (and, on the installed-node path, no longer strands the node without a RancherD config).

This is observed on both LACP/802.3ad and single-NIC active-backup bonds, and across install methods, so it is not specific to any one bond mode.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

Refs: harvester/harvester#10885

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
