### PR TITLE
feat: add dual stack IPv4 Family First config

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/harvester/harvester-installer/pkg/config"
 	"github.com/harvester/harvester-installer/pkg/console"
@@ -60,7 +61,7 @@ Executes the Harvester installer if no command is specified.`,
 						return err
 					}
 					if len(paths) == 0 || cmd.Bool("force") {
-						err = config.UpdateManagementInterfaceConfig(harvesterCfg.ManagementInterface, harvesterCfg.OS.DNSNameservers, cmd.String("connection-path"), false)
+						err = config.UpdateManagementInterfaceConfig(harvesterCfg.ManagementInterface, harvesterCfg.OS.DNSNameservers, cmd.String("connection-path"), false, strings.Contains(harvesterCfg.Install.ClusterPodCIDR, ","))
 						if err != nil {
 							return err
 						}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -539,7 +539,10 @@ func GenerateRancherdConfig(config *HarvesterConfig) (*yipSchema.YipConfig, erro
 		return nil, err
 	}
 
-	ipv6Enabled := strings.Contains(config.Install.ClusterPodCIDR, ",")
+	ipv6Enabled, err := isIPv6Enabled(config.Install.ClusterPodCIDR)
+	if err != nil {
+		return nil, err
+	}
 	if err := UpdateManagementInterfaceConfig(config.ManagementInterface, config.OS.DNSNameservers, NMConnectionPath, true, ipv6Enabled); err != nil {
 		return nil, err
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -167,6 +167,11 @@ type Install struct {
 	ClusterPodCIDR     string `json:"clusterPodCidr,omitempty"`
 	ClusterServiceCIDR string `json:"clusterServiceCidr,omitempty"`
 
+	// IPv6Enabled is set by the installer UI for join/install modes where
+	// ClusterPodCIDR is not provided. For create mode the flag is derived
+	// from the CIDR input instead.
+	IPv6Enabled bool `json:"ipv6Enabled,omitempty"`
+
 	ForceEFI      bool     `json:"forceEfi,omitempty"`
 	Device        string   `json:"device,omitempty"`
 	ConfigURL     string   `json:"configUrl,omitempty"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -539,7 +539,8 @@ func GenerateRancherdConfig(config *HarvesterConfig) (*yipSchema.YipConfig, erro
 		return nil, err
 	}
 
-	if err := UpdateManagementInterfaceConfig(config.ManagementInterface, config.OS.DNSNameservers, NMConnectionPath, true); err != nil {
+	ipv6Enabled := strings.Contains(config.Install.ClusterPodCIDR, ",")
+	if err := UpdateManagementInterfaceConfig(config.ManagementInterface, config.OS.DNSNameservers, NMConnectionPath, true, ipv6Enabled); err != nil {
 		return nil, err
 	}
 

--- a/pkg/config/cos.go
+++ b/pkg/config/cos.go
@@ -996,12 +996,29 @@ WantedBy=sysinit.target`)
 	})
 }
 
-// isIPv6Enabled checks if the clusterPodCIDR is dual-stack IPv4
-// family first (IPv4, IPv6) or not.
+// isIPv6Enabled reports whether clusterPodCIDR describes a valid dual-stack
+// configuration: exactly two comma-separated prefixes in IPv4-first order.
+// An empty value returns (false, nil). A single IPv4 CIDR returns (false, nil).
+// A single IPv6-only CIDR returns an error (unsupported mode).
+// A two-part value with a malformed prefix returns (false, err).
 func isIPv6Enabled(clusterPodCIDR string) (bool, error) {
 	parts := strings.Split(clusterPodCIDR, ",")
+	if len(parts) == 1 {
+		cidr := strings.TrimSpace(parts[0])
+		if cidr == "" {
+			return false, nil
+		}
+		prefix, err := netip.ParsePrefix(cidr)
+		if err != nil {
+			return false, err
+		}
+		if !prefix.Addr().Is4() {
+			return false, fmt.Errorf("IPv6-only CIDR %q is not supported; use IPv4 or IPv4,IPv6 for dual-stack", cidr)
+		}
+		return false, nil
+	}
 	if len(parts) != 2 {
-		return false, fmt.Errorf("invalid clusterPodCIDR format")
+		return false, fmt.Errorf("at most two CIDRs (IPv4,IPv6) are allowed, got %d", len(parts))
 	}
 	first, err := netip.ParsePrefix(strings.TrimSpace(parts[0]))
 	if err != nil {

--- a/pkg/config/cos.go
+++ b/pkg/config/cos.go
@@ -195,7 +195,15 @@ func ConvertToCOS(config *HarvesterConfig) (*yipSchema.YipConfig, error) {
 	// disable multipath for longhorn
 	disableLonghornMultipathing(&initramfs)
 
-	// write a persistent sysctl drop-in and apply at runtime; persists after reboot
+	// Write a persistent sysctl drop-in whose value matches the install's IPv6 choice.
+	// For dual-stack, IPv6 is enabled (disable_ipv6=0); for IPv4-only it is disabled (disable_ipv6=1).
+	ipv6Enabled := strings.Contains(cfg.Install.ClusterPodCIDR, ",")
+	ipv6SysctlVal := "1"
+	ipv6FileHeader := "# Written by harvester-installer (IPv4-only install)\n"
+	if ipv6Enabled {
+		ipv6SysctlVal = "0"
+		ipv6FileHeader = "# Written by harvester-installer (dual-stack install)\n"
+	}
 	initramfs.Directories = append(initramfs.Directories, yipSchema.Directory{
 		Path:        "/etc/sysctl.d",
 		Permissions: 0755,
@@ -204,8 +212,11 @@ func ConvertToCOS(config *HarvesterConfig) (*yipSchema.YipConfig, error) {
 	})
 	initramfs.Files = append(initramfs.Files, yipSchema.File{
 		Path: "/etc/sysctl.d/zz-harvester-enable-ipv6.conf",
-		Content: fmt.Sprintf("# Written by harvester-installer: overrides /etc/sysctl.d/ipv6.conf\n%s = 0\n%s = 0\n%s = 0\n",
-			SysctlDisableIPv6All, SysctlDisableIPv6Default, SysctlDisableIPv6Lo),
+		Content: fmt.Sprintf("%s%s = %s\n%s = %s\n%s = %s\n",
+			ipv6FileHeader,
+			SysctlDisableIPv6All, ipv6SysctlVal,
+			SysctlDisableIPv6Default, ipv6SysctlVal,
+			SysctlDisableIPv6Lo, ipv6SysctlVal),
 		Permissions: 0644,
 		Owner:       0,
 		Group:       0,
@@ -213,9 +224,9 @@ func ConvertToCOS(config *HarvesterConfig) (*yipSchema.YipConfig, error) {
 	if initramfs.Sysctl == nil {
 		initramfs.Sysctl = make(map[string]string)
 	}
-	initramfs.Sysctl[SysctlDisableIPv6All] = "0"
-	initramfs.Sysctl[SysctlDisableIPv6Default] = "0"
-	initramfs.Sysctl[SysctlDisableIPv6Lo] = "0"
+	initramfs.Sysctl[SysctlDisableIPv6All] = ipv6SysctlVal
+	initramfs.Sysctl[SysctlDisableIPv6Default] = ipv6SysctlVal
+	initramfs.Sysctl[SysctlDisableIPv6Lo] = ipv6SysctlVal
 
 	// TOP
 	if cfg.Install.Mode != ModeInstall {
@@ -231,7 +242,7 @@ func ConvertToCOS(config *HarvesterConfig) (*yipSchema.YipConfig, error) {
 			initramfs.Systemctl.Enable = append(initramfs.Systemctl.Enable, timeWaitSyncService)
 		}
 
-		err = UpdateManagementInterfaceConfig(cfg.ManagementInterface, cfg.OS.DNSNameservers, NMConnectionPath, false)
+		err = UpdateManagementInterfaceConfig(cfg.ManagementInterface, cfg.OS.DNSNameservers, NMConnectionPath, false, ipv6Enabled)
 		if err != nil {
 			return nil, err
 		}
@@ -552,7 +563,7 @@ func SaveOriginalNetworkConfig() error {
 
 // UpdateManagementInterfaceConfig generates NetworkManager connection profiles.
 // It restarts networking and waits for the connection to be up if applyConfig is true.
-func UpdateManagementInterfaceConfig(mgmtInterface Network, dnsNameServers []string, configPath string, applyConfig bool) error {
+func UpdateManagementInterfaceConfig(mgmtInterface Network, dnsNameServers []string, configPath string, applyConfig bool, ipv6Enabled bool) error {
 	if len(mgmtInterface.Interfaces) == 0 {
 		return errors.New("no slave defined for management network bond")
 	}
@@ -584,7 +595,7 @@ func UpdateManagementInterfaceConfig(mgmtInterface Network, dnsNameServers []str
 		return err
 	}
 
-	if err := updateBridge(MgmtInterfaceName, &mgmtInterface, dnsNameServers, configPath); err != nil {
+	if err := updateBridge(MgmtInterfaceName, &mgmtInterface, dnsNameServers, configPath, ipv6Enabled); err != nil {
 		return err
 	}
 
@@ -669,7 +680,7 @@ func updateBond(name string, network *Network, configPath string) error {
 	return nil
 }
 
-func updateBridge(name string, mgmtNetwork *Network, dnsNameServers []string, configPath string) error {
+func updateBridge(name string, mgmtNetwork *Network, dnsNameServers []string, configPath string, ipv6Enabled bool) error {
 	// add Bridge named MgmtInterfaceName and attach Bond named MgmtBondInterfaceName to bridge
 
 	// pvid is always 1, if vlan id is 1, it means untagged vlan.
@@ -703,9 +714,10 @@ func updateBridge(name string, mgmtNetwork *Network, dnsNameServers []string, co
 	}
 	// add bridge
 	bridgeData := map[string]interface{}{
-		"Bridge":     bridgeMgmt,
-		"BridgeName": MgmtInterfaceName,
-		"DNSServers": "",
+		"Bridge":      bridgeMgmt,
+		"BridgeName":  MgmtInterfaceName,
+		"DNSServers":  "",
+		"IPv6Enabled": ipv6Enabled,
 	}
 	if !needVlanInterface && len(dnsNameServers) > 0 {
 		bridgeData["DNSServers"] = strings.Join(dnsNameServers, ";") + ";"
@@ -726,9 +738,10 @@ func updateBridge(name string, mgmtNetwork *Network, dnsNameServers []string, co
 		vlanMgmt.SubnetMask = maskToCIDR(vlanMgmt.SubnetMask)
 
 		vlanData := map[string]interface{}{
-			"BridgeName": name,
-			"Vlan":       vlanMgmt,
-			"DNSServers": "",
+			"BridgeName":  name,
+			"Vlan":        vlanMgmt,
+			"DNSServers":  "",
+			"IPv6Enabled": ipv6Enabled,
 		}
 		if len(dnsNameServers) > 0 {
 			vlanData["DNSServers"] = strings.Join(dnsNameServers, ";") + ";"

--- a/pkg/config/cos.go
+++ b/pkg/config/cos.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -197,7 +198,10 @@ func ConvertToCOS(config *HarvesterConfig) (*yipSchema.YipConfig, error) {
 
 	// Write a persistent sysctl drop-in whose value matches the install's IPv6 choice.
 	// For dual-stack, IPv6 is enabled (disable_ipv6=0); for IPv4-only it is disabled (disable_ipv6=1).
-	ipv6Enabled := strings.Contains(cfg.Install.ClusterPodCIDR, ",")
+	ipv6Enabled, err := isIPv6Enabled(cfg.Install.ClusterPodCIDR)
+	if err != nil {
+		return nil, err
+	}
 	ipv6SysctlVal := "1"
 	ipv6FileHeader := "# Written by harvester-installer (IPv4-only install)\n"
 	if ipv6Enabled {
@@ -990,4 +994,22 @@ WantedBy=sysinit.target`)
 		Owner:       0,
 		Group:       0,
 	})
