### PR TITLE
ci: use group for vagrant-install workflow

### DIFF
--- a/.github/workflows/vagrant-install.yaml
+++ b/.github/workflows/vagrant-install.yaml
@@ -18,11 +18,7 @@ jobs:
   main:
     name: Build and deploy
     runs-on:
-      - self-hosted
-      - Linux
-      - kvm
-      - vagrant
-      - equinix
+      group: vagrant
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Build Harvester artifacts


### PR DESCRIPTION
This allows sharing the runner with the main repo.