+}
+
+// isIPv6Enabled checks if the clusterPodCIDR is dual-stack IPv4
+// family first (IPv4, IPv6) or not.
+func isIPv6Enabled(clusterPodCIDR string) (bool, error) {
+	parts := strings.Split(clusterPodCIDR, ",")
+	if len(parts) != 2 {
+		return false, fmt.Errorf("invalid clusterPodCIDR format")
+	}
+	first, err := netip.ParsePrefix(strings.TrimSpace(parts[0]))
+	if err != nil {
+		return false, err
+	}
+	second, err := netip.ParsePrefix(strings.TrimSpace(parts[1]))
+	if err != nil {
+		return false, err
+	}
+	return first.Addr().Is4() && !second.Addr().Is4(), nil
 }

--- a/pkg/config/cos.go
+++ b/pkg/config/cos.go
@@ -198,9 +198,17 @@ func ConvertToCOS(config *HarvesterConfig) (*yipSchema.YipConfig, error) {
 
 	// Write a persistent sysctl drop-in whose value matches the install's IPv6 choice.
 	// For dual-stack, IPv6 is enabled (disable_ipv6=0); for IPv4-only it is disabled (disable_ipv6=1).
-	ipv6Enabled, err := isIPv6Enabled(cfg.Install.ClusterPodCIDR)
-	if err != nil {
-		return nil, err
+	// For create mode the choice is derived from the cluster CIDR.
+	// For join/install modes the installer UI explicitly asks the user and stores the result
+	// in cfg.Install.IPv6Enabled — never infer it from the empty CIDR.
+	var ipv6Enabled bool
+	if cfg.Install.Mode == ModeCreate {
+		ipv6Enabled, err = isIPv6Enabled(cfg.Install.ClusterPodCIDR)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		ipv6Enabled = cfg.Install.IPv6Enabled
 	}
 	ipv6SysctlVal := "1"
 	ipv6FileHeader := "# Written by harvester-installer (IPv4-only install)\n"

--- a/pkg/config/cos_test.go
+++ b/pkg/config/cos_test.go
@@ -294,7 +294,9 @@ func TestConvertToCOS_EnableIPv6(t *testing.T) {
 	conf, err := LoadHarvesterConfig(util.LoadFixture(t, "harvester-config.yaml"))
 	assert.NoError(t, err)
 	conf.Mode = ModeInstall
-	conf.Install.ClusterPodCIDR = "10.42.0.0/16,fd42::/48" // dual-stack triggers IPv6 enable path
+	// For non-create modes, IPv6 is driven by the explicit flag set by the installer UI (or
+	// config.yaml for PXE). ClusterPodCIDR is empty for join/install nodes and is not used.
+	conf.Install.IPv6Enabled = true
 
 	yipConfig, err := ConvertToCOS(conf)
 	assert.NoError(t, err)

--- a/pkg/config/cos_test.go
+++ b/pkg/config/cos_test.go
@@ -294,6 +294,7 @@ func TestConvertToCOS_EnableIPv6(t *testing.T) {
 	conf, err := LoadHarvesterConfig(util.LoadFixture(t, "harvester-config.yaml"))
 	assert.NoError(t, err)
 	conf.Mode = ModeInstall
+	conf.Install.ClusterPodCIDR = "10.42.0.0/16,fd42::/48" // dual-stack triggers IPv6 enable path
 
 	yipConfig, err := ConvertToCOS(conf)
 	assert.NoError(t, err)

--- a/pkg/config/templates/nm-bridge.nmconnection
+++ b/pkg/config/templates/nm-bridge.nmconnection
@@ -33,4 +33,10 @@ address1={{ .Bridge.IP }}/{{ .Bridge.SubnetMask }},{{ .Bridge.Gateway }}
 {{- end }}
 
 [ipv6]
+{{ if .IPv6Enabled -}}
+method=auto
+addr-gen-mode=eui64
+ip6-privacy=0
+{{- else -}}
 method=disabled
+{{- end }}

--- a/pkg/config/templates/nm-vlan.nmconnection
+++ b/pkg/config/templates/nm-vlan.nmconnection
@@ -25,4 +25,10 @@ address1={{ .Vlan.IP }}/{{ .Vlan.SubnetMask }},{{ .Vlan.Gateway }}
 {{- end }}
 
 [ipv6]
+{{ if .IPv6Enabled -}}
+method=auto
+addr-gen-mode=eui64
+ip6-privacy=0
+{{- else -}}
 method=disabled
+{{- end }}

--- a/pkg/console/constant.go
+++ b/pkg/console/constant.go
@@ -89,7 +89,7 @@ const (
 	clusterNetworkNotePanel      = "clusterNetworkNotePanel"
 	clusterNetworkDNSNotePanel   = "clusterNetworkDNSNotePanel"
 	clusterNetworkValidatorPanel = "clusterNetworkValidatorPanel"
-	clusterNetworkNote           = "Note: Leave blank to use the default pod CIDR 10.52.0.0/16, service CIDR 10.53.0.0/16 and cluster DNS 10.53.0.10. If the service CIDR is changed, the DNS IP must be updated to be within the service CIDR."
+	clusterNetworkNote           = "Note: Leave blank to use the default pod CIDR 10.52.0.0/16, service CIDR 10.53.0.0/16 and cluster DNS 10.53.0.10. For dual-stack, use comma-separated IPv4,IPv6 values (e.g. 10.42.0.0/16,fd42::/48). IPv4 must be listed first. If the service CIDR is changed, the DNS IP must be updated to be within the service CIDR."
 
 	clusterTokenCreateNote = "Note: The token is used for adding nodes to the cluster"
 	clusterTokenJoinNote   = "Note: Input the token of the existing cluster"

--- a/pkg/console/constant.go
+++ b/pkg/console/constant.go
@@ -13,6 +13,7 @@ const (
 	diskNotePanel               = "diskNote"
 	preflightCheckPanel         = "preflightCheck"
 	askCreatePanel              = "askCreate"
+	askIPv6Panel                = "askIPv6"
 	serverURLPanel              = "serverUrl"
 	passwordPanel               = "osPassword"
 	passwordConfirmPanel        = "osPasswordConfirm"

--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -165,6 +165,7 @@ func setPanels(c *Console) error {
 		addFooterPanel,
 		addPreflightCheckPanel,
 		addAskCreatePanel,
+		addAskIPv6Panel,
 		addAskRolePanel,
 		addDiskPanel,
 		addHostnamePanel,
@@ -867,7 +868,7 @@ func addAskCreatePanel(c *Console) error {
 			// all packages are already install
 			// configure hostname and network
 			if c.config.Install.Mode == config.ModeJoin {
-				return showRolePage(c)
+				return showIPv6Page(c)
 			}
 			if alreadyInstalled {
 				return showNetworkPage(c)
@@ -883,6 +884,14 @@ func showPasswordPage(c *Console) error {
 	return showNext(c, passwordConfirmPanel, passwordPanel)
 }
 
+func showIPv6Page(c *Console) error {
+	setLocation := createVerticalLocatorWithName(c)
+	if err := setLocation(askIPv6Panel, 3); err != nil {
+		return err
+	}
+	return showNext(c, askIPv6Panel)
+}
+
 func showRolePage(c *Console) error {
 	setLocation := createVerticalLocatorWithName(c)
 
@@ -891,6 +900,93 @@ func showRolePage(c *Console) error {
 	}
 
 	return showNext(c, askRolePanel)
+}
+
+// addAskIPv6Panel shows a Yes/No prompt for enabling IPv6 on join-mode nodes.
+// IPv6 is disabled by default; enabling it is required for dual-stack clusters.
+func addAskIPv6Panel(c *Console) error {
+	const (
+		optNo  = "no"
+		optYes = "yes"
+	)
+	var awaitingIPv6Ack bool
+
+	optionsFunc := func() ([]widgets.Option, error) {
+		return []widgets.Option{
+			{Value: optNo, Text: "No"},
+			{Value: optYes, Text: "Yes"},
+		}, nil
+	}
+
+	v, err := widgets.NewSelect(c.Gui, askIPv6Panel, "", optionsFunc)
+	if err != nil {
+		return err
+	}
+
+	v.PreShow = func() error {
+		awaitingIPv6Ack = false
+		if c.config.Install.IPv6Enabled {
+			v.Value = optYes
+		} else {
+			v.Value = optNo
+		}
+		if err := c.setContentByName(titlePanel, "Enable IPv6 on this node?"); err != nil {
+			return err
+		}
+		if err := c.setContentByName(validatorPanel, ""); err != nil {
+			return err
+		}
+		return c.setContentByName(notePanel,
+			"Note: Enabling IPv6 is required for Dual Stack (IPv4, IPv6) configurations.")
+	}
+
+	gotoPrev := func(_ *gocui.Gui, _ *gocui.View) error {
+		c.CloseElements(askIPv6Panel)
+		if err := c.setContentByName(validatorPanel, ""); err != nil {
+			return err
+		}
+		if err := c.setContentByName(notePanel, ""); err != nil {
+			return err
+		}
+		return showNext(c, askCreatePanel)
+	}
+
+	v.KeyBindings = map[gocui.Key]func(*gocui.Gui, *gocui.View) error{
+		gocui.KeyEnter: func(_ *gocui.Gui, _ *gocui.View) error {
+			selected, err := v.GetData()
+			if err != nil {
+				return err
+			}
+
+			if selected == optYes && !awaitingIPv6Ack {
+				// First Enter on "Yes": show the experimental warning in the
+				// validator panel (red) and ask the user to press Enter once more.
+				awaitingIPv6Ack = true
+				return c.setContentByName(validatorPanel,
+					"WARNING: Dual-stack networking (IPv4, IPv6) is an experimental feature "+
+						"and may behave unexpectedly in production. "+
+						"Press Enter again to confirm, or press ESC to go back.")
+			}
+
+			// Reset warning and store choice.
+			awaitingIPv6Ack = false
+			if err := c.setContentByName(validatorPanel, ""); err != nil {
+				return err
+			}
+			if err := c.setContentByName(notePanel, ""); err != nil {
+				return err
+			}
+			c.config.Install.IPv6Enabled = (selected == optYes)
+
+			if err = v.Close(); err != nil {
+				return err
+			}
+			return showRolePage(c)
+		},
+		gocui.KeyEsc: gotoPrev,
+	}
+	c.AddElement(askIPv6Panel, v)
+	return nil
 }
 
 func addAskRolePanel(c *Console) error {
@@ -917,6 +1013,10 @@ func addAskRolePanel(c *Console) error {
 	}
 	gotoPrevPage := func(_ *gocui.Gui, _ *gocui.View) error {
 		c.CloseElements(askRolePanel)
+		// In join mode the page before role is the IPv6 prompt.
+		if c.config.Install.Mode == config.ModeJoin {
+			return showIPv6Page(c)
+		}
 		return showNext(c, askCreatePanel)
 	}
 	askRoleV.PreShow = func() error {

--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -2086,6 +2086,16 @@ func addClusterNetworkPanel(c *Console) error {
 				return err
 			}
 		}
+		if len(parts) == 1 {
+			// A single CIDR must be IPv4; IPv6-only is not a supported mode.
+			single, err := netip.ParsePrefix(strings.TrimSpace(parts[0])) // already validated above
+			if err != nil {
+				return err
+			}
+			if !single.Addr().Is4() {
+				return fmt.Errorf("a single CIDR must be IPv4 (e.g. 10.42.0.0/16); for dual-stack provide IPv4,IPv6")
+			}
+		}
 		if len(parts) == 2 {
 			firstStr := strings.TrimSpace(parts[0])
 			secondStr := strings.TrimSpace(parts[1])

--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -1992,7 +1992,12 @@ func addClusterNetworkPanel(c *Console) error {
 			clusterNetworkValidatorPanel)
 	}
 
+	// awaitingDualStackAck tracks whether the user has seen the dual-stack
+	// experimental warning and needs to press Enter once more to confirm.
+	var awaitingDualStackAck bool
+
 	prevPage := func(_ *gocui.Gui, _ *gocui.View) error {
+		awaitingDualStackAck = false
 		closePage()
 		return showNetworkPage(c)
 	}
@@ -2072,9 +2077,23 @@ func addClusterNetworkPanel(c *Console) error {
 		if cidr == "" {
 			return nil
 		}
-
-		_, err := netip.ParsePrefix(cidr)
-		return err
+		parts := strings.Split(cidr, ",")
+		if len(parts) > 2 {
+			return fmt.Errorf("at most two CIDRs (IPv4,IPv6) are allowed, got %d", len(parts))
+		}
+		for _, p := range parts {
+			if _, err := netip.ParsePrefix(strings.TrimSpace(p)); err != nil {
+				return err
+			}
+		}
+		if len(parts) == 2 {
+			first, _ := netip.ParsePrefix(strings.TrimSpace(parts[0]))
+			second, _ := netip.ParsePrefix(strings.TrimSpace(parts[1]))
+			if !first.Addr().Is4() || second.Addr().Is4() {
+				return fmt.Errorf("dual-stack CIDRs must be in IPv4-first order (e.g. 10.42.0.0/16,fd42::/48)")
+			}
+		}
+		return nil
 	}
 
 	validateDNSIP := func(ip string) error {
@@ -2087,20 +2106,34 @@ func addClusterNetworkPanel(c *Console) error {
 			return nil
 		}
 
-		// the DNS IP address must be well-formed and within the
-		// service CIDR
-		ipAddr, err := netip.ParseAddr(ip)
-		if err != nil {
-			return fmt.Errorf("invalid cluster DNS IP: %w", err)
+		// Build a map from Is4() bool → service prefix so each DNS address
+		// can be matched to the CIDR of its own address family.
+		svcParts := strings.Split(serviceCIDR, ",")
+		svcNets := make(map[bool]netip.Prefix, len(svcParts))
+		for _, part := range svcParts {
+			part = strings.TrimSpace(part)
+			prefix, parseErr := netip.ParsePrefix(part)
+			if parseErr != nil {
+				return fmt.Errorf("to override the cluster DNS IP, the service CIDR must be valid: %w", parseErr)
+			}
+			svcNets[prefix.Addr().Is4()] = prefix
 		}
 
-		svcNet, err := netip.ParsePrefix(serviceCIDR)
-		if err != nil {
-			return fmt.Errorf("to override the cluster DNS IP, the service CIDR must be valid: %w", err)
-		}
-
-		if !svcNet.Contains(ipAddr) {
-			return fmt.Errorf("invalid cluster DNS IP: %s is not in the service CIDR %s", ip, serviceCIDR)
+		// Validate each DNS address against the service CIDR of the same family.
+		dnsParts := strings.Split(ip, ",")
+		for _, part := range dnsParts {
+			part = strings.TrimSpace(part)
+			ipAddr, parseErr := netip.ParseAddr(part)
+			if parseErr != nil {
+				return fmt.Errorf("invalid cluster DNS IP: %w", parseErr)
+			}
+			svcNet, ok := svcNets[ipAddr.Is4()]
+			if !ok {
+				return fmt.Errorf("invalid cluster DNS IP: %s has no matching service CIDR for its address family", part)
+			}
+			if !svcNet.Contains(ipAddr) {
+				return fmt.Errorf("invalid cluster DNS IP: %s is not in the service CIDR %s", part, svcNet)
+			}
 		}
 
 		return nil
@@ -2118,7 +2151,9 @@ func addClusterNetworkPanel(c *Console) error {
 				clusterNetworkValidatorPanel,
 				fmt.Sprintf("Invalid pod CIDR: %s", err))
 		}
+
 		c.config.ClusterPodCIDR = podCIDR
+		awaitingDualStackAck = false
 
 		// reset any previous error in the validator panel before
 		// moving to the next panel
@@ -2140,6 +2175,7 @@ func addClusterNetworkPanel(c *Console) error {
 				fmt.Sprintf("Invalid service CIDR: %s", err))
 		}
 		c.config.ClusterServiceCIDR = serviceCIDR
+		awaitingDualStackAck = false
 
 		// reset any previous error in the validator panel before
 		// moving to the next panel
@@ -2155,11 +2191,28 @@ func addClusterNetworkPanel(c *Console) error {
 			return err
 		}
 		if err = validateDNSIP(dns); err != nil {
+			awaitingDualStackAck = false
 			return c.setContentByName(clusterNetworkValidatorPanel, err.Error())
 		}
 		c.config.ClusterDNS = dns
 
-		// reset the validator panel before moving to the next page
+		// All fields are validated. If dual-stack was configured, show an inline
+		// warning on the first Enter and require a second Enter to confirm.
+		if strings.Contains(c.config.ClusterPodCIDR, ",") {
+			if !awaitingDualStackAck {
+				awaitingDualStackAck = true
+				return c.setContentByName(clusterNetworkValidatorPanel,
+					"WARNING: Dual-stack networking (IPv4, IPv6) is an experimental feature "+
+						"and may behave unexpectedly in production. "+
+						"Press Enter again to confirm, or go back to change the configuration.")
+			}
+			// Second Enter: user confirmed, apply IPv6 and proceed.
+			awaitingDualStackAck = false
+			if err = applyKernelIPv6(true); err != nil {
+				return c.setContentByName(clusterNetworkValidatorPanel, err.Error())
+			}
+		}
+
 		if err = c.setContentByName(clusterNetworkValidatorPanel, ""); err != nil {
 			return err
 		}
@@ -2190,6 +2243,7 @@ func addClusterNetworkPanel(c *Console) error {
 	dnsInput.KeyBindings = map[gocui.Key]func(*gocui.Gui, *gocui.View) error{
 		gocui.KeyEsc: prevPage,
 		gocui.KeyArrowUp: func(_ *gocui.Gui, _ *gocui.View) error {
+			awaitingDualStackAck = false
 			return showNext(c, clusterServiceCIDRPanel)
 		},
 		gocui.KeyArrowDown: dnsConfirm,
@@ -2209,9 +2263,8 @@ func addClusterNetworkPanel(c *Console) error {
 	validatorPanel := widgets.NewPanel(c.Gui, clusterNetworkValidatorPanel)
 	validatorPanel.FgColor = gocui.ColorRed
 	validatorPanel.Focus = false
-	maxX, _ := c.Gui.Size()
-	validatorPanel.X1 = maxX / 8 * 6
-	setLocation(validatorPanel, 3)
+	validatorPanel.Wrap = true
+	setLocation(validatorPanel, 6)
 	c.AddElement(clusterNetworkValidatorPanel, validatorPanel)
 
 	return nil

--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -2083,7 +2083,7 @@ func addClusterNetworkPanel(c *Console) error {
 		}
 		for _, p := range parts {
 			if _, err := netip.ParsePrefix(strings.TrimSpace(p)); err != nil {
-				return err
+				return fmt.Errorf("%q is not a valid CIDR (expected e.g. 10.42.0.0/16 or fd42::/48)", strings.TrimSpace(p))
 			}
 		}
 		if len(parts) == 1 {
@@ -2135,6 +2135,14 @@ func addClusterNetworkPanel(c *Console) error {
 				return fmt.Errorf("to override the cluster DNS IP, the service CIDR must be valid: %w", parseErr)
 			}
 			svcNets[prefix.Addr().Is4()] = prefix
+		}
+
+		// A single DNS IP must be IPv4; IPv6-only is not a supported mode.
+		if !strings.Contains(ip, ",") {
+			singleAddr, parseErr := netip.ParseAddr(strings.TrimSpace(ip))
+			if parseErr == nil && !singleAddr.Is4() {
+				return fmt.Errorf("a single DNS IP must be IPv4 (e.g. 10.53.0.10); for dual-stack provide IPv4,IPv6 (e.g. 10.53.0.10,fd53::a)")
+			}
 		}
 
 		// Validate each DNS address against the service CIDR of the same family.

--- a/pkg/console/install_panels.go
+++ b/pkg/console/install_panels.go
@@ -2087,8 +2087,16 @@ func addClusterNetworkPanel(c *Console) error {
 			}
 		}
 		if len(parts) == 2 {
-			first, _ := netip.ParsePrefix(strings.TrimSpace(parts[0]))
-			second, _ := netip.ParsePrefix(strings.TrimSpace(parts[1]))
+			firstStr := strings.TrimSpace(parts[0])
+			secondStr := strings.TrimSpace(parts[1])
+			first, err := netip.ParsePrefix(firstStr)
+			if err != nil {
+				return err
+			}
+			second, err := netip.ParsePrefix(secondStr)
+			if err != nil {
+				return err
+			}
 			if !first.Addr().Is4() || second.Addr().Is4() {
 				return fmt.Errorf("dual-stack CIDRs must be in IPv4-first order (e.g. 10.42.0.0/16,fd42::/48)")
 			}
@@ -2121,6 +2129,10 @@ func addClusterNetworkPanel(c *Console) error {
 
 		// Validate each DNS address against the service CIDR of the same family.
 		dnsParts := strings.Split(ip, ",")
+		if len(dnsParts) > 2 {
+			return fmt.Errorf("at most two DNS IPs (IPv4,IPv6) are allowed, got %d", len(dnsParts))
+		}
+		parsed := make([]netip.Addr, 0, len(dnsParts))
 		for _, part := range dnsParts {
 			part = strings.TrimSpace(part)
 			ipAddr, parseErr := netip.ParseAddr(part)
@@ -2133,6 +2145,12 @@ func addClusterNetworkPanel(c *Console) error {
 			}
 			if !svcNet.Contains(ipAddr) {
 				return fmt.Errorf("invalid cluster DNS IP: %s is not in the service CIDR %s", part, svcNet)
+			}
+			parsed = append(parsed, ipAddr)
+		}
+		if len(parsed) == 2 {
+			if !parsed[0].Is4() || parsed[1].Is4() {
+				return fmt.Errorf("dual-stack DNS IPs must be in IPv4-first order (e.g. 10.53.0.10,fd53::a)")
 			}
 		}
 

--- a/pkg/console/network.go
+++ b/pkg/console/network.go
@@ -89,18 +89,7 @@ func applyNetworks(network config.Network, hostname string) error {
 		}
 	}
 
-	// enable IPv6 before applying NetworkManager profiles
-	for _, param := range []string{
-		config.SysctlDisableIPv6All,
-		config.SysctlDisableIPv6Default,
-		config.SysctlDisableIPv6Lo,
-	} {
-		if out, execErr := exec.Command("sysctl", "-w", fmt.Sprintf("%s=0", param)).CombinedOutput(); execErr != nil {
-			logrus.Warnf("Failed to enable IPv6 sysctl %s: %v (%s)", param, execErr, string(out))
-		}
-	}
-
-	err = config.UpdateManagementInterfaceConfig(network, []string{}, config.NMConnectionPath, true)
+	err = config.UpdateManagementInterfaceConfig(network, []string{}, config.NMConnectionPath, true, false)
 	if err != nil {
 		return err
 	}
@@ -255,6 +244,31 @@ func filterNICSBySession(hwDeviceMap map[string]netlink.Link, links []netlink.Li
 					break //device is already removed, no point checking for other addresses
 				}
 			}
+		}
+	}
+	return nil
+}
+
+// applyKernelIPv6 enables (enabled=true) or disables (enabled=false) IPv6 in the
+// running kernel by writing the disable_ipv6 sysctls. Called at the cluster-CIDR
+// confirm step so the live installer session matches the chosen networking mode.
+// For dual-stack (enabled=true) any sysctl failure is returned as a hard error.
+// For IPv4-only (enabled=false) failures are logged as warnings only.
+func applyKernelIPv6(enabled bool) error {
+	value := "0"
+	if !enabled {
+		value = "1"
+	}
+	for _, param := range []string{
+		config.SysctlDisableIPv6All,
+		config.SysctlDisableIPv6Default,
+		config.SysctlDisableIPv6Lo,
+	} {
+		if out, execErr := exec.Command("sysctl", "-w", fmt.Sprintf("%s=%s", param, value)).CombinedOutput(); execErr != nil {
+			if enabled {
+				return fmt.Errorf("failed to enable IPv6 (%s): %v (%s)", param, execErr, string(out))
+			}
+			logrus.Warnf("Failed to disable IPv6 sysctl %s: %v (%s)", param, execErr, string(out))
 		}
 	}
 	return nil


### PR DESCRIPTION
Adding dual stack IPv4 Family First config to installer including the following:
* extend CIDR/DNS validators in the install pannel for dual stack support
* show warning that the feature is experimental when dual stack is configured
* extending the note to menton the support
* configure sysctl to enale or disable IPv6 depending on the config; no longer unconditional
* configure networkamanager profile with ipv6 if dual stack is enabled
* fix converttocos test by adding the condition on which it's enabled
* add panel to enable IPv6 when node is joining - default is disabled/no

#### Problem:
You could not have harvester node through installer to enable dual stack config

#### Solution:
Add panel to installer and propagate dual stack config

#### Related Issue(s):
https://github.com/harvester/harvester/issues/10796

#### Test plan:

UX tests:

1. Installer shows no warning when config is ipv4 only; only note present dual stack is configurable and possible
2. Installer warns and prompts enter when dual stack is configured
3. Installer rejects dual stack configs with IPv6 family first or IPv6 only
4. Installer rejects bad IPv6 values
5. Installer prompts user to enable or disable IPv6 on node which joins to cluster

Functional Tests:
1. IPv4 only does not configure IPv6; only kernel level ipv6 enabled is accepted
2. Dual stack config enables IPv6 across the stack:
2.1 on host level - kernel, networkmanager bridges/vlan/interface
2.2 on application/rke2 level - dual stack preferred - IPv4,IPv6 only
3. Config file installation - non interactive is validating dual stack ipv4 first config (comma in the end is rejected, 3 values added etc)
6. Joining a node to the cluster in Dual Stack mode works and second node configures dual stack as well
7. Upgrade to version with installer does not accidentally enable ipv6 config on NM level
8. Config is saved across reboots for both IPv4 and Dual Stack

#### Test Results:

Set Up:

<details>
<summary>Virtual Network</summary>

In Connection details in Virtual Machine Manager you'd need Virtual Network with IPv4 and IPv6 ranges:
<img width="1665" height="981" alt="image" src="https://github.com/user-attachments/assets/0c0983cb-1299-4fe2-9ba5-232307d5206a" />

And just before beginning installation check custom config:
<img width="1276" height="870" alt="image" src="https://github.com/user-attachments/assets/f19a4f5c-3ac5-401d-99cd-cacf89cbbf73" />
pick NIC to be the network interface:
<img width="1626" height="1039" alt="image" src="https://github.com/user-attachments/assets/5e2b37ad-420d-4001-9182-0a9c819d7ced" />

Contents:

```
<network>
  <name>virbr4</name>
  <uuid>81d9e815-d918-4a9a-ba30-791e969e2de5</uuid>
  <forward mode="nat">
    <nat ipv6="yes">
      <port start="1024" end="65535"/>
    </nat>
  </forward>
  <bridge name="virbr4" stp="on" delay="0"/>
  <mac address="52:54:00:ce:ec:f7"/>
  <domain name="virbr4"/>
  <ip address="192.168.103.1" netmask="255.255.255.0">
    <dhcp>
      <range start="192.168.103.128" end="192.168.103.254"/>
    </dhcp>
  </ip>
  <ip family="ipv6" address="fd00:cafe:4::1" prefix="64">
    <dhcp>
      <range start="fd00:cafe:4::100" end="fd00:cafe:4::1ff"/>
    </dhcp>
  </ip>
</network>
```
</details>

<details>
<summary>Harvester Network Config</summary>

In the: `Configure cluster network`:
<img width="1279" height="436" alt="image" src="https://github.com/user-attachments/assets/38e7c5a1-cf5d-43f9-b9e9-264e3014e7b4" />

Following config works with the Virtual Network configured in above step (the `virbr4`):

| Field In Installer  |      Value      |
|----------|-------------|
|Pod CIDR|	10.52.0.0/16,fd42::/48|
|Service CIDR|	10.53.0.0/16,fd43::/112|
|Cluster DNS|	10.53.0.10 or 10.53.0.10,fd43::a|
</details>

UX tests:

<details>
<summary>1. Installer shows no warning when config is ipv4 only; only note present dual stack is configurable and possible</summary>
When IPv4 Is configured note is always present that dual stack is configurable:
<img width="1276" height="864" alt="image" src="https://github.com/user-attachments/assets/15fabb21-87f3-479d-884b-50363e82f957" />
1st enter to continue - next without warning:
<img width="1276" height="864" alt="image" src="https://github.com/user-attachments/assets/e95102d4-7e7c-4fc7-9aa4-77925a704912" />
</details>

<details>
<summary>2. Installer warns and prompts enter when dual stack is configured</summary>
Configure Dual Stack:
<img width="1276" height="864" alt="image" src="https://github.com/user-attachments/assets/0640e9f0-85bc-4b24-82af-8aade82ca41f" />
After pressing 1st Enter:
<img width="1276" height="864" alt="image" src="https://github.com/user-attachments/assets/fd75bbd4-30c2-4f75-bbad-ae3d2b0d2837" />
Second enter passes.
</details>

<details>
<summary>3. Installer rejects dual stack configs with IPv6 family first or IPv6 only
</summary>

IPv6 Only:

<img width="1272" height="868" alt="image" src="https://github.com/user-attachments/assets/e3cc5375-9e8a-47fc-ac64-dcb15af9ab38" />
<img width="1272" height="868" alt="image" src="https://github.com/user-attachments/assets/f979311c-b70e-4b56-b969-601a38424f2e" />
<img width="1272" height="868" alt="image" src="https://github.com/user-attachments/assets/6e5f9bb1-f536-486e-9dc8-20d0991e490b" />

Dual Stack IPv6 Family first:
<img width="1272" height="868" alt="image" src="https://github.com/user-attachments/assets/ac640702-af01-4c69-8b80-d53b977910b8" />
<img width="1272" height="868" alt="image" src="https://github.com/user-attachments/assets/82b3d5fe-cfb2-4cec-a4a8-c9a3c1039aaf" />
<img width="1272" height="868" alt="image" src="https://github.com/user-attachments/assets/c1be1265-0312-470e-9c9a-9f771880bc7f" />

</details>


<details>
<summary>4. Installer rejects bad IPv6 values
</summary>
<img width="1272" height="868" alt="image" src="https://github.com/user-attachments/assets/4c0ca20f-a852-4573-a4e9-ef961f605750" />
<img width="1272" height="868" alt="image" src="https://github.com/user-attachments/assets/a2945b2e-c8a7-4369-a65f-7c9a7663583d" />
<img width="1278" height="869" alt="image" src="https://github.com/user-attachments/assets/e3f8e124-4454-47e6-b386-59b010ac0eb7" />
<img width="1278" height="869" alt="image" src="https://github.com/user-attachments/assets/6058d0fd-38fe-4418-bb8e-57009fa6755f" />

</details>

<details>
<summary>5. Installer prompts user to enable or disable IPv6 on node which joins to cluster
</summary>
Defaults to no:
<img width="1278" height="862" alt="image" src="https://github.com/user-attachments/assets/55ba452d-c0b3-41e1-8a9e-85b67c7ddb18" />
<img width="1278" height="862" alt="image" src="https://github.com/user-attachments/assets/5428b36a-b339-4d0f-90de-57d1aa72d0ba" />

Prompts second enter to enable IPv6 with warning:
<img width="1278" height="862" alt="image" src="https://github.com/user-attachments/assets/0efd1a84-006a-48ec-a9fd-ed1581b4c6ef" />

Final config `ipv6_enabled` is toggled to `true`:
<img width="1278" height="862" alt="image" src="https://github.com/user-attachments/assets/9fb4953c-3574-499c-9a49-bc6dae4e2ea9" />
</details>

Functional Tests:

<details>
<summary>1. IPv4 only does not configure IPv6; only kernel level ipv6 enabled is accepted
</summary>

Config (go through enter press on the network tab):
<img width="1278" height="869" alt="image" src="https://github.com/user-attachments/assets/419d57a0-af8a-4f9d-9eb9-e4e2c2ad4eff" />

Ready:
<img width="1278" height="869" alt="image" src="https://github.com/user-attachments/assets/c04b0484-28f1-491b-803b-e6fbd9d692e9" />

Results from the commands on the host node, config and in the kubernetes:
```
node-1:/home/rancher # # expect disabled = 1 or true
node-1:/home/rancher # sysctl net.ipv6.conf.all.disable_ipv6 \
>        net.ipv6.conf.default.disable_ipv6 \
>        net.ipv6.conf.lo.disable_ipv6
net.ipv6.conf.all.disable_ipv6 = 1
net.ipv6.conf.default.disable_ipv6 = 1
net.ipv6.conf.lo.disable_ipv6 = 1
node-1:/home/rancher # 
node-1:/home/rancher # cat /etc/sysctl.d/zz-harvester-enable-ipv6.conf
# Written by harvester-installer (IPv4-only install)
net.ipv6.conf.all.disable_ipv6 = 1
net.ipv6.conf.default.disable_ipv6 = 1
net.ipv6.conf.lo.disable_ipv6 = 1
node-1:/home/rancher # # expect NetworkManager ipv6 to method=disabled or empty
node-1:/home/rancher # nmcli con show
NAME               UUID                                  TYPE      DEVICE       
bridge-mgmt        713373f6-bf9d-3ee3-abb2-5f295bd18145  bridge    mgmt-br      
bond-mgmt          48589773-cb7d-38c5-b579-7dd119af73b6  bond      mgmt-bo      
bond-slave-enp1s0  97ed9ced-a5cc-306a-b37c-8a6a1e6f0ad8  ethernet  enp1s0       
lo                 181654f2-8823-4923-97c4-8de2fa10f7e2  loopback  lo           
vip-66eee24b       804b2e32-3ad5-4bff-b88a-131d046d88b5  macvlan   vip-66eee24b 
node-1:/home/rancher # grep -A5 '\[ipv6\]' /etc/NetworkManager/system-connections/bridge-mgmt.nmconnection
[ipv6]
method=disabled
node-1:/home/rancher # grep -A5 '\[ipv6\]' /etc/NetworkManager/system-connections/bond-mgmt.nmconnection
node-1:/home/rancher # grep -A5 '\[ipv6\]' /etc/NetworkManager/system-connections/bond-slave-enp1s0.nmconnection
node-1:/home/rancher # nmcli -f connection.id,ipv6.method con show bridge-mgmt bond-mgmt bond-slave-enp1s0
connection.id:                          bridge-mgmt
ipv6.method:                            disabled

connection.id:                          bond-mgmt

connection.id:                          bond-slave-enp1s0
node-1:/home/rancher # # ip -6 must be empty
node-1:/home/rancher # ip -6 addr show dev mgmt-br scope global
node-1:/home/rancher # ip -6 route show default
node-1:/home/rancher # # rke config single IPv4 CIDRs
node-1:/home/rancher # cat /etc/rancher/rke2/config.yaml.d/90-harvester-server.yaml
cni: multus,canal
cluster-cidr: 10.52.0.0/16
service-cidr: 10.53.0.0/16
cluster-dns: 10.53.0.10
tls-san:
  - 192.168.103.172

kubelet-arg:
- "max-pods=200"
audit-policy-file: /etc/rancher/rke2/config.yaml.d/92-harvester-kube-audit-policy.yaml
node-1:/home/rancher # # services should be empty and no ipv6 addresses on the bridge
node-1:/home/rancher # ss -tlnp | grep ':::'
node-1:/home/rancher # grep mgmt-br /proc/net/if_inet6
node-1:/home/rancher # # services are IPv4 only in kubernetes only RKE has default PreferDualStack but has IPv4 only addresses configured
node-1:/home/rancher # kubectl get svc -A -o custom-columns="NAME:.metadata.name,FAMILY-POLICY:.spec.ipFamilyPolicy,FAMILIES:.spec.ipFamilies"
NAME                                      FAMILY-POLICY     FAMILIES
capi-webhook-service                      SingleStack       [IPv4]
gitjob                                    SingleStack       [IPv4]
monitoring-fleet-controller               SingleStack       [IPv4]
monitoring-gitjob                         SingleStack       [IPv4]
harvester-cluster-repo                    SingleStack       [IPv4]
imperative-api-extension                  SingleStack       [IPv4]
rancher                                   SingleStack       [IPv4]
rancher-internal                          SingleStack       [IPv4]
rancher-webhook                           SingleStack       [IPv4]
kubernetes                                SingleStack       [IPv4]
cdi-api                                   SingleStack       [IPv4]
cdi-prometheus-metrics                    SingleStack       [IPv4]
cdi-uploadproxy                           SingleStack       [IPv4]
harvester                                 SingleStack       [IPv4]
harvester-load-balancer-webhook           SingleStack       [IPv4]
harvester-network-webhook                 SingleStack       [IPv4]
harvester-node-disk-manager-webhook       SingleStack       [IPv4]
harvester-node-manager-webhook            SingleStack       [IPv4]
harvester-webhook                         SingleStack       [IPv4]
kubevirt-operator-webhook                 SingleStack       [IPv4]
kubevirt-prometheus-metrics               SingleStack       [IPv4]
virt-api                                  SingleStack       [IPv4]
virt-exportproxy                          SingleStack       [IPv4]
ingress-expose                            SingleStack       [IPv4]
rke2-coredns-rke2-coredns                 SingleStack       [IPv4]
rke2-ingress-nginx-controller-admission   PreferDualStack   [IPv4]
rke2-metrics-server                       PreferDualStack   [IPv4]
longhorn-admission-webhook                SingleStack       [IPv4]
longhorn-backend                          SingleStack       [IPv4]
longhorn-frontend                         SingleStack       [IPv4]
longhorn-recovery-backend                 SingleStack       [IPv4]
```

</details>

<details>
<summary>2. Dual stack config enables IPv6 across the stack
</summary>

Config:
<img width="1278" height="869" alt="image" src="https://github.com/user-attachments/assets/d8bb6ddc-087b-4f27-99af-4b7ee922b8df" />

Test Results:
```
node-1:/home/rancher # # Kernel IPv6 must be enabled - all three = 0
node-1:/home/rancher # sysctl net.ipv6.conf.all.disable_ipv6 \
>        net.ipv6.conf.default.disable_ipv6 \
>        net.ipv6.conf.lo.disable_ipv6
net.ipv6.conf.all.disable_ipv6 = 0
net.ipv6.conf.default.disable_ipv6 = 0
net.ipv6.conf.lo.disable_ipv6 = 0
node-1:/home/rancher # 
node-1:/home/rancher # cat /etc/sysctl.d/zz-harvester-enable-ipv6.conf
# Written by harvester-installer (dual-stack install)
net.ipv6.conf.all.disable_ipv6 = 0
net.ipv6.conf.default.disable_ipv6 = 0
net.ipv6.conf.lo.disable_ipv6 = 0
node-1:/home/rancher # # NetworkManager is method=auto
node-1:/home/rancher # grep -A5 '\[ipv6\]' /etc/NetworkManager/system-connections/bridge-mgmt.nmconnection
[ipv6]
method=auto
addr-gen-mode=eui64
ip6-privacy=0
node-1:/home/rancher # nmcli -f connection.id,ipv6.method con show bridge-mgmt bond-mgmt
connection.id:                          bridge-mgmt
ipv6.method:                            auto

connection.id:                          bond-mgmt
node-1:/home/rancher # # IPv6 addresses assigned on bridge
node-1:/home/rancher # ip -6 addr show dev mgmt-br scope global
3: mgmt-br: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    inet6 fd00:cafe:4::1c8/128 scope global dynamic noprefixroute 
       valid_lft 85109sec preferred_lft 85109sec
node-1:/home/rancher # ip -6 route show default
default via fe80::5054:ff:fece:ecf7 dev mgmt-br proto ra metric 20425 pref medium
node-1:/home/rancher # # rke2 with dual stack config
node-1:/home/rancher # cat /etc/rancher/rke2/config.yaml.d/90-harvester-server.yaml
cni: multus,canal
cluster-cidr: 10.52.0.0/16,fd42::/48
service-cidr: 10.53.0.0/16,fd43::/112
cluster-dns: 10.53.0.10,fd43::a
tls-san:
  - 192.168.103.205

kubelet-arg:
- "max-pods=200"
audit-policy-file: /etc/rancher/rke2/config.yaml.d/92-harvester-kube-audit-policy.yaml
node-1:/home/rancher # kubectl get node -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.podCIDRs}{"\n"}{end}'
node-1  ["10.52.0.0/24","fd42::/64"]
node-1:/home/rancher # # services running with prefer dual stack has actually 2 Families
node-1:/home/rancher # kubectl get svc -A -o custom-columns="NAME:.metadata.name,POLICY:.spec.ipFamilyPolicy,FAMILIES:.spec.ipFamilies,IPS:.spec.clusterIPs"
NAME                                      POLICY            FAMILIES      IPS
capi-webhook-service                      SingleStack       [IPv4]        [10.53.34.154]
gitjob                                    SingleStack       [IPv4]        [10.53.48.250]
monitoring-fleet-controller               SingleStack       [IPv4]        [10.53.11.245]
monitoring-gitjob                         SingleStack       [IPv4]        [10.53.70.58]
harvester-cluster-repo                    SingleStack       [IPv4]        [10.53.19.78]
imperative-api-extension                  SingleStack       [IPv4]        [10.53.66.189]
rancher                                   SingleStack       [IPv4]        [10.53.60.32]
rancher-internal                          SingleStack       [IPv4]        [10.53.115.224]
rancher-webhook                           SingleStack       [IPv4]        [10.53.163.165]
kubernetes                                SingleStack       [IPv4]        [10.53.0.1]
cdi-api                                   SingleStack       [IPv4]        [10.53.220.163]
cdi-prometheus-metrics                    SingleStack       [IPv4]        [10.53.10.44]
cdi-uploadproxy                           SingleStack       [IPv4]        [10.53.59.85]
harvester                                 SingleStack       [IPv4]        [10.53.191.18]
harvester-load-balancer-webhook           SingleStack       [IPv4]        [10.53.213.230]
harvester-network-webhook                 SingleStack       [IPv4]        [10.53.195.97]
harvester-node-disk-manager-webhook       SingleStack       [IPv4]        [10.53.56.185]
harvester-node-manager-webhook            SingleStack       [IPv4]        [10.53.188.237]
harvester-webhook                         SingleStack       [IPv4]        [10.53.66.76]
kubevirt-operator-webhook                 SingleStack       [IPv4]        [10.53.108.157]
kubevirt-prometheus-metrics               SingleStack       [IPv4]        [None]
virt-api                                  SingleStack       [IPv4]        [10.53.136.88]
virt-exportproxy                          SingleStack       [IPv4]        [10.53.117.196]
ingress-expose                            SingleStack       [IPv4]        [10.53.125.113]
rke2-coredns-rke2-coredns                 PreferDualStack   [IPv4 IPv6]   [10.53.0.10 fd43::a]
rke2-ingress-nginx-controller-admission   PreferDualStack   [IPv4 IPv6]   [10.53.126.198 fd43::8e43]
rke2-metrics-server                       PreferDualStack   [IPv4 IPv6]   [10.53.54.93 fd43::9d9a]
longhorn-admission-webhook                SingleStack       [IPv4]        [10.53.143.208]
longhorn-backend                          SingleStack       [IPv4]        [10.53.157.228]
longhorn-frontend                         SingleStack       [IPv4]        [10.53.141.69]
longhorn-recovery-backend                 SingleStack       [IPv4]        [10.53.66.227]
node-1:/home/rancher # kubectl get svc kubernetes -o jsonpath='{.spec.clusterIPs}{"\n"}{.spec.ipFamilies}{"\n"}'
["10.53.0.1"]
["IPv4"]
node-1:/home/rancher # # actual dns tests to show both IPv4 and IPv6 DNS work from inside a pod
node-1:/home/rancher # kubectl run dnstest --image=busybox --restart=Never --rm -it -- nslookup kubernetes.default 10.53.0.10
Server:         10.53.0.10
Address:        10.53.0.10:53

** server can't find kubernetes.default: NXDOMAIN

** server can't find kubernetes.default: NXDOMAIN

pod "dnstest" deleted from default namespace
pod default/dnstest terminated (Error)
node-1:/home/rancher # kubectl run dnstest --image=busybox --restart=Never --rm -it -- nslookup kubernetes.default fd43::a
Server:         fd43::a
Address:        [fd43::a]:53

** server can't find kubernetes.default: NXDOMAIN

** server can't find kubernetes.default: NXDOMAIN

pod "dnstest" deleted from default namespace
pod default/dnstest terminated (Error)
node-1:/home/rancher # kubectl run iptest --image=busybox --restart=Never -- sleep 3600
pod/iptest created
node-1:/home/rancher # kubectl get pod iptest -o jsonpath='{.status.podIPs}{"\n"}'
[{"ip":"10.52.0.82"},{"ip":"fd42::52"}]
node-1:/home/rancher # kubectl delete pod iptest
pod "iptest" deleted from default namespace
node-1:/home/rancher # # test actual pod communication over IPv6 inside kubernetes on the harvester node
node-1:/home/rancher # kubectl run pod-a --image=busybox --restart=Never -- sleep 3600
pod/pod-a created
node-1:/home/rancher # kubectl run pod-b --image=busybox --restart=Never -- sleep 3600
pod/pod-b created
node-1:/home/rancher # kubectl wait pod pod-a pod-b --for=condition=Ready --timeout=60s
pod/pod-a condition met
pod/pod-b condition met
node-1:/home/rancher # kubectl get pod pod-a -o jsonpath='{.status.podIPs}{"\n"}'
[{"ip":"10.52.0.84"},{"ip":"fd42::54"}]
node-1:/home/rancher # kubectl get pod pod-b -o jsonpath='{.status.podIPs}{"\n"}'
[{"ip":"10.52.0.85"},{"ip":"fd42::55"}]
node-1:/home/rancher # kubectl exec pod-a -- ping -6 -c3 "fd42::55"
PING fd42::55 (fd42::55): 56 data bytes
64 bytes from fd42::55: seq=0 ttl=63 time=0.173 ms
64 bytes from fd42::55: seq=1 ttl=63 time=0.075 ms
64 bytes from fd42::55: seq=2 ttl=63 time=0.108 ms

--- fd42::55 ping statistics ---
3 packets transmitted, 3 packets received, 0% packet loss
round-trip min/avg/max = 0.075/0.118/0.173 ms
node-1:/home/rancher # kubectl exec pod-b -- ping -6 -c3 "fd42::54"
PING fd42::54 (fd42::54): 56 data bytes
64 bytes from fd42::54: seq=0 ttl=63 time=0.095 ms
64 bytes from fd42::54: seq=1 ttl=63 time=0.074 ms
64 bytes from fd42::54: seq=2 ttl=63 time=0.098 ms

--- fd42::54 ping statistics ---
3 packets transmitted, 3 packets received, 0% packet loss
round-trip min/avg/max = 0.074/0.089/0.098 ms
node-1:/home/rancher # # DNS Resolution works from inside the pods
node-1:/home/rancher # kubectl exec pod-a -- nslookup kubernetes fd43::a
Server:         fd43::a
Address:        [fd43::a]:53

** server can't find kubernetes: NXDOMAIN

** server can't find kubernetes: NXDOMAIN

command terminated with exit code 1

```
</details>

> Note: kubernetes service itself is single stack IPv4 even when RKE2 is configured dual stack because this is the default behavior - described in last step in non goals in the [Dual Stack k8s KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/563-dual-stack#non-goals) stating:
Enable Kubernetes api-server dual-stack addresses listening and binding. **Additionally enable dual-stack for Kubernetes default service.**

<details>
<summary>3. Config file installation - non interactive is validating dual stack ipv4 first config (comma in the end is rejected, 3 values added etc)
</summary>
TBD
</details>

<details>
<summary>4. Joining a node to the cluster in Dual Stack mode works and second node configures dual stack as well
</summary>
Config of vm `node-2` which is joining is same as vm `node-1` above and final config after installer is:
<img width="1278" height="862" alt="image" src="https://github.com/user-attachments/assets/9fb4953c-3574-499c-9a49-bc6dae4e2ea9" />

Eventually cluster forms as Ready:
<img width="2557" height="872" alt="image" src="https://github.com/user-attachments/assets/11128e72-95ef-4da5-8e27-56008a7f4848" />

node-2 commands show it has ipv6 configured and IPv6 addresses present:
```
node-2:/home/rancher # sysctl net.ipv6.conf.all.disable_ipv6
net.ipv6.conf.all.disable_ipv6 = 0
node-2:/home/rancher # sysctl net.ipv6.conf.default.disable_ipv6
net.ipv6.conf.default.disable_ipv6 = 0
node-2:/home/rancher # ip -6 addr show mgmt-br
3: mgmt-br: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    inet6 fd00:cafe:4::178/128 scope global dynamic noprefixroute 
       valid_lft 86122sec preferred_lft 86122sec
    inet6 fe80::5054:ff:fefd:985a/64 scope link noprefixroute 
       valid_lft forever preferred_lft forever

```

On node-1, node-2 shows with second IP and the machine and node are both ready:

```
node-1:/home/rancher # kubectl get node node-2 -o jsonpath='{.status.addresses}' | jq '.[]'
{
  "address": "192.168.103.187",
  "type": "InternalIP"
}
{
  "address": "fd00:cafe:4::178",
  "type": "InternalIP"
}
{
  "address": "node-2",
  "type": "Hostname"
}
node-1:/home/rancher # kubectl get machines -n fleet-local
NAME                  CLUSTER   NODE NAME   READY   AVAILABLE   UP-TO-DATE   PHASE     AGE    VERSION
custom-39bc8a3a172c   local     node-1      True    True                     Running   16m    
custom-b5f692834626   local     node-2      True    True                     Running   5m7s   
node-1:/home/rancher # kubectl get nodes -o wide
NAME     STATUS   ROLES                AGE     VERSION          INTERNAL-IP       EXTERNAL-IP   OS-IMAGE                   KERNEL-VERSION             CONTAINER-RUNTIME
node-1   Ready    control-plane,etcd   20m     v1.35.6+rke2r1   192.168.103.174   <none>        Harvester 0a5484d2-dirty   6.12.0-160000.36-default   containerd://2.2.5-k3s2
node-2   Ready    <none>               5m20s   v1.35.6+rke2r1   192.168.103.187   <none>        Harvester 0a5484d2-dirty   6.12.0-160000.36-default   containerd://2.2.5-k3s2
node-1:/home/rancher # 
```

</details>

#### Additional documentation or context
https://github.com/harvester/harvester/blob/master/enhancements/20260528-dual-stack-ipv4-first.md